### PR TITLE
Add input_schema to error responses for AI self-correction

### DIFF
--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: Abilities MCP Adapter
  * Plugin URI:  https://github.com/Wicked-Evolutions/abilities-mcp-adapter
  * Description: Exposes WordPress abilities as MCP tools, resources, and prompts. Upload, activate, and your WordPress abilities become MCP tools.
- * Version:     1.0.8
+ * Version:     1.0.9
  * Author:      Wicked Evolutions
  * Author URI:  https://wickedevolutions.com
  * Copyright:   Copyright (C) 2026 Wicked Evolutions
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Plugin constants.
-define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.0.8' );
+define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.0.9' );
 define( 'ABILITIES_MCP_ADAPTER_PATH', plugin_dir_path( __FILE__ ) );
 
 // License manager — FluentCart license for auto-update delivery.

--- a/src/Handlers/Tools/ToolsHandler.php
+++ b/src/Handlers/Tools/ToolsHandler.php
@@ -346,6 +346,7 @@ class ToolsHandler {
 					'ability_name'   => $ability->get_name(),
 					'failure_reason' => 'ability_disabled',
 					'permission'     => $permission,
+					'input_schema'   => $ability->get_input_schema(),
 				),
 			);
 		}
@@ -391,6 +392,7 @@ class ToolsHandler {
 						'tool_name'      => $tool_name,
 						'ability_name'   => $ability->get_name(),
 						'failure_reason' => $failure_reason,
+						'input_schema'   => $ability->get_input_schema(),
 					),
 				);
 			}
@@ -411,6 +413,7 @@ class ToolsHandler {
 					'ability_name'   => $ability->get_name(),
 					'failure_reason' => 'permission_check_failed',
 					'error_type'     => get_class( $e ),
+					'input_schema'   => $ability->get_input_schema(),
 				),
 			);
 		}
@@ -440,6 +443,7 @@ class ToolsHandler {
 						'ability_name'   => $ability->get_name(),
 						'failure_reason' => 'wp_error',
 						'error_code'     => $result->get_error_code(),
+						'input_schema'   => $ability->get_input_schema(),
 					),
 				);
 			}
@@ -485,6 +489,7 @@ class ToolsHandler {
 					'ability_name'   => $ability->get_name(),
 					'failure_reason' => 'execution_failed',
 					'error_type'     => get_class( $e ),
+					'input_schema'   => $ability->get_input_schema(),
 				),
 			);
 		}


### PR DESCRIPTION
## Summary
- Adds the ability's `input_schema` to `_metadata` on error responses (paths 4-8 in ToolsHandler.php)
- When an AI agent sends wrong parameters, it now gets the schema back and can self-correct without a separate `get-ability-info` call
- One field added to an existing array in 5 locations. Zero risk to working abilities.

## Details
- **P0 fix** — highest leverage single change identified from CTO session 5 (2026-03-15)
- **GitHub issue:** Fixes #4
- **Version:** v1.0.9
- Paths 1-3 and 9 unchanged (no ability object in scope)
- Paths 10-14 (ExecuteAbilityAbility) unchanged (separate concern)

## Test plan
- [x] Regression: 3 working abilities unchanged
- [x] Schema appears on input validation errors
- [x] Schema appears on pro-gated permission errors
- [x] No-arg abilities return null/empty schema
- [x] Code verification: 5 `input_schema` lines confirmed deployed
- [x] Live on wickedevolutions.com — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)