### PR TITLE
DB-2: Redaction filter at /mcp response boundary (3 buckets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased] — DB-3 (held for public-alpha hardening Launch Gate)
+
+### Added — Safety Settings UI + AI-callable settings abilities
+- New admin page **Settings → MCP Safety** with four sections:
+  1. Master toggle (off requires checkbox confirmation; Bucket 1 secrets always filtered).
+  2. Redaction keyword list — Bucket 1 read-only; Bucket 2 with per-default warning; Bucket 3 with per-default no warning; custom-add input (Bucket 2 or 3 only); restore defaults.
+  3. Per-ability exemptions — two columns (Bucket 3 left, Bucket 2 right with confirm-on-add warning).
+  4. Trusted proxy — Cloudflare preset / custom CIDR allowlist (consumed by the rate limiter in DB-4).
+- Seven AI-callable abilities, all gated by `manage_options`:
+  - `settings/get-redaction-list` — read state, no friction.
+  - `settings/add-redaction-keyword` — strengthen, no friction.
+  - `settings/remove-custom-keyword` — reverse own additions, no friction.
+  - `settings/restore-redaction-defaults` — restore baseline, no friction.
+  - `settings/remove-default-bucket3-keyword` — weaken Bucket 3 default, **in-chat 1/2 confirmation required**.
+  - `settings/exempt-ability-from-bucket3` — per-ability Bucket 3 unlock, **in-chat 1/2 confirmation required**.
+  - `settings/unexempt-ability-from-bucket3` — re-lock exemption, no friction.
+- One-time confirmation tokens stored as WP transients with 60s TTL, bound to (session, ability, params); single-use; replay-safe.
+- All settings writes emit `boundary.master_toggle.changed`, `boundary.redaction_keywords.changed`, `boundary.ability_exemption.changed`, `boundary.confirmation.failed` events through the existing `BoundaryEventEmitter`.
+- New option keys: `abilities_mcp_redaction_master_enabled`, `abilities_mcp_redaction_keywords` (Bucket 3 customs), `abilities_mcp_bucket2_keywords` (Bucket 2 customs — DB-2 to read after rebase), `abilities_mcp_bucket3_exemptions`, `abilities_mcp_bucket2_exemptions`, `abilities_mcp_redaction_keywords_removed_defaults`, `abilities_mcp_bucket2_keywords_removed_defaults`, `abilities_mcp_trusted_proxy_enabled`, `abilities_mcp_trusted_proxy_mode`, `abilities_mcp_trusted_proxy_allowlist`.
+
+### Held
+- Bucket 2 default-removal, Bucket 2 ability-exemption, master-toggle-off — Admin UI only by design. No ability paths exist for these.
+- Released together with DB-1, DB-2, DB-4, DB-5, DB-6 at the Launch Gate.
+
 ## [1.2.0] - 2026-03-20
 
 ### Added

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -45,13 +45,19 @@ if ( file_exists( $autoloader ) ) {
 	return;
 }
 
-use WickedEvolutions\McpAdapter\Core\McpAdapter;
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
 use WickedEvolutions\McpAdapter\Admin\AbilitySettingsPage;
+use WickedEvolutions\McpAdapter\Admin\SafetySettingsPage;
+use WickedEvolutions\McpAdapter\Core\McpAdapter;
 
-// Register admin settings page (license + ability permissions).
+// Register admin settings pages (license + ability permissions + safety settings).
 if ( is_admin() ) {
 	AbilitySettingsPage::register();
+	SafetySettingsPage::register();
 }
+
+// Register safety-settings abilities inside the Abilities API init hook.
+add_action( 'wp_abilities_api_init', array( SettingsAbilities::class, 'register_all' ) );
 
 // Enable MCP tool validation — silently drops invalid tools instead of breaking all tools.
 add_filter( 'mcp_adapter_validation_enabled', '__return_true' );

--- a/src/Abilities/Settings/SettingsAbilities.php
+++ b/src/Abilities/Settings/SettingsAbilities.php
@@ -1,0 +1,648 @@
+<?php
+/**
+ * AI-callable safety-settings abilities (DB-3).
+ *
+ * Seven abilities for managing the redaction filter from chat. All abilities
+ * require `manage_options`. Bucket 2 weakening and master-toggle changes
+ * have NO ability paths — those are Admin-UI only by design.
+ *
+ * Friction model:
+ *   - Strengthen / reverse own additions / restore defaults: zero friction.
+ *   - Weaken Bucket 3 default keyword OR exempt ability from Bucket 3:
+ *     in-chat 1/2 confirmation token (60s, session-bound, params-bound).
+ *
+ * Confirmation flow:
+ *   1. AI calls ability without `confirmation_token`.
+ *   2. Adapter mints a token bound to (session, ability, params) and returns
+ *      { confirmation_required: true, token, summary, options[1=yes,2=no] }.
+ *   3. AI surfaces the warning + options to the operator.
+ *   4. Operator picks 1 → AI re-issues with the token.
+ *   5. Adapter consumes the token (one-time, TTL 60s) and executes.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Abilities\Settings;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Settings\ConfirmationTokenStore;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+/**
+ * Registers the seven `settings/*` abilities.
+ */
+final class SettingsAbilities {
+
+	/**
+	 * Hook into `wp_abilities_api_init` to register all settings abilities.
+	 */
+	public static function register_all(): void {
+		self::register_get_redaction_list();
+		self::register_add_redaction_keyword();
+		self::register_remove_custom_keyword();
+		self::register_restore_redaction_defaults();
+		self::register_remove_default_bucket3_keyword();
+		self::register_exempt_ability_from_bucket3();
+		self::register_unexempt_ability_from_bucket3();
+	}
+
+	// Permission callback (shared) ---------------------------------------
+
+	public static function check_permission( $input = array() ) {
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error( 'authentication_required', 'Settings abilities require an authenticated administrator.' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'insufficient_capability', 'Settings abilities require the manage_options capability.' );
+		}
+		return true;
+	}
+
+	// settings/get-redaction-list ----------------------------------------
+
+	private static function register_get_redaction_list(): void {
+		wp_register_ability(
+			'settings/get-redaction-list',
+			array(
+				'label'               => 'Get redaction list',
+				'description'         => 'Read the current redaction configuration: master toggle, bucket-1/2/3 keyword lists, per-ability exemptions. No friction.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'master_enabled'      => array( 'type' => 'boolean' ),
+						'bucket1'             => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+						'bucket2'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'active'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'custom'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'removed' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							),
+						),
+						'bucket3'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'active'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'custom'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'removed' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							),
+						),
+						'exemptions_bucket3'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+						'exemptions_bucket2'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_get_redaction_list' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_get_redaction_list( $input = array() ): array {
+		return array(
+			'master_enabled'     => Repo::is_master_enabled(),
+			'bucket1'            => Repo::bucket1_default_keywords(),
+			'bucket2'            => array(
+				'active'  => Repo::get_active_keywords( Repo::BUCKET_PAYMENT ),
+				'custom'  => Repo::get_custom_keywords( Repo::BUCKET_PAYMENT ),
+				'removed' => Repo::get_removed_defaults( Repo::BUCKET_PAYMENT ),
+			),
+			'bucket3'            => array(
+				'active'  => Repo::get_active_keywords( Repo::BUCKET_CONTACT ),
+				'custom'  => Repo::get_custom_keywords( Repo::BUCKET_CONTACT ),
+				'removed' => Repo::get_removed_defaults( Repo::BUCKET_CONTACT ),
+			),
+			'exemptions_bucket3' => Repo::get_exemptions( Repo::BUCKET_CONTACT ),
+			'exemptions_bucket2' => Repo::get_exemptions( Repo::BUCKET_PAYMENT ),
+		);
+	}
+
+	// settings/add-redaction-keyword (no friction) -----------------------
+
+	private static function register_add_redaction_keyword(): void {
+		wp_register_ability(
+			'settings/add-redaction-keyword',
+			array(
+				'label'               => 'Add redaction keyword',
+				'description'         => 'Add a custom keyword to Bucket 2 (payment / regulated) or Bucket 3 (contact PII). Strengthens defaults — no confirmation required. Bucket 1 is hardcoded and not addable.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword', 'bucket' ),
+					'properties' => array(
+						'keyword' => array( 'type' => 'string', 'description' => 'Field-name keyword to redact (lower-cased automatically).' ),
+						'bucket'  => array( 'type' => 'integer', 'enum' => array( 2, 3 ) ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'added'   => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_add_redaction_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_add_redaction_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$bucket  = isset( $input['bucket'] ) ? (int) $input['bucket'] : 0;
+
+		$result = Repo::add_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'added'   => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'add_custom',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+				'method'    => 'settings/add-redaction-keyword',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'added'   => (bool) $result,
+			'message' => $result ? 'Keyword added.' : 'Keyword already present.',
+		);
+	}
+
+	// settings/remove-custom-keyword (no friction) -----------------------
+
+	private static function register_remove_custom_keyword(): void {
+		wp_register_ability(
+			'settings/remove-custom-keyword',
+			array(
+				'label'               => 'Remove custom redaction keyword',
+				'description'         => 'Reverse a previously-added custom keyword (Bucket 2 or 3). Reversal of operator additions only — does not remove default keywords. No confirmation required.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword', 'bucket' ),
+					'properties' => array(
+						'keyword' => array( 'type' => 'string' ),
+						'bucket'  => array( 'type' => 'integer', 'enum' => array( 2, 3 ) ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'removed' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_remove_custom_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_remove_custom_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$bucket  = isset( $input['bucket'] ) ? (int) $input['bucket'] : 0;
+
+		$result = Repo::remove_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'removed' => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove_custom',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+				'method'    => 'settings/remove-custom-keyword',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'removed' => (bool) $result,
+			'message' => $result ? 'Custom keyword removed.' : 'Keyword was not in the custom list.',
+		);
+	}
+
+	// settings/restore-redaction-defaults (no friction) ------------------
+
+	private static function register_restore_redaction_defaults(): void {
+		wp_register_ability(
+			'settings/restore-redaction-defaults',
+			array(
+				'label'               => 'Restore redaction defaults',
+				'description'         => 'Restore Bucket 2 + Bucket 3 redaction lists to factory defaults. Clears custom additions and removed-defaults. No confirmation required (strengthens safety).',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_restore_redaction_defaults' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_restore_redaction_defaults( $input = array() ): array {
+		Repo::restore_defaults();
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'restore_defaults',
+				'method'    => 'settings/restore-redaction-defaults',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'message' => 'Redaction lists restored to defaults.',
+		);
+	}
+
+	// settings/remove-default-bucket3-keyword (1/2 confirmation) ---------
+
+	private static function register_remove_default_bucket3_keyword(): void {
+		wp_register_ability(
+			'settings/remove-default-bucket3-keyword',
+			array(
+				'label'               => 'Remove default Bucket 3 keyword',
+				'description'         => 'Weaken the default Bucket 3 redaction list by removing a default keyword. Requires in-chat 1/2 confirmation. Bucket 2 default removal is not available via abilities — it is admin-UI only.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword' ),
+					'properties' => array(
+						'keyword'            => array( 'type' => 'string' ),
+						'confirmation_token' => array( 'type' => 'string', 'description' => 'One-time token returned by the first call. Required on the second call.' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'                => array( 'type' => 'boolean' ),
+						'confirmation_required'  => array( 'type' => 'boolean' ),
+						'token'                  => array( 'type' => 'string' ),
+						'summary'                => array( 'type' => 'string' ),
+						'options'                => array( 'type' => 'array' ),
+						'message'                => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_remove_default_bucket3_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_remove_default_bucket3_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$token   = isset( $input['confirmation_token'] ) ? (string) $input['confirmation_token'] : '';
+
+		$ability = 'settings/remove-default-bucket3-keyword';
+		$params  = array( 'keyword' => strtolower( trim( $keyword ) ) );
+
+		if ( '' === $token ) {
+			$session = ConfirmationTokenStore::current_session_id();
+			$minted  = ConfirmationTokenStore::mint( $session, $ability, $params );
+
+			return array(
+				'success'               => false,
+				'confirmation_required' => true,
+				'token'                 => $minted,
+				'summary'               => sprintf(
+					"Remove '%s' from Bucket 3 redaction defaults — exposes this contact field in all subsequent ability responses until re-added. This weakens the default safety posture.",
+					$params['keyword']
+				),
+				'options'               => array(
+					array( 'key' => '1', 'label' => 'Yes, confirm' ),
+					array( 'key' => '2', 'label' => 'No' ),
+				),
+				'message'               => 'Confirmation required. Re-issue the call with this token within 60 seconds.',
+			);
+		}
+
+		$session = ConfirmationTokenStore::current_session_id();
+		$consume = ConfirmationTokenStore::consume( $token, $session, $ability, $params );
+		if ( is_wp_error( $consume ) ) {
+			BoundaryEventEmitter::emit(
+				null,
+				'boundary.confirmation.failed',
+				array(
+					'severity'   => 'warn',
+					'user_id'    => (int) get_current_user_id(),
+					'method'     => $ability,
+					'error_code' => $consume->get_error_code(),
+					'reason'     => $consume->get_error_message(),
+				)
+			);
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $consume->get_error_message(),
+			);
+		}
+
+		$result = Repo::remove_default_keyword( Repo::BUCKET_CONTACT, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'warn',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove_default',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_3',
+				'method'    => $ability,
+			)
+		);
+
+		return array(
+			'success'               => true,
+			'confirmation_required' => false,
+			'message'               => $result
+				? 'Default keyword removed. Use settings/restore-redaction-defaults or add-redaction-keyword to re-enable.'
+				: 'Keyword was already removed.',
+		);
+	}
+
+	// settings/exempt-ability-from-bucket3 (1/2 confirmation) ------------
+
+	private static function register_exempt_ability_from_bucket3(): void {
+		wp_register_ability(
+			'settings/exempt-ability-from-bucket3',
+			array(
+				'label'               => 'Exempt ability from Bucket 3 redaction',
+				'description'         => 'Allow contact PII (email, phone, address, IP) to flow through one specific ability\'s response. Requires in-chat 1/2 confirmation. Bucket 2 exemptions are admin-UI only.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'ability_name' ),
+					'properties' => array(
+						'ability_name'       => array( 'type' => 'string', 'description' => 'Namespaced ability name (e.g. "users/list").' ),
+						'confirmation_token' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'               => array( 'type' => 'boolean' ),
+						'confirmation_required' => array( 'type' => 'boolean' ),
+						'token'                 => array( 'type' => 'string' ),
+						'summary'               => array( 'type' => 'string' ),
+						'options'               => array( 'type' => 'array' ),
+						'message'               => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_exempt_ability_from_bucket3' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_exempt_ability_from_bucket3( $input = array() ): array {
+		$ability_name = isset( $input['ability_name'] ) ? (string) $input['ability_name'] : '';
+		$token        = isset( $input['confirmation_token'] ) ? (string) $input['confirmation_token'] : '';
+
+		$ability = 'settings/exempt-ability-from-bucket3';
+		$params  = array( 'ability_name' => trim( $ability_name ) );
+
+		if ( '' === $token ) {
+			$session = ConfirmationTokenStore::current_session_id();
+			$minted  = ConfirmationTokenStore::mint( $session, $ability, $params );
+
+			return array(
+				'success'               => false,
+				'confirmation_required' => true,
+				'token'                 => $minted,
+				'summary'               => sprintf(
+					"Exempt '%s' from Bucket 3 redaction — its responses will return contact PII (email, phone, address, IP) un-redacted. This weakens the default safety posture for this specific ability only.",
+					$params['ability_name']
+				),
+				'options'               => array(
+					array( 'key' => '1', 'label' => 'Yes, confirm' ),
+					array( 'key' => '2', 'label' => 'No' ),
+				),
+				'message'               => 'Confirmation required. Re-issue the call with this token within 60 seconds.',
+			);
+		}
+
+		$session = ConfirmationTokenStore::current_session_id();
+		$consume = ConfirmationTokenStore::consume( $token, $session, $ability, $params );
+		if ( is_wp_error( $consume ) ) {
+			BoundaryEventEmitter::emit(
+				null,
+				'boundary.confirmation.failed',
+				array(
+					'severity'   => 'warn',
+					'user_id'    => (int) get_current_user_id(),
+					'method'     => $ability,
+					'error_code' => $consume->get_error_code(),
+					'reason'     => $consume->get_error_message(),
+				)
+			);
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $consume->get_error_message(),
+			);
+		}
+
+		$result = Repo::add_exemption( Repo::BUCKET_CONTACT, $ability_name );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.ability_exemption.changed',
+			array(
+				'severity'  => 'warn',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'add',
+				'name'      => sanitize_text_field( $ability_name ),
+				'dimension' => 'bucket_3',
+				'method'    => $ability,
+			)
+		);
+
+		return array(
+			'success'               => true,
+			'confirmation_required' => false,
+			'message'               => $result
+				? 'Ability exempted from Bucket 3 redaction.'
+				: 'Ability was already exempt.',
+		);
+	}
+
+	// settings/unexempt-ability-from-bucket3 (no friction) ---------------
+
+	private static function register_unexempt_ability_from_bucket3(): void {
+		wp_register_ability(
+			'settings/unexempt-ability-from-bucket3',
+			array(
+				'label'               => 'Re-lock ability under Bucket 3',
+				'description'         => 'Remove a previously-granted Bucket 3 exemption. Strengthens safety — no confirmation required.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'ability_name' ),
+					'properties' => array(
+						'ability_name' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'removed' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_unexempt_ability_from_bucket3' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_unexempt_ability_from_bucket3( $input = array() ): array {
+		$ability_name = isset( $input['ability_name'] ) ? (string) $input['ability_name'] : '';
+
+		$result = Repo::remove_exemption( Repo::BUCKET_CONTACT, $ability_name );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'removed' => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.ability_exemption.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove',
+				'name'      => sanitize_text_field( $ability_name ),
+				'dimension' => 'bucket_3',
+				'method'    => 'settings/unexempt-ability-from-bucket3',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'removed' => (bool) $result,
+			'message' => $result ? 'Bucket 3 exemption removed.' : 'Ability was not exempt.',
+		);
+	}
+}

--- a/src/Admin/SafetySettingsPage.php
+++ b/src/Admin/SafetySettingsPage.php
@@ -1,0 +1,715 @@
+<?php
+/**
+ * Safety Settings — admin page.
+ *
+ * Operator-facing surface for the redaction filter (DB-2) and trusted-proxy
+ * configuration (DB-4). Four sections:
+ *   1. Master toggle (off requires checkbox confirmation)
+ *   2. Redaction keyword list — Bucket 1 read-only, Bucket 2 (warning per remove),
+ *      Bucket 3 (no warning), custom add input.
+ *   3. Per-ability exemptions — two columns (Bucket 3 left, Bucket 2 right).
+ *   4. Trusted proxy (Cloudflare preset / custom CIDR allowlist).
+ *
+ * All writes log boundary.* events to the kl_boundary log via the adapter's
+ * existing BoundaryEventEmitter.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Admin;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+/**
+ * Safety Settings admin page (Settings → MCP Safety).
+ */
+final class SafetySettingsPage {
+
+	public const PAGE_SLUG   = 'mcp-adapter-safety';
+	private const NONCE_FORM = 'mcp_adapter_safety_save';
+
+	public static function register(): void {
+		add_action( 'admin_menu', array( self::class, 'add_menu_page' ) );
+		add_action( 'admin_init', array( self::class, 'handle_save' ) );
+	}
+
+	public static function add_menu_page(): void {
+		add_options_page(
+			__( 'MCP Safety Settings', 'mcp-adapter' ),
+			__( 'MCP Safety', 'mcp-adapter' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( self::class, 'render_page' )
+		);
+	}
+
+	public static function page_url( array $args = array() ): string {
+		$args['page'] = self::PAGE_SLUG;
+		return add_query_arg( $args, admin_url( 'options-general.php' ) );
+	}
+
+	/**
+	 * Process the settings form. The form has multiple "actions" multiplexed
+	 * onto a single endpoint via the `mcp_safety_action` hidden field.
+	 */
+	public static function handle_save(): void {
+		if ( ! isset( $_POST['mcp_safety_action'] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage safety settings.', 'mcp-adapter' ) );
+		}
+		check_admin_referer( self::NONCE_FORM, 'mcp_safety_nonce' );
+
+		$action = sanitize_key( wp_unslash( $_POST['mcp_safety_action'] ) );
+		$notice = '';
+
+		switch ( $action ) {
+			case 'master_toggle':
+				$notice = self::handle_master_toggle();
+				break;
+			case 'add_keyword':
+				$notice = self::handle_add_keyword();
+				break;
+			case 'remove_custom_keyword':
+				$notice = self::handle_remove_custom_keyword();
+				break;
+			case 'remove_default_keyword':
+				$notice = self::handle_remove_default_keyword();
+				break;
+			case 'restore_defaults':
+				$notice = self::handle_restore_defaults();
+				break;
+			case 'set_exemption':
+				$notice = self::handle_set_exemption();
+				break;
+			case 'unset_exemption':
+				$notice = self::handle_unset_exemption();
+				break;
+			case 'trusted_proxy':
+				$notice = self::handle_trusted_proxy();
+				break;
+		}
+
+		wp_safe_redirect( self::page_url( array( 'updated' => '1', 'msg' => rawurlencode( $notice ) ) ) );
+		exit;
+	}
+
+	private static function handle_master_toggle(): string {
+		$desired = isset( $_POST['mcp_master_enabled'] ) ? '1' === $_POST['mcp_master_enabled'] : true;
+		$confirmed = isset( $_POST['mcp_master_confirm'] ) && '1' === $_POST['mcp_master_confirm'];
+
+		$current = Repo::is_master_enabled();
+		if ( $desired === $current ) {
+			return __( 'No change to master toggle.', 'mcp-adapter' );
+		}
+
+		// Disabling requires the inner checkbox.
+		if ( ! $desired && ! $confirmed ) {
+			return __( 'Disabling personal-data filtering requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		Repo::set_master_enabled( $desired );
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.master_toggle.changed',
+			array(
+				'severity' => $desired ? 'info' : 'warn',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => $desired ? 'enabled' : 'disabled',
+			)
+		);
+
+		return $desired
+			? __( 'Personal-data filtering enabled.', 'mcp-adapter' )
+			: __( 'Personal-data filtering disabled. Bucket 1 secrets remain redacted regardless.', 'mcp-adapter' );
+	}
+
+	private static function handle_add_keyword(): string {
+		$keyword = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		if ( Repo::BUCKET_PAYMENT !== $bucket && Repo::BUCKET_CONTACT !== $bucket ) {
+			return __( 'Bucket must be 2 or 3.', 'mcp-adapter' );
+		}
+
+		$result = Repo::add_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'add_custom',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Keyword added.', 'mcp-adapter' )
+			: __( 'Keyword already present.', 'mcp-adapter' );
+	}
+
+	private static function handle_remove_custom_keyword(): string {
+		$keyword = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		$result = Repo::remove_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove_custom',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Custom keyword removed.', 'mcp-adapter' )
+			: __( 'Keyword was not in the custom list.', 'mcp-adapter' );
+	}
+
+	private static function handle_remove_default_keyword(): string {
+		$keyword   = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket    = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+		$confirmed = isset( $_POST['mcp_default_confirm'] ) && '1' === $_POST['mcp_default_confirm'];
+
+		// Bucket 2 default removal requires the in-form checkbox confirmation.
+		if ( Repo::BUCKET_PAYMENT === $bucket && ! $confirmed ) {
+			return __( 'Removing a Bucket 2 default keyword requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		$result = Repo::remove_default_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => Repo::BUCKET_PAYMENT === $bucket ? 'warn' : 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove_default',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Default keyword removed. Restore defaults to bring it back.', 'mcp-adapter' )
+			: __( 'Keyword was already removed.', 'mcp-adapter' );
+	}
+
+	private static function handle_restore_defaults(): string {
+		Repo::restore_defaults();
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'restore_defaults',
+			)
+		);
+
+		return __( 'Redaction lists restored to defaults.', 'mcp-adapter' );
+	}
+
+	private static function handle_set_exemption(): string {
+		$ability   = isset( $_POST['mcp_ability'] ) ? (string) wp_unslash( $_POST['mcp_ability'] ) : '';
+		$bucket    = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+		$confirmed = isset( $_POST['mcp_exempt_confirm'] ) && '1' === $_POST['mcp_exempt_confirm'];
+
+		if ( Repo::BUCKET_PAYMENT === $bucket && ! $confirmed ) {
+			return __( 'Exempting an ability from Bucket 2 requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		$result = Repo::add_exemption( $bucket, $ability );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.ability_exemption.changed',
+			array(
+				'severity' => Repo::BUCKET_PAYMENT === $bucket ? 'warn' : 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'add',
+				'name'     => sanitize_text_field( $ability ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Exemption added.', 'mcp-adapter' )
+			: __( 'Ability was already exempt.', 'mcp-adapter' );
+	}
+
+	private static function handle_unset_exemption(): string {
+		$ability = isset( $_POST['mcp_ability'] ) ? (string) wp_unslash( $_POST['mcp_ability'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		$result = Repo::remove_exemption( $bucket, $ability );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.ability_exemption.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove',
+				'name'     => sanitize_text_field( $ability ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Exemption removed.', 'mcp-adapter' )
+			: __( 'Ability was not exempt.', 'mcp-adapter' );
+	}
+
+	private static function handle_trusted_proxy(): string {
+		$enabled   = isset( $_POST['mcp_proxy_enabled'] ) && '1' === $_POST['mcp_proxy_enabled'];
+		$mode      = isset( $_POST['mcp_proxy_mode'] ) ? sanitize_key( wp_unslash( $_POST['mcp_proxy_mode'] ) ) : Repo::PROXY_MODE_CLOUDFLARE;
+		$allowlist = isset( $_POST['mcp_proxy_allowlist'] ) ? (string) wp_unslash( $_POST['mcp_proxy_allowlist'] ) : '';
+		// Sanitize allowlist: keep one CIDR/IP per line, strip blanks/comments.
+		$lines = preg_split( "/\r?\n/", $allowlist ) ?: array();
+		$clean = array();
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+			if ( '' === $line || str_starts_with( $line, '#' ) ) {
+				continue;
+			}
+			$line = preg_replace( '/[^0-9a-fA-F:.\\/]/', '', $line ) ?? '';
+			if ( '' !== $line ) {
+				$clean[] = $line;
+			}
+		}
+		$allowlist = implode( "\n", $clean );
+
+		Repo::set_trusted_proxy_enabled( $enabled );
+		Repo::set_trusted_proxy_mode( $mode );
+		Repo::set_trusted_proxy_allowlist_raw( $allowlist );
+
+		return __( 'Trusted proxy settings saved.', 'mcp-adapter' );
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public static function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'MCP Safety Settings', 'mcp-adapter' ); ?></h1>
+			<p><?php esc_html_e( 'Controls the redaction filter that runs at the /mcp response boundary, plus trusted-proxy IP detection used by the rate limiter.', 'mcp-adapter' ); ?></p>
+
+			<?php if ( isset( $_GET['updated'] ) && '1' === $_GET['updated'] ) : ?>
+				<div class="notice notice-success is-dismissible">
+					<p><?php echo esc_html( isset( $_GET['msg'] ) ? rawurldecode( wp_unslash( (string) $_GET['msg'] ) ) : __( 'Settings saved.', 'mcp-adapter' ) ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<?php
+			self::render_master_toggle_section();
+			self::render_keyword_list_section();
+			self::render_exemptions_section();
+			self::render_trusted_proxy_section();
+			?>
+		</div>
+		<?php
+	}
+
+	private static function render_master_toggle_section(): void {
+		$enabled = Repo::is_master_enabled();
+		?>
+		<h2><?php esc_html_e( '1. Master Toggle', 'mcp-adapter' ); ?></h2>
+		<form method="post" action="" style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:16px;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="master_toggle" />
+
+			<label style="display:flex;align-items:flex-start;gap:8px;">
+				<input type="checkbox" name="mcp_master_enabled" value="1" <?php checked( $enabled ); ?> id="mcp-master-toggle" />
+				<span>
+					<strong><?php esc_html_e( 'Filter personal data and payment identifiers in AI responses', 'mcp-adapter' ); ?></strong><br>
+					<span style="color:#646970;font-size:13px;"><?php esc_html_e( 'Default ON. Bucket 1 secrets (passwords, API keys, tokens) are filtered regardless.', 'mcp-adapter' ); ?></span>
+				</span>
+			</label>
+
+			<div id="mcp-master-warning" style="margin-top:12px;<?php echo $enabled ? '' : 'display:none;'; ?>padding:12px;background:#fcf0f1;border-left:4px solid #d63638;">
+				<p style="margin:0 0 8px;font-weight:600;color:#d63638;">⚠️ <?php esc_html_e( 'Disabling personal-data and payment-identifier filtering', 'mcp-adapter' ); ?></p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<?php esc_html_e( 'When this is off, AI clients connected to your site will receive the full contents of every ability response — including email addresses, phone numbers, postal addresses, IP addresses, payment-related identifiers, and other personal data attached to your users and customers.', 'mcp-adapter' ); ?>
+				</p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<em><?php esc_html_e( 'Note: Authentication credentials, password hashes, API keys, and session tokens remain filtered regardless of this setting.', 'mcp-adapter' ); ?></em>
+				</p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<?php esc_html_e( 'If you handle personal data, payment data, or operate in a regulated industry, disabling personal-data filtering may put you out of compliance with GDPR, PCI-DSS, HIPAA, or similar laws.', 'mcp-adapter' ); ?>
+				</p>
+				<label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+					<input type="checkbox" name="mcp_master_confirm" value="1" />
+					<?php esc_html_e( 'I understand and accept the risk. Disable personal-data filtering.', 'mcp-adapter' ); ?>
+				</label>
+			</div>
+
+			<p style="margin-top:12px;">
+				<?php submit_button( __( 'Save Master Toggle', 'mcp-adapter' ), 'primary', 'submit', false ); ?>
+			</p>
+		</form>
+		<script>
+		(function(){
+			var t = document.getElementById('mcp-master-toggle');
+			var w = document.getElementById('mcp-master-warning');
+			if (!t || !w) return;
+			function sync(){ w.style.display = t.checked ? 'none' : 'block'; }
+			t.addEventListener('change', sync);
+			sync();
+		})();
+		</script>
+		<?php
+	}
+
+	private static function render_keyword_list_section(): void {
+		?>
+		<h2><?php esc_html_e( '2. Redaction Keyword List', 'mcp-adapter' ); ?></h2>
+
+		<h3><?php esc_html_e( 'Bucket 1 — Secrets (always-on)', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'These secrets are always filtered. They cannot be disabled.', 'mcp-adapter' ); ?></p>
+		<div style="background:#f6f7f7;border:1px solid #dcdcde;border-radius:4px;padding:12px;max-width:780px;font-family:monospace;font-size:12px;line-height:1.6;">
+			<?php echo esc_html( implode( ', ', Repo::bucket1_default_keywords() ) ); ?>
+		</div>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Bucket 2 — Payment / Regulated Identifiers', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'Configurable via this admin UI ONLY. Cannot be weakened by AI.', 'mcp-adapter' ); ?></p>
+		<?php self::render_bucket_table( Repo::BUCKET_PAYMENT ); ?>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Bucket 3 — Contact PII / Access Labels', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'Configurable via admin UI or AI ability. Default keyword removal does not require an extra warning here (matches the AI confirmation friction).', 'mcp-adapter' ); ?></p>
+		<?php self::render_bucket_table( Repo::BUCKET_CONTACT ); ?>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Add a custom keyword', 'mcp-adapter' ); ?></h3>
+		<form method="post" action="" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="add_keyword" />
+			<input type="text" name="mcp_keyword" placeholder="e.g. gravity_forms_secret" required
+				style="flex:1;min-width:240px;padding:6px 8px;font-family:monospace;" />
+			<select name="mcp_bucket">
+				<option value="3"><?php esc_html_e( 'Bucket 3 (contact PII)', 'mcp-adapter' ); ?></option>
+				<option value="2"><?php esc_html_e( 'Bucket 2 (payment / regulated)', 'mcp-adapter' ); ?></option>
+			</select>
+			<?php submit_button( __( 'Add', 'mcp-adapter' ), 'secondary', 'submit', false ); ?>
+		</form>
+		<p style="color:#646970;font-size:12px;margin-top:6px;">
+			<?php esc_html_e( 'Bucket 1 is hardcoded. Custom keywords go to Bucket 2 or Bucket 3 only.', 'mcp-adapter' ); ?>
+		</p>
+
+		<form method="post" action="" style="margin-top:16px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="restore_defaults" />
+			<?php submit_button( __( 'Restore default redaction lists', 'mcp-adapter' ), 'secondary', 'submit', false, array( 'onclick' => "return confirm('Restore both Bucket 2 and Bucket 3 to factory defaults? Custom additions and removed defaults will be cleared.')" ) ); ?>
+		</form>
+		<?php
+	}
+
+	private static function render_bucket_table( int $bucket ): void {
+		$active   = Repo::get_active_keywords( $bucket );
+		$customs  = array_flip( Repo::get_custom_keywords( $bucket ) );
+		$defaults = Repo::BUCKET_PAYMENT === $bucket
+			? Repo::bucket2_default_keywords()
+			: Repo::bucket3_default_keywords();
+		$default_set = array_flip( array_map( 'strtolower', $defaults ) );
+
+		// Build merged list: active + recently-removed defaults so the operator can see both states.
+		$removed_defaults = Repo::get_removed_defaults( $bucket );
+
+		?>
+		<table class="widefat striped" style="max-width:780px;">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Keyword', 'mcp-adapter' ); ?></th>
+					<th style="width:120px;"><?php esc_html_e( 'Source', 'mcp-adapter' ); ?></th>
+					<th style="width:200px;"><?php esc_html_e( 'Action', 'mcp-adapter' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $active as $kw ) : ?>
+					<tr>
+						<td><code><?php echo esc_html( $kw ); ?></code></td>
+						<td>
+							<?php
+							if ( isset( $customs[ $kw ] ) ) {
+								esc_html_e( 'Custom', 'mcp-adapter' );
+							} elseif ( isset( $default_set[ $kw ] ) ) {
+								esc_html_e( 'Default', 'mcp-adapter' );
+							} else {
+								esc_html_e( 'Active', 'mcp-adapter' );
+							}
+							?>
+						</td>
+						<td>
+							<?php if ( isset( $customs[ $kw ] ) ) : ?>
+								<form method="post" action="" style="margin:0;">
+									<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+									<input type="hidden" name="mcp_safety_action" value="remove_custom_keyword" />
+									<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+									<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+									<button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove (custom)', 'mcp-adapter' ); ?></button>
+								</form>
+							<?php elseif ( isset( $default_set[ $kw ] ) ) : ?>
+								<?php if ( Repo::BUCKET_PAYMENT === $bucket ) : ?>
+									<form method="post" action="" style="margin:0;" onsubmit="return confirm('Remove default Bucket 2 keyword \'<?php echo esc_js( $kw ); ?>\'? This exposes payment / regulated identifiers in matching field names.')">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="remove_default_keyword" />
+										<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+										<input type="hidden" name="mcp_default_confirm" value="1" />
+										<button type="submit" class="button-link-delete">
+											⚠️ <?php esc_html_e( 'Remove default (warning)', 'mcp-adapter' ); ?>
+										</button>
+									</form>
+								<?php else : ?>
+									<form method="post" action="" style="margin:0;">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="remove_default_keyword" />
+										<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+										<button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove default', 'mcp-adapter' ); ?></button>
+									</form>
+								<?php endif; ?>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				<?php foreach ( $removed_defaults as $kw ) : ?>
+					<tr style="opacity:0.55;">
+						<td><code style="text-decoration:line-through;"><?php echo esc_html( $kw ); ?></code></td>
+						<td><em><?php esc_html_e( 'Default removed', 'mcp-adapter' ); ?></em></td>
+						<td>
+							<form method="post" action="" style="margin:0;">
+								<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+								<input type="hidden" name="mcp_safety_action" value="add_keyword" />
+								<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+								<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+								<button type="submit" class="button"><?php esc_html_e( 'Restore', 'mcp-adapter' ); ?></button>
+							</form>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				<?php if ( empty( $active ) && empty( $removed_defaults ) ) : ?>
+					<tr><td colspan="3"><em><?php esc_html_e( 'No keywords configured.', 'mcp-adapter' ); ?></em></td></tr>
+				<?php endif; ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	private static function render_exemptions_section(): void {
+		$abilities  = self::list_public_abilities();
+		$exempt_b3  = array_flip( Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+		$exempt_b2  = array_flip( Repo::get_exemptions( Repo::BUCKET_PAYMENT ) );
+		?>
+		<h2><?php esc_html_e( '3. Per-Ability Exemptions', 'mcp-adapter' ); ?></h2>
+		<p><?php esc_html_e( 'Exempt specific abilities from redaction. Bucket 2 exemptions can only be granted from this admin UI.', 'mcp-adapter' ); ?></p>
+
+		<div style="display:flex;gap:24px;flex-wrap:wrap;max-width:1200px;">
+			<div style="flex:1;min-width:380px;">
+				<h3><?php esc_html_e( 'Exempt from Bucket 3 (contact PII)', 'mcp-adapter' ); ?></h3>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th style="width:60px;"><?php esc_html_e( 'Exempt', 'mcp-adapter' ); ?></th>
+							<th><?php esc_html_e( 'Ability', 'mcp-adapter' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $abilities as $name ) : ?>
+							<?php $is_exempt = isset( $exempt_b3[ $name ] ); ?>
+							<tr>
+								<td>
+									<form method="post" action="" style="margin:0;">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="<?php echo $is_exempt ? 'unset_exemption' : 'set_exemption'; ?>" />
+										<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="3" />
+										<button type="submit" class="button" style="padding:1px 8px;">
+											<?php echo $is_exempt ? esc_html__( 'Yes ✓', 'mcp-adapter' ) : esc_html__( 'No', 'mcp-adapter' ); ?>
+										</button>
+									</form>
+								</td>
+								<td><code><?php echo esc_html( $name ); ?></code></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+
+			<div style="flex:1;min-width:380px;">
+				<h3><?php esc_html_e( 'Exempt from Bucket 2 (payment / regulated)', 'mcp-adapter' ); ?></h3>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th style="width:60px;"><?php esc_html_e( 'Exempt', 'mcp-adapter' ); ?></th>
+							<th><?php esc_html_e( 'Ability', 'mcp-adapter' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $abilities as $name ) : ?>
+							<?php $is_exempt = isset( $exempt_b2[ $name ] ); ?>
+							<tr>
+								<td>
+									<?php if ( $is_exempt ) : ?>
+										<form method="post" action="" style="margin:0;">
+											<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+											<input type="hidden" name="mcp_safety_action" value="unset_exemption" />
+											<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+											<input type="hidden" name="mcp_bucket" value="2" />
+											<button type="submit" class="button" style="padding:1px 8px;"><?php esc_html_e( 'Yes ✓', 'mcp-adapter' ); ?></button>
+										</form>
+									<?php else : ?>
+										<form method="post" action="" style="margin:0;"
+											onsubmit="return confirm('Are you sure? Exempting <?php echo esc_js( $name ); ?> from Bucket 2 will expose card_number, ssn, etc. for this specific ability.')">
+											<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+											<input type="hidden" name="mcp_safety_action" value="set_exemption" />
+											<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+											<input type="hidden" name="mcp_bucket" value="2" />
+											<input type="hidden" name="mcp_exempt_confirm" value="1" />
+											<button type="submit" class="button" style="padding:1px 8px;">⚠️ <?php esc_html_e( 'No', 'mcp-adapter' ); ?></button>
+										</form>
+									<?php endif; ?>
+								</td>
+								<td><code><?php echo esc_html( $name ); ?></code></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+		</div>
+		<?php
+	}
+
+	private static function render_trusted_proxy_section(): void {
+		$enabled   = Repo::is_trusted_proxy_enabled();
+		$mode      = Repo::get_trusted_proxy_mode();
+		$allowlist = Repo::get_trusted_proxy_allowlist_raw();
+		?>
+		<h2><?php esc_html_e( '4. Trusted Proxy', 'mcp-adapter' ); ?></h2>
+		<p><?php esc_html_e( 'Configure how the rate limiter detects the real client IP when your site is behind a CDN or load balancer.', 'mcp-adapter' ); ?></p>
+
+		<form method="post" action="" style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:16px;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="trusted_proxy" />
+
+			<label style="display:flex;align-items:center;gap:8px;">
+				<input type="checkbox" name="mcp_proxy_enabled" value="1" <?php checked( $enabled ); ?> />
+				<strong><?php esc_html_e( 'Enable trusted proxy IP detection', 'mcp-adapter' ); ?></strong>
+			</label>
+
+			<fieldset style="margin-top:16px;border:1px solid #dcdcde;border-radius:4px;padding:12px;">
+				<legend style="padding:0 6px;font-weight:600;"><?php esc_html_e( 'Mode', 'mcp-adapter' ); ?></legend>
+
+				<label style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+					<input type="radio" name="mcp_proxy_mode" value="cloudflare" <?php checked( $mode, Repo::PROXY_MODE_CLOUDFLARE ); ?> />
+					<span>
+						<strong><?php esc_html_e( 'Cloudflare preset', 'mcp-adapter' ); ?></strong><br>
+						<span style="color:#646970;font-size:13px;">
+							<?php esc_html_e( 'Adapter accepts CF-Connecting-IP only when REMOTE_ADDR is a Cloudflare edge IP.', 'mcp-adapter' ); ?>
+						</span>
+					</span>
+				</label>
+
+				<label style="display:flex;align-items:flex-start;gap:8px;">
+					<input type="radio" name="mcp_proxy_mode" value="custom" <?php checked( $mode, Repo::PROXY_MODE_CUSTOM ); ?> />
+					<span style="flex:1;">
+						<strong><?php esc_html_e( 'Custom IP allowlist', 'mcp-adapter' ); ?></strong><br>
+						<span style="color:#646970;font-size:13px;"><?php esc_html_e( 'One IP or CIDR range per line. Lines starting with # are ignored.', 'mcp-adapter' ); ?></span><br>
+						<textarea name="mcp_proxy_allowlist" rows="4" style="width:100%;font-family:monospace;font-size:12px;margin-top:6px;"
+							placeholder="10.0.0.0/8&#10;192.168.1.1"><?php echo esc_textarea( $allowlist ); ?></textarea>
+					</span>
+				</label>
+			</fieldset>
+
+			<p style="margin-top:12px;font-size:12px;color:#646970;">
+				<?php esc_html_e( 'Why this matters: when the rate limiter cannot trust X-Forwarded-For, attackers behind the CDN can spoof the client IP and bypass rate limits. The allowlist ensures only requests originating from your CDN edge are trusted.', 'mcp-adapter' ); ?>
+			</p>
+
+			<?php submit_button( __( 'Save Trusted Proxy Settings', 'mcp-adapter' ) ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * MCP-public ability names, sorted, namespaced.
+	 *
+	 * @return string[]
+	 */
+	private static function list_public_abilities(): array {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return array();
+		}
+		$abilities = wp_get_abilities();
+		$names     = array();
+		foreach ( $abilities as $ability ) {
+			if ( ! self::is_mcp_public( $ability ) ) {
+				continue;
+			}
+			$names[] = $ability->get_name();
+		}
+		sort( $names );
+		return $names;
+	}
+
+	private static function is_mcp_public( \WP_Ability $ability ): bool {
+		if ( method_exists( $ability, 'get_show_in_rest' ) ) {
+			$show = $ability->get_show_in_rest();
+			if ( null !== $show ) {
+				return (bool) $show;
+			}
+		}
+		$meta = $ability->get_meta();
+		if ( isset( $meta['show_in_rest'] ) ) {
+			return (bool) $meta['show_in_rest'];
+		}
+		return (bool) ( $meta['mcp']['public'] ?? false );
+	}
+
+	/**
+	 * Best-effort observability handler from the live adapter, or null.
+	 *
+	 * Settings writes happen in admin context where the MCP request loop
+	 * isn't running, so the typed handler may not be wired. The action
+	 * hook (Path 2) still fires regardless — that is the path DB-1's
+	 * BoundaryEventLogger uses anyway.
+	 */
+	private static function observability_handler(): ?\WickedEvolutions\McpAdapter\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface {
+		return null;
+	}
+}

--- a/src/Cli/StdioServerBridge.php
+++ b/src/Cli/StdioServerBridge.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 namespace WickedEvolutions\McpAdapter\Cli;
 
 use WickedEvolutions\McpAdapter\Core\McpServer;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactionGate;
 use WickedEvolutions\McpAdapter\Transport\Infrastructure\RequestRouter;
 
 /**
@@ -219,6 +220,12 @@ class StdioServerBridge {
 				$id,
 				'stdio'
 			);
+
+			// Redact at the response boundary before formatting.
+			$observability_handler = method_exists( $this->server, 'get_observability_handler' )
+				? $this->server->get_observability_handler()
+				: null;
+			$result = ResponseRedactionGate::apply( $result, $method, $params, $id, $observability_handler );
 
 			// If this is a notification (no id), don't send a response
 			if ( null === $id ) {

--- a/src/Infrastructure/Observability/BoundaryEventEmitter.php
+++ b/src/Infrastructure/Observability/BoundaryEventEmitter.php
@@ -62,6 +62,10 @@ final class BoundaryEventEmitter {
 		'retry_after_ms',
 		'batch_size',
 		'body_size',
+		// boundary.redaction_applied counters (per-bucket, values never included):
+		'redaction_count_b1',
+		'redaction_count_b2',
+		'redaction_count_b3',
 	);
 
 	/**

--- a/src/Infrastructure/Redaction/PatternMatchers.php
+++ b/src/Infrastructure/Redaction/PatternMatchers.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Bucket 1 / Bucket 2 pattern matchers.
+ *
+ * All matchers operate on a single scalar string value. They MUST NOT be applied to
+ * arrays, objects, numbers, booleans, or full JSON blobs — pattern matching across
+ * free-form text would corrupt legitimate content (e.g. a blog post mentioning a
+ * credit-card pattern).
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
+
+/**
+ * Scalar-string pattern matchers for Bucket 1 (secrets) and Bucket 2 (payment).
+ */
+final class PatternMatchers {
+
+	/**
+	 * Known password-hash format prefixes / markers.
+	 *
+	 * @var string[]
+	 */
+	private const PASSWORD_HASH_PREFIXES = array(
+		'$P$',
+		'$H$',
+		'$2a$',
+		'$2b$',
+		'$2y$',
+		'$argon2',
+		'$pbkdf2',
+		'$scrypt',
+	);
+
+	/**
+	 * Known API-key value prefixes.
+	 *
+	 * @var string[]
+	 */
+	private const API_KEY_PREFIXES = array(
+		'sk_live_',
+		'sk_test_',
+		'pk_live_',
+		'pk_test_',
+		'xoxb-',
+		'xoxp-',
+		'ghp_',
+		'gho_',
+		'ghu_',
+		'ghs_',
+		'ghr_',
+	);
+
+	/**
+	 * Whether the value matches a known password-hash format.
+	 *
+	 * @param mixed $value Value to test.
+	 * @return bool
+	 */
+	public static function is_password_hash( $value ): bool {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return false;
+		}
+		foreach ( self::PASSWORD_HASH_PREFIXES as $prefix ) {
+			if ( 0 === strpos( $value, $prefix ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether the value matches a known API-key prefix or vendor pattern.
+	 *
+	 * Includes Stripe (sk_live_/sk_test_/pk_live_/pk_test_), Slack (xoxb-/xoxp-),
+	 * GitHub (ghp_/gho_/ghu_/ghs_/ghr_), AWS access key id (AKIA + 16 upper alnum),
+	 * Google API keys (AIza + 35 url-safe).
+	 *
+	 * @param mixed $value Value to test.
+	 * @return bool
+	 */
+	public static function is_known_api_key( $value ): bool {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		foreach ( self::API_KEY_PREFIXES as $prefix ) {
+			if ( 0 === strpos( $value, $prefix ) ) {
+				return true;
+			}
+		}
+
+		// AWS access key id: AKIA followed by 16 upper-case alphanumerics.
+		if ( 1 === preg_match( '/^AKIA[0-9A-Z]{16}$/', $value ) ) {
+			return true;
+		}
+
+		// Google API key: AIza followed by 35 url-safe characters.
+		if ( 1 === preg_match( '/^AIza[0-9A-Za-z_\-]{35}$/', $value ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the string is a 13-19 digit run that passes the Luhn check.
+	 *
+	 * Whitespace and hyphens between digit groups are not stripped — the matcher
+	 * fires only when the value is *exactly* a contiguous digit string of plausible
+	 * card length. This keeps blog-post text containing the literal word
+	 * "1234-5678-9012-3456" out of scope (which is what we want; pattern matching
+	 * is only meaningful on field values that actually look like a stored PAN).
+	 *
+	 * @param mixed $value Value to test.
+	 * @return bool
+	 */
+	public static function passes_luhn( $value ): bool {
+		if ( ! is_string( $value ) || 1 !== preg_match( '/^[0-9]{13,19}$/', $value ) ) {
+			return false;
+		}
+
+		$sum     = 0;
+		$flip    = false;
+		$length  = strlen( $value );
+		for ( $i = $length - 1; $i >= 0; $i-- ) {
+			$digit = (int) $value[ $i ];
+			if ( $flip ) {
+				$digit *= 2;
+				if ( $digit > 9 ) {
+					$digit -= 9;
+				}
+			}
+			$sum  += $digit;
+			$flip  = ! $flip;
+		}
+
+		return 0 === ( $sum % 10 );
+	}
+}

--- a/src/Infrastructure/Redaction/RedactionConfig.php
+++ b/src/Infrastructure/Redaction/RedactionConfig.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Redaction configuration — default keyword lists, options, and exemptions.
+ *
+ * Three buckets:
+ *   - Bucket 1 (secrets): always-on, never disabled. Cannot be configured.
+ *   - Bucket 2 (payment / regulated IDs): default-on, configurable via Admin UI only.
+ *   - Bucket 3 (contact PII / access labels): default-on, configurable via Admin UI or AI.
+ *
+ * The custom keyword option `abilities_mcp_redaction_keywords` is a Bucket 3 extension list
+ * (additional contact-style fields the operator wants redacted). Bucket 1 and Bucket 2
+ * keyword lists are hard-coded — operators tune behaviour via exemptions, not list edits.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
+
+/**
+ * Redaction configuration loader.
+ */
+final class RedactionConfig {
+
+	public const OPTION_MASTER_ENABLED      = 'abilities_mcp_redaction_master_enabled';
+	public const OPTION_BUCKET3_KEYWORDS    = 'abilities_mcp_redaction_keywords';
+	public const OPTION_BUCKET3_EXEMPTIONS  = 'abilities_mcp_bucket3_exemptions';
+	public const OPTION_BUCKET2_EXEMPTIONS  = 'abilities_mcp_bucket2_exemptions';
+
+	public const BUCKET_SECRETS  = 1;
+	public const BUCKET_PAYMENT  = 2;
+	public const BUCKET_CONTACT  = 3;
+
+	/**
+	 * Bucket 1 — always-on secrets.
+	 *
+	 * @return string[]
+	 */
+	public static function bucket1_keywords(): array {
+		return array(
+			// Credentials.
+			'password',
+			'pass',
+			'passwd',
+			'user_pass',
+			'user_password',
+			'db_password',
+			'database_password',
+			'smtp_password',
+			'imap_password',
+			'pop_password',
+			'ftp_password',
+			'ssh_password',
+
+			// Named API keys / secrets.
+			'api_key',
+			'api_secret',
+			'consumer_key',
+			'consumer_secret',
+			'client_secret',
+			'client_key',
+			'private_key',
+			'license_key',
+			'serial_key',
+			'activation_key',
+			'app_key',
+			'app_secret',
+			'webhook_secret',
+			'webhook_key',
+			'signing_key',
+			'encryption_key',
+			'master_key',
+			'secret_key',
+
+			// Tokens.
+			'access_token',
+			'refresh_token',
+			'bearer_token',
+			'auth_token',
+			'authentication_token',
+			'oauth_token',
+			'oauth_secret',
+			'session_token',
+			'session_tokens',
+			'session_secret',
+			'csrf_token',
+			'nonce_token',
+			'id_token',
+			'personal_access_token',
+
+			// wp-config secrets.
+			'auth_key',
+			'secure_auth_key',
+			'logged_in_key',
+			'nonce_key',
+			'auth_salt',
+			'secure_auth_salt',
+			'logged_in_salt',
+			'nonce_salt',
+		);
+	}
+
+	/**
+	 * Bucket 2 — payment + regulated IDs.
+	 *
+	 * @return string[]
+	 */
+	public static function bucket2_keywords(): array {
+		return array(
+			'card_number',
+			'cardnumber',
+			'cc_number',
+			'pan',
+			'cvv',
+			'cvc',
+			'cv2',
+			'card_cvv',
+			'card_cvc',
+			'card_pin',
+			'ssn',
+			'social_security_number',
+			'social_security',
+			'tax_id',
+			'ein',
+			'tin',
+			'vat_number',
+			'vat_id',
+		);
+	}
+
+	/**
+	 * Bucket 3 — contact PII / access labels (default list before custom additions).
+	 *
+	 * @return string[]
+	 */
+	public static function bucket3_default_keywords(): array {
+		return array(
+			// Email.
+			'email',
+			'user_email',
+			'customer_email',
+			'contact_email',
+			'billing_email',
+			'shipping_email',
+			'payment_email',
+
+			// Phone.
+			'phone',
+			'phone_number',
+			'mobile',
+			'mobile_number',
+			'tel',
+			'telephone',
+			'billing_phone',
+			'shipping_phone',
+			'contact_phone',
+
+			// Address.
+			'address',
+			'street_address',
+			'address_line_1',
+			'address_line_2',
+			'street',
+			'street1',
+			'street2',
+			'billing_address',
+			'shipping_address',
+			'billing_address_1',
+			'shipping_address_1',
+
+			// Login identity.
+			'user_login',
+			'username',
+
+			// IP.
+			'ip',
+			'ip_address',
+			'user_ip',
+			'client_ip',
+			'remote_ip',
+			'last_ip',
+
+			// Date of birth.
+			'birthdate',
+			'birth_date',
+			'date_of_birth',
+			'dob',
+
+			// Public key (infrastructure, configurable per principle).
+			'public_key',
+		);
+	}
+
+	/**
+	 * Whether Bucket 2 + Bucket 3 redaction is active.
+	 *
+	 * Bucket 1 ignores this toggle entirely.
+	 *
+	 * @return bool
+	 */
+	public static function is_master_enabled(): bool {
+		$raw = function_exists( 'get_option' )
+			? get_option( self::OPTION_MASTER_ENABLED, true )
+			: true;
+
+		$enabled = (bool) $raw;
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$enabled = (bool) apply_filters( self::OPTION_MASTER_ENABLED, $enabled );
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Active Bucket 3 keyword list (defaults + custom additions, after filter).
+	 *
+	 * @return string[] Lower-cased canonical names.
+	 */
+	public static function bucket3_keywords(): array {
+		$defaults = self::bucket3_default_keywords();
+		$custom   = array();
+
+		if ( function_exists( 'get_option' ) ) {
+			$stored = get_option( self::OPTION_BUCKET3_KEYWORDS, array() );
+			if ( is_array( $stored ) ) {
+				foreach ( $stored as $kw ) {
+					if ( is_string( $kw ) && '' !== $kw ) {
+						$custom[] = $kw;
+					}
+				}
+			}
+		}
+
+		$merged = array_merge( $defaults, $custom );
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( self::OPTION_BUCKET3_KEYWORDS, $merged );
+			if ( is_array( $filtered ) ) {
+				$merged = array();
+				foreach ( $filtered as $kw ) {
+					if ( is_string( $kw ) && '' !== $kw ) {
+						$merged[] = $kw;
+					}
+				}
+			}
+		}
+
+		return self::normalize_keywords( $merged );
+	}
+
+	/**
+	 * Whether the named ability is exempt from the given bucket.
+	 *
+	 * Bucket 1 is never exempt.
+	 *
+	 * @param string|null $ability_name Ability name (e.g. `fluent-cart/list-customers`), or null.
+	 * @param int         $bucket       Bucket constant.
+	 *
+	 * @return bool
+	 */
+	public static function is_ability_exempt( ?string $ability_name, int $bucket ): bool {
+		if ( self::BUCKET_SECRETS === $bucket || null === $ability_name || '' === $ability_name ) {
+			return false;
+		}
+
+		$option = self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_EXEMPTIONS
+			: self::OPTION_BUCKET3_EXEMPTIONS;
+
+		if ( ! function_exists( 'get_option' ) ) {
+			return false;
+		}
+
+		$exempt = get_option( $option, array() );
+		if ( ! is_array( $exempt ) ) {
+			return false;
+		}
+
+		foreach ( $exempt as $name ) {
+			if ( is_string( $name ) && $name === $ability_name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Lower-case + dedupe a keyword list for case-insensitive matching.
+	 *
+	 * @param string[] $keywords
+	 * @return string[]
+	 */
+	public static function normalize_keywords( array $keywords ): array {
+		$out = array();
+		foreach ( $keywords as $kw ) {
+			if ( ! is_string( $kw ) ) {
+				continue;
+			}
+			$lower = strtolower( $kw );
+			if ( '' === $lower ) {
+				continue;
+			}
+			$out[ $lower ] = true;
+		}
+		return array_keys( $out );
+	}
+}

--- a/src/Infrastructure/Redaction/RedactionConfig.php
+++ b/src/Infrastructure/Redaction/RedactionConfig.php
@@ -7,9 +7,10 @@
  *   - Bucket 2 (payment / regulated IDs): default-on, configurable via Admin UI only.
  *   - Bucket 3 (contact PII / access labels): default-on, configurable via Admin UI or AI.
  *
- * The custom keyword option `abilities_mcp_redaction_keywords` is a Bucket 3 extension list
- * (additional contact-style fields the operator wants redacted). Bucket 1 and Bucket 2
- * keyword lists are hard-coded — operators tune behaviour via exemptions, not list edits.
+ * Option I/O is delegated to {@see SafetySettingsRepository} (Launch Gate runbook v0.2.0
+ * single source of truth). This class remains the runtime entry point for the redactor
+ * itself and the public surface for the documented filter hooks
+ * (`abilities_mcp_redaction_master_enabled`, `abilities_mcp_redaction_keywords`).
  *
  * Copyright (C) 2026 Influencentricity | Wicked Evolutions
  * License: GPL-2.0-or-later
@@ -22,19 +23,21 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
 
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository;
+
 /**
  * Redaction configuration loader.
  */
 final class RedactionConfig {
 
-	public const OPTION_MASTER_ENABLED      = 'abilities_mcp_redaction_master_enabled';
-	public const OPTION_BUCKET3_KEYWORDS    = 'abilities_mcp_redaction_keywords';
-	public const OPTION_BUCKET3_EXEMPTIONS  = 'abilities_mcp_bucket3_exemptions';
-	public const OPTION_BUCKET2_EXEMPTIONS  = 'abilities_mcp_bucket2_exemptions';
+	public const OPTION_MASTER_ENABLED      = SafetySettingsRepository::OPTION_MASTER_ENABLED;
+	public const OPTION_BUCKET3_KEYWORDS    = SafetySettingsRepository::OPTION_BUCKET3_KEYWORDS;
+	public const OPTION_BUCKET3_EXEMPTIONS  = SafetySettingsRepository::OPTION_BUCKET3_EXEMPTIONS;
+	public const OPTION_BUCKET2_EXEMPTIONS  = SafetySettingsRepository::OPTION_BUCKET2_EXEMPTIONS;
 
-	public const BUCKET_SECRETS  = 1;
-	public const BUCKET_PAYMENT  = 2;
-	public const BUCKET_CONTACT  = 3;
+	public const BUCKET_SECRETS  = SafetySettingsRepository::BUCKET_SECRETS;
+	public const BUCKET_PAYMENT  = SafetySettingsRepository::BUCKET_PAYMENT;
+	public const BUCKET_CONTACT  = SafetySettingsRepository::BUCKET_CONTACT;
 
 	/**
 	 * Bucket 1 — always-on secrets.
@@ -42,95 +45,16 @@ final class RedactionConfig {
 	 * @return string[]
 	 */
 	public static function bucket1_keywords(): array {
-		return array(
-			// Credentials.
-			'password',
-			'pass',
-			'passwd',
-			'user_pass',
-			'user_password',
-			'db_password',
-			'database_password',
-			'smtp_password',
-			'imap_password',
-			'pop_password',
-			'ftp_password',
-			'ssh_password',
-
-			// Named API keys / secrets.
-			'api_key',
-			'api_secret',
-			'consumer_key',
-			'consumer_secret',
-			'client_secret',
-			'client_key',
-			'private_key',
-			'license_key',
-			'serial_key',
-			'activation_key',
-			'app_key',
-			'app_secret',
-			'webhook_secret',
-			'webhook_key',
-			'signing_key',
-			'encryption_key',
-			'master_key',
-			'secret_key',
-
-			// Tokens.
-			'access_token',
-			'refresh_token',
-			'bearer_token',
-			'auth_token',
-			'authentication_token',
-			'oauth_token',
-			'oauth_secret',
-			'session_token',
-			'session_tokens',
-			'session_secret',
-			'csrf_token',
-			'nonce_token',
-			'id_token',
-			'personal_access_token',
-
-			// wp-config secrets.
-			'auth_key',
-			'secure_auth_key',
-			'logged_in_key',
-			'nonce_key',
-			'auth_salt',
-			'secure_auth_salt',
-			'logged_in_salt',
-			'nonce_salt',
-		);
+		return SafetySettingsRepository::bucket1_default_keywords();
 	}
 
 	/**
-	 * Bucket 2 — payment + regulated IDs.
+	 * Bucket 2 — payment + regulated IDs (active list: defaults plus customs minus removals).
 	 *
 	 * @return string[]
 	 */
 	public static function bucket2_keywords(): array {
-		return array(
-			'card_number',
-			'cardnumber',
-			'cc_number',
-			'pan',
-			'cvv',
-			'cvc',
-			'cv2',
-			'card_cvv',
-			'card_cvc',
-			'card_pin',
-			'ssn',
-			'social_security_number',
-			'social_security',
-			'tax_id',
-			'ein',
-			'tin',
-			'vat_number',
-			'vat_id',
-		);
+		return SafetySettingsRepository::get_active_keywords( SafetySettingsRepository::BUCKET_PAYMENT );
 	}
 
 	/**
@@ -139,61 +63,7 @@ final class RedactionConfig {
 	 * @return string[]
 	 */
 	public static function bucket3_default_keywords(): array {
-		return array(
-			// Email.
-			'email',
-			'user_email',
-			'customer_email',
-			'contact_email',
-			'billing_email',
-			'shipping_email',
-			'payment_email',
-
-			// Phone.
-			'phone',
-			'phone_number',
-			'mobile',
-			'mobile_number',
-			'tel',
-			'telephone',
-			'billing_phone',
-			'shipping_phone',
-			'contact_phone',
-
-			// Address.
-			'address',
-			'street_address',
-			'address_line_1',
-			'address_line_2',
-			'street',
-			'street1',
-			'street2',
-			'billing_address',
-			'shipping_address',
-			'billing_address_1',
-			'shipping_address_1',
-
-			// Login identity.
-			'user_login',
-			'username',
-
-			// IP.
-			'ip',
-			'ip_address',
-			'user_ip',
-			'client_ip',
-			'remote_ip',
-			'last_ip',
-
-			// Date of birth.
-			'birthdate',
-			'birth_date',
-			'date_of_birth',
-			'dob',
-
-			// Public key (infrastructure, configurable per principle).
-			'public_key',
-		);
+		return SafetySettingsRepository::bucket3_default_keywords();
 	}
 
 	/**
@@ -204,11 +74,7 @@ final class RedactionConfig {
 	 * @return bool
 	 */
 	public static function is_master_enabled(): bool {
-		$raw = function_exists( 'get_option' )
-			? get_option( self::OPTION_MASTER_ENABLED, true )
-			: true;
-
-		$enabled = (bool) $raw;
+		$enabled = SafetySettingsRepository::is_master_enabled();
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$enabled = (bool) apply_filters( self::OPTION_MASTER_ENABLED, $enabled );
@@ -218,26 +84,12 @@ final class RedactionConfig {
 	}
 
 	/**
-	 * Active Bucket 3 keyword list (defaults + custom additions, after filter).
+	 * Active Bucket 3 keyword list (defaults + custom additions − removed defaults, after filter).
 	 *
 	 * @return string[] Lower-cased canonical names.
 	 */
 	public static function bucket3_keywords(): array {
-		$defaults = self::bucket3_default_keywords();
-		$custom   = array();
-
-		if ( function_exists( 'get_option' ) ) {
-			$stored = get_option( self::OPTION_BUCKET3_KEYWORDS, array() );
-			if ( is_array( $stored ) ) {
-				foreach ( $stored as $kw ) {
-					if ( is_string( $kw ) && '' !== $kw ) {
-						$custom[] = $kw;
-					}
-				}
-			}
-		}
-
-		$merged = array_merge( $defaults, $custom );
+		$merged = SafetySettingsRepository::get_active_keywords( SafetySettingsRepository::BUCKET_CONTACT );
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$filtered = apply_filters( self::OPTION_BUCKET3_KEYWORDS, $merged );
@@ -269,26 +121,9 @@ final class RedactionConfig {
 			return false;
 		}
 
-		$option = self::BUCKET_PAYMENT === $bucket
-			? self::OPTION_BUCKET2_EXEMPTIONS
-			: self::OPTION_BUCKET3_EXEMPTIONS;
+		$exempt = SafetySettingsRepository::get_exemptions( $bucket );
 
-		if ( ! function_exists( 'get_option' ) ) {
-			return false;
-		}
-
-		$exempt = get_option( $option, array() );
-		if ( ! is_array( $exempt ) ) {
-			return false;
-		}
-
-		foreach ( $exempt as $name ) {
-			if ( is_string( $name ) && $name === $ability_name ) {
-				return true;
-			}
-		}
-
-		return false;
+		return in_array( $ability_name, $exempt, true );
 	}
 
 	/**

--- a/src/Infrastructure/Redaction/RedactionLimitExceeded.php
+++ b/src/Infrastructure/Redaction/RedactionLimitExceeded.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Raised when redaction traversal exceeds the configured depth or node limit.
+ *
+ * Caller MUST treat this as a fatal redaction failure and return a transport-level
+ * error rather than emit a partially-redacted response — partial redaction is a
+ * silent leak, not a graceful degradation.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
+
+use RuntimeException;
+
+/**
+ * Redaction guard breach.
+ */
+final class RedactionLimitExceeded extends RuntimeException {}

--- a/src/Infrastructure/Redaction/ResponseRedactionGate.php
+++ b/src/Infrastructure/Redaction/ResponseRedactionGate.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Adapter-layer gate that runs the redaction filter at the response boundary.
+ *
+ * Both HTTP and stdio transports route through {@see RequestRouter::route_request()}
+ * and then format the result as JSON-RPC. This gate sits between those two steps —
+ * it inspects the resolved method and ability name, runs {@see ResponseRedactor}
+ * over the success body, and (if an observability handler is wired) emits
+ * `boundary.redaction_applied` with per-bucket counts.
+ *
+ * The gate never mutates protocol-error envelopes (`{"error": {...}}`) — only the
+ * success result body is filtered. Errors are already plain-text strings or
+ * structured codes, never response payload data.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\McpErrorFactory;
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface;
+
+/**
+ * Gate that applies redaction at the adapter response boundary.
+ */
+final class ResponseRedactionGate {
+
+	/**
+	 * Apply redaction to a router result, in place of the router's return value.
+	 *
+	 * On success: returns the redacted result (same shape).
+	 * On limit exceeded: returns an internal-error envelope (better to fail closed
+	 *   than leak a partial response).
+	 *
+	 * Pass-through cases (no redaction):
+	 *   - Result already contains a JSON-RPC error envelope.
+	 *   - Result is empty.
+	 *
+	 * @param array                                  $result        Router result (possibly containing _session_id/_session_token).
+	 * @param string                                 $method        JSON-RPC method (e.g. `tools/call`).
+	 * @param array                                  $params        JSON-RPC params (used to extract ability name on tools/call).
+	 * @param mixed                                  $request_id    Original request id (preserved on error).
+	 * @param McpObservabilityHandlerInterface|null  $observability Optional handler for boundary events.
+	 *
+	 * @return array
+	 */
+	public static function apply( array $result, string $method, array $params, $request_id, ?McpObservabilityHandlerInterface $observability = null ): array {
+		// Don't redact protocol error envelopes.
+		if ( isset( $result['error']['code'], $result['error']['message'] )
+			&& is_int( $result['error']['code'] )
+			&& is_string( $result['error']['message'] )
+		) {
+			return $result;
+		}
+
+		// Extract internal session bookkeeping before redaction so the redactor
+		// never sees them. Caller must restore them on the returned result.
+		$session_id    = $result['_session_id'] ?? null;
+		$session_token = $result['_session_token'] ?? null;
+		$metadata      = $result['_metadata'] ?? null;
+		unset( $result['_session_id'], $result['_session_token'], $result['_metadata'] );
+
+		$ability_name = self::extract_ability_name( $method, $params );
+
+		try {
+			$redactor = new ResponseRedactor( $ability_name );
+			$redacted = $redactor->redact( $result );
+			$counts   = $redactor->get_counts();
+		} catch ( RedactionLimitExceeded $e ) {
+			self::emit_redaction_failure( $observability, $method, $ability_name, $e->getMessage() );
+			return array(
+				'error' => McpErrorFactory::internal_error( $request_id, 'Response too large to safely redact' )['error'],
+			);
+		}
+
+		if ( null !== $session_id ) {
+			$redacted['_session_id'] = $session_id;
+		}
+		if ( null !== $session_token ) {
+			$redacted['_session_token'] = $session_token;
+		}
+		if ( null !== $metadata ) {
+			$redacted['_metadata'] = $metadata;
+		}
+
+		$total = $counts[ RedactionConfig::BUCKET_SECRETS ]
+			+ $counts[ RedactionConfig::BUCKET_PAYMENT ]
+			+ $counts[ RedactionConfig::BUCKET_CONTACT ];
+
+		if ( $total > 0 ) {
+			self::emit_redaction_event( $observability, $method, $ability_name, $counts );
+		}
+
+		return $redacted;
+	}
+
+	/**
+	 * Pull the ability name out of params for tools/call. Other methods have no ability scope.
+	 *
+	 * @param string $method
+	 * @param array  $params
+	 * @return string|null
+	 */
+	private static function extract_ability_name( string $method, array $params ): ?string {
+		if ( 'tools/call' === $method && isset( $params['name'] ) && is_string( $params['name'] ) ) {
+			return $params['name'];
+		}
+		return null;
+	}
+
+	/**
+	 * Emit `boundary.redaction_applied` with per-bucket counts (no values).
+	 *
+	 * @param McpObservabilityHandlerInterface|null $handler
+	 * @param string                                $method
+	 * @param string|null                           $ability_name
+	 * @param array<int,int>                        $counts
+	 */
+	private static function emit_redaction_event( ?McpObservabilityHandlerInterface $handler, string $method, ?string $ability_name, array $counts ): void {
+		BoundaryEventEmitter::emit(
+			$handler,
+			'boundary.redaction_applied',
+			array(
+				'severity'           => 'info',
+				'method'             => $method,
+				'name'               => $ability_name ?? '',
+				'redaction_count_b1' => $counts[ RedactionConfig::BUCKET_SECRETS ] ?? 0,
+				'redaction_count_b2' => $counts[ RedactionConfig::BUCKET_PAYMENT ] ?? 0,
+				'redaction_count_b3' => $counts[ RedactionConfig::BUCKET_CONTACT ] ?? 0,
+			)
+		);
+	}
+
+	/**
+	 * Emit `boundary.transport.error` for redaction-guard failures.
+	 *
+	 * @param McpObservabilityHandlerInterface|null $handler
+	 * @param string                                $method
+	 * @param string|null                           $ability_name
+	 * @param string                                $reason
+	 */
+	private static function emit_redaction_failure( ?McpObservabilityHandlerInterface $handler, string $method, ?string $ability_name, string $reason ): void {
+		BoundaryEventEmitter::emit(
+			$handler,
+			'boundary.transport.error',
+			array(
+				'severity'   => 'warn',
+				'method'     => $method,
+				'name'       => $ability_name ?? '',
+				'error_code' => 'redaction_' . $reason,
+			)
+		);
+	}
+}

--- a/src/Infrastructure/Redaction/ResponseRedactionGate.php
+++ b/src/Infrastructure/Redaction/ResponseRedactionGate.php
@@ -104,25 +104,29 @@ final class ResponseRedactionGate {
 	/**
 	 * Pull the ability name out of params for tools/call. Other methods have no ability scope.
 	 *
-	 * The MCP adapter's primary AI-client path goes through the
-	 * `mcp-adapter/execute-ability` meta-tool — `params['name']` is the
-	 * meta-tool, the *real* ability whose response we're about to redact
-	 * lives at `params['arguments']['ability_name']`. Returning the
-	 * meta-tool's name there would defeat any per-ability exemption the
-	 * operator configured on the inner ability. So we unwrap.
+	 * Naming convention: the WordPress Abilities API stores ability names in
+	 * **slash form** (e.g. `fluent-cart/list-customers`). MCP tool names cannot
+	 * contain `/`, so {@see RegisterAbilityAsMcpTool::get_data()} converts
+	 * `/` to `-` when advertising tools over the wire — `tools/call` therefore
+	 * arrives with `params['name']` in **dash form** (e.g.
+	 * `fluent-cart-list-customers`). Per-ability exemptions are stored against
+	 * the slash form (canonical registry name), so any name the gate returns
+	 * MUST be in slash form before reaching `is_ability_exempt()`.
 	 *
-	 * `mcp-adapter/batch-execute` carries multiple inner abilities at
-	 * `params['arguments']['requests'][i]['name']`. A single redaction
-	 * pass over the outer response cannot honour per-ability exemptions
-	 * for each inner result, so we return null — exemptions don't apply
-	 * inside batch-execute. This is a documented limitation, not a
-	 * regression: the safe-by-default behaviour (full redaction) is
-	 * preserved; the sharp edge is that exempt abilities lose their
-	 * exemption when invoked inside a batch.
+	 * The adapter's primary AI-client path goes through the
+	 * `mcp-adapter-execute-ability` meta-tool — `params['name']` is the
+	 * meta-tool, the *real* ability lives at `params['arguments']['ability_name']`
+	 * (which the operator typically passes in slash form already, but we
+	 * still normalise defensively).
+	 *
+	 * `mcp-adapter-batch-execute` carries multiple inner abilities at
+	 * `params['arguments']['requests'][i]['name']`. A single redaction pass
+	 * over the outer response cannot honour per-ability exemptions for each
+	 * inner result, so we return null — exemptions don't apply inside batch.
 	 *
 	 * @param string $method
 	 * @param array  $params
-	 * @return string|null
+	 * @return string|null Slash-form ability name suitable for exemption lookup, or null.
 	 */
 	private static function extract_ability_name( string $method, array $params ): ?string {
 		if ( 'tools/call' !== $method ) {
@@ -133,22 +137,114 @@ final class ResponseRedactionGate {
 			return null;
 		}
 
-		// `mcp-adapter/execute-ability` — the real ability is one level deeper.
-		if ( 'mcp-adapter/execute-ability' === $outer ) {
+		// Meta-tool: `mcp-adapter-execute-ability` — unwrap to the inner ability.
+		if ( 'mcp-adapter-execute-ability' === $outer || 'mcp-adapter/execute-ability' === $outer ) {
 			$args = isset( $params['arguments'] ) && is_array( $params['arguments'] ) ? $params['arguments'] : array();
 			if ( isset( $args['ability_name'] ) && is_string( $args['ability_name'] ) && '' !== $args['ability_name'] ) {
-				return $args['ability_name'];
+				return self::tool_name_to_ability_name( $args['ability_name'] );
 			}
 			return null;
 		}
 
-		// `mcp-adapter/batch-execute` — multiple inner abilities, can't pick one.
-		if ( 'mcp-adapter/batch-execute' === $outer ) {
+		// Meta-tool: `mcp-adapter-batch-execute` — multiple inner abilities, can't pick one.
+		if ( 'mcp-adapter-batch-execute' === $outer || 'mcp-adapter/batch-execute' === $outer ) {
 			return null;
 		}
 
 		// Direct tools/call against an ability registered as an MCP tool.
-		return $outer;
+		// Outer name arrives in dash form — translate back to slash before lookup.
+		return self::tool_name_to_ability_name( $outer );
+	}
+
+	/**
+	 * Translate an MCP tool name (dash form, over-the-wire) to the canonical
+	 * Abilities-API name (slash form, registry storage).
+	 *
+	 * Builds a dash→slash map from `wp_get_abilities()` once per request.
+	 * If the input already contains a `/`, or doesn't match any registered
+	 * ability, the input is returned unchanged — defensive fall-back so
+	 * non-MCP code paths and unit-test contexts continue to work.
+	 *
+	 * @param string $tool_name
+	 * @return string
+	 */
+	public static function tool_name_to_ability_name( string $tool_name ): string {
+		if ( '' === $tool_name ) {
+			return $tool_name;
+		}
+		// Already in slash form — registered abilities never contain a `/`
+		// in their dash-form tool name, so a `/` means we already have the
+		// canonical form.
+		if ( false !== strpos( $tool_name, '/' ) ) {
+			return $tool_name;
+		}
+
+		$map = self::dash_to_slash_map();
+		return $map[ $tool_name ] ?? $tool_name;
+	}
+
+	/**
+	 * Class-level cache for the dash→slash map. Built lazily on first lookup
+	 * and lives for the duration of the request. Tests can reset it via
+	 * {@see reset_name_cache_for_testing()}.
+	 *
+	 * @var array<string,string>|null
+	 */
+	private static ?array $dash_to_slash_cache = null;
+
+	/**
+	 * Build (and cache) a dash→slash lookup of every registered ability.
+	 * Empty when `wp_get_abilities()` is unavailable (e.g. unit-test
+	 * contexts without the WP Abilities API loaded).
+	 *
+	 * @return array<string,string>
+	 */
+	private static function dash_to_slash_map(): array {
+		if ( null !== self::$dash_to_slash_cache ) {
+			return self::$dash_to_slash_cache;
+		}
+
+		$cache = array();
+
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			self::$dash_to_slash_cache = $cache;
+			return $cache;
+		}
+
+		$abilities = wp_get_abilities();
+		if ( ! is_array( $abilities ) && ! ( $abilities instanceof \Traversable ) ) {
+			self::$dash_to_slash_cache = $cache;
+			return $cache;
+		}
+
+		foreach ( $abilities as $ability ) {
+			if ( ! is_object( $ability ) || ! method_exists( $ability, 'get_name' ) ) {
+				continue;
+			}
+			$slash = (string) $ability->get_name();
+			if ( '' === $slash ) {
+				continue;
+			}
+			$dash = str_replace( '/', '-', $slash );
+			// First-write wins — duplicate dash forms from differently-named
+			// abilities should not silently rewrite an earlier registration.
+			if ( ! isset( $cache[ $dash ] ) ) {
+				$cache[ $dash ] = $slash;
+			}
+		}
+
+		self::$dash_to_slash_cache = $cache;
+		return $cache;
+	}
+
+	/**
+	 * Reset the dash→slash cache so the next lookup rebuilds it from the
+	 * current ability registry. Test-only.
+	 *
+	 * @internal
+	 */
+	public static function reset_name_cache_for_testing(): void {
+		self::$dash_to_slash_cache = null;
 	}
 
 	/**

--- a/src/Infrastructure/Redaction/ResponseRedactionGate.php
+++ b/src/Infrastructure/Redaction/ResponseRedactionGate.php
@@ -104,15 +104,51 @@ final class ResponseRedactionGate {
 	/**
 	 * Pull the ability name out of params for tools/call. Other methods have no ability scope.
 	 *
+	 * The MCP adapter's primary AI-client path goes through the
+	 * `mcp-adapter/execute-ability` meta-tool — `params['name']` is the
+	 * meta-tool, the *real* ability whose response we're about to redact
+	 * lives at `params['arguments']['ability_name']`. Returning the
+	 * meta-tool's name there would defeat any per-ability exemption the
+	 * operator configured on the inner ability. So we unwrap.
+	 *
+	 * `mcp-adapter/batch-execute` carries multiple inner abilities at
+	 * `params['arguments']['requests'][i]['name']`. A single redaction
+	 * pass over the outer response cannot honour per-ability exemptions
+	 * for each inner result, so we return null — exemptions don't apply
+	 * inside batch-execute. This is a documented limitation, not a
+	 * regression: the safe-by-default behaviour (full redaction) is
+	 * preserved; the sharp edge is that exempt abilities lose their
+	 * exemption when invoked inside a batch.
+	 *
 	 * @param string $method
 	 * @param array  $params
 	 * @return string|null
 	 */
 	private static function extract_ability_name( string $method, array $params ): ?string {
-		if ( 'tools/call' === $method && isset( $params['name'] ) && is_string( $params['name'] ) ) {
-			return $params['name'];
+		if ( 'tools/call' !== $method ) {
+			return null;
 		}
-		return null;
+		$outer = isset( $params['name'] ) && is_string( $params['name'] ) ? $params['name'] : '';
+		if ( '' === $outer ) {
+			return null;
+		}
+
+		// `mcp-adapter/execute-ability` — the real ability is one level deeper.
+		if ( 'mcp-adapter/execute-ability' === $outer ) {
+			$args = isset( $params['arguments'] ) && is_array( $params['arguments'] ) ? $params['arguments'] : array();
+			if ( isset( $args['ability_name'] ) && is_string( $args['ability_name'] ) && '' !== $args['ability_name'] ) {
+				return $args['ability_name'];
+			}
+			return null;
+		}
+
+		// `mcp-adapter/batch-execute` — multiple inner abilities, can't pick one.
+		if ( 'mcp-adapter/batch-execute' === $outer ) {
+			return null;
+		}
+
+		// Direct tools/call against an ability registered as an MCP tool.
+		return $outer;
 	}
 
 	/**

--- a/src/Infrastructure/Redaction/ResponseRedactor.php
+++ b/src/Infrastructure/Redaction/ResponseRedactor.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Response redactor — runs at the adapter response boundary.
+ *
+ * Recursive, type-aware substitution. Three buckets:
+ *   - Bucket 1 (secrets): always-on, never disabled.
+ *   - Bucket 2 (payment / regulated IDs): default-on, master-toggle gated.
+ *   - Bucket 3 (contact PII / access labels): default-on, master-toggle gated.
+ *
+ * Matching rules:
+ *   - Field-name match is case-insensitive against the canonical keyword lists.
+ *   - When a field name matches, the ENTIRE value at that key is replaced (recursively
+ *     untouched — the subtree is redacted as a whole using a type-shape-preserving marker).
+ *   - When a field name does NOT match, traversal recurses into arrays/objects and the
+ *     scalar leaf is checked against Bucket 1 / Bucket 2 pattern matchers (hash formats,
+ *     known API-key prefixes, Luhn-valid PANs). Patterns NEVER run on free-text bodies as
+ *     a regex over the serialised JSON — they apply per-scalar-string only.
+ *
+ * Hard limits:
+ *   - Max depth 64
+ *   - Max nodes 100,000
+ * Exceeding either raises {@see RedactionLimitExceeded}, which the caller MUST translate
+ * to a transport-level error rather than returning a partially-redacted response.
+ *
+ * Filter hooks:
+ *   - `abilities_mcp_redaction_keywords` — modify Bucket 3 keyword list.
+ *   - `abilities_mcp_redaction_master_enabled` — modify master toggle.
+ *   - `abilities_mcp_redacted_value` — `(value, field_name, bucket_number)` → custom marker.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Infrastructure\Redaction;
+
+/**
+ * Boundary redactor.
+ */
+final class ResponseRedactor {
+
+	public const MAX_DEPTH = 64;
+	public const MAX_NODES = 100000;
+
+	public const FILTER_REDACTED_VALUE = 'abilities_mcp_redacted_value';
+
+	/**
+	 * Lower-case Bucket 1 keyword set (key => true) for O(1) lookup.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $bucket1_set;
+
+	/**
+	 * Lower-case Bucket 2 keyword set.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $bucket2_set;
+
+	/**
+	 * Lower-case Bucket 3 keyword set.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $bucket3_set;
+
+	/**
+	 * Whether Bucket 2 is active for this response (master + per-ability exemption).
+	 *
+	 * @var bool
+	 */
+	private bool $bucket2_active;
+
+	/**
+	 * Whether Bucket 3 is active for this response (master + per-ability exemption).
+	 *
+	 * @var bool
+	 */
+	private bool $bucket3_active;
+
+	/**
+	 * Per-bucket counters for the most recent {@see redact()} call.
+	 *
+	 * @var array<int,int>
+	 */
+	private array $counts = array();
+
+	/**
+	 * Node counter for the most recent {@see redact()} call.
+	 *
+	 * @var int
+	 */
+	private int $node_count = 0;
+
+	/**
+	 * Build a redactor configured for the given ability call.
+	 *
+	 * @param string|null $ability_name Ability name (e.g. `users/list`), or null when method has no ability.
+	 */
+	public function __construct( ?string $ability_name = null ) {
+		$this->bucket1_set = self::flip_lower( RedactionConfig::bucket1_keywords() );
+		$this->bucket2_set = self::flip_lower( RedactionConfig::bucket2_keywords() );
+		$this->bucket3_set = self::flip_lower( RedactionConfig::bucket3_keywords() );
+
+		$master                = RedactionConfig::is_master_enabled();
+		$this->bucket2_active  = $master && ! RedactionConfig::is_ability_exempt( $ability_name, RedactionConfig::BUCKET_PAYMENT );
+		$this->bucket3_active  = $master && ! RedactionConfig::is_ability_exempt( $ability_name, RedactionConfig::BUCKET_CONTACT );
+	}
+
+	/**
+	 * Redact a response body. Returns the redacted copy.
+	 *
+	 * @param array $response Response body to redact.
+	 *
+	 * @return array
+	 *
+	 * @throws RedactionLimitExceeded When max depth or max nodes is exceeded.
+	 */
+	public function redact( array $response ): array {
+		$this->counts     = array(
+			RedactionConfig::BUCKET_SECRETS => 0,
+			RedactionConfig::BUCKET_PAYMENT => 0,
+			RedactionConfig::BUCKET_CONTACT => 0,
+		);
+		$this->node_count = 0;
+
+		return $this->walk_array( $response, 0, null );
+	}
+
+	/**
+	 * Redacted-value counts from the most recent redaction (per bucket).
+	 *
+	 * @return array{1:int,2:int,3:int}
+	 */
+	public function get_counts(): array {
+		return array(
+			RedactionConfig::BUCKET_SECRETS => $this->counts[ RedactionConfig::BUCKET_SECRETS ] ?? 0,
+			RedactionConfig::BUCKET_PAYMENT => $this->counts[ RedactionConfig::BUCKET_PAYMENT ] ?? 0,
+			RedactionConfig::BUCKET_CONTACT => $this->counts[ RedactionConfig::BUCKET_CONTACT ] ?? 0,
+		);
+	}
+
+	/**
+	 * Walk an array. Each element is checked against keyword set first; on miss,
+	 * the value is recursed (for arrays/objects) or pattern-checked (for scalar strings).
+	 *
+	 * @param array       $arr   Array node.
+	 * @param int         $depth Current depth.
+	 * @param string|null $key   Parent key, or null at the root.
+	 *
+	 * @return array
+	 *
+	 * @throws RedactionLimitExceeded
+	 */
+	private function walk_array( array $arr, int $depth, ?string $key ): array {
+		if ( $depth > self::MAX_DEPTH ) {
+			throw new RedactionLimitExceeded( 'max_depth_exceeded' );
+		}
+
+		$out = array();
+		foreach ( $arr as $k => $v ) {
+			if ( ++$this->node_count > self::MAX_NODES ) {
+				throw new RedactionLimitExceeded( 'max_nodes_exceeded' );
+			}
+
+			$out[ $k ] = is_string( $k )
+				? $this->process_named_field( $k, $v, $depth + 1 )
+				: $this->process_value( $v, $depth + 1, null );
+		}
+		return $out;
+	}
+
+	/**
+	 * Apply field-name matching to a string-keyed entry. On hit, redact the whole subtree.
+	 *
+	 * @param string $key   Field name.
+	 * @param mixed  $value Field value.
+	 * @param int    $depth Current depth (for the value; the key itself is at depth-1).
+	 *
+	 * @return mixed
+	 *
+	 * @throws RedactionLimitExceeded
+	 */
+	private function process_named_field( string $key, $value, int $depth ) {
+		$lower = strtolower( $key );
+
+		if ( isset( $this->bucket1_set[ $lower ] ) ) {
+			$this->counts[ RedactionConfig::BUCKET_SECRETS ]++;
+			return $this->build_marker( $value, $key, RedactionConfig::BUCKET_SECRETS );
+		}
+
+		if ( $this->bucket2_active && isset( $this->bucket2_set[ $lower ] ) ) {
+			$this->counts[ RedactionConfig::BUCKET_PAYMENT ]++;
+			return $this->build_marker( $value, $key, RedactionConfig::BUCKET_PAYMENT );
+		}
+
+		if ( $this->bucket3_active && isset( $this->bucket3_set[ $lower ] ) ) {
+			$this->counts[ RedactionConfig::BUCKET_CONTACT ]++;
+			return $this->build_marker( $value, $key, RedactionConfig::BUCKET_CONTACT );
+		}
+
+		return $this->process_value( $value, $depth, $key );
+	}
+
+	/**
+	 * Process a value: recurse into containers, apply pattern matchers to scalar strings.
+	 *
+	 * @param mixed       $value Value to process.
+	 * @param int         $depth Current depth.
+	 * @param string|null $key   Parent field name (string keys only) or null.
+	 *
+	 * @return mixed
+	 *
+	 * @throws RedactionLimitExceeded
+	 */
+	private function process_value( $value, int $depth, ?string $key ) {
+		if ( is_array( $value ) ) {
+			return $this->walk_array( $value, $depth, $key );
+		}
+
+		if ( is_object( $value ) ) {
+			$as_array = (array) $value;
+			$walked   = $this->walk_array( $as_array, $depth, $key );
+			return (object) $walked;
+		}
+
+		if ( is_string( $value ) ) {
+			return $this->maybe_redact_scalar_string( $value, $key );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Apply Bucket 1 / Bucket 2 pattern matchers to a scalar string.
+	 *
+	 * Patterns NEVER apply to free-text-style fields when the field name itself was
+	 * already known and exempted via traversal — only to scalars whose containing key
+	 * was not bucketed. Bucket 1 patterns always run; Bucket 2 patterns only when active.
+	 *
+	 * Bucket 3 has no pattern matcher (the brief excludes contact-PII heuristic detection
+	 * to keep blog/comment bodies untouched).
+	 *
+	 * @param string      $value Scalar string value.
+	 * @param string|null $key   Containing field name (or null at array root).
+	 *
+	 * @return mixed
+	 */
+	private function maybe_redact_scalar_string( string $value, ?string $key ) {
+		if ( PatternMatchers::is_password_hash( $value ) || PatternMatchers::is_known_api_key( $value ) ) {
+			$this->counts[ RedactionConfig::BUCKET_SECRETS ]++;
+			return $this->build_marker( $value, $key ?? '', RedactionConfig::BUCKET_SECRETS );
+		}
+
+		if ( $this->bucket2_active && PatternMatchers::passes_luhn( $value ) ) {
+			$this->counts[ RedactionConfig::BUCKET_PAYMENT ]++;
+			return $this->build_marker( $value, $key ?? '', RedactionConfig::BUCKET_PAYMENT );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Build a redaction marker that preserves the original value's shape.
+	 *
+	 * Type rules:
+	 *   - string  → "[redacted:bucket_N]"
+	 *   - number  → null (preserves nullable schema slot)
+	 *   - bool    → original value (booleans are not in any bucket)
+	 *   - object  → {"redacted": true, "reason": "bucket_N"}
+	 *   - array   → ["[redacted:bucket_N]"]
+	 *   - null    → null (no marker)
+	 *
+	 * Caller can override via `abilities_mcp_redacted_value` filter.
+	 *
+	 * @param mixed  $value      Original value.
+	 * @param string $field_name Field name (informational; passed to filter).
+	 * @param int    $bucket     Bucket constant.
+	 *
+	 * @return mixed
+	 */
+	private function build_marker( $value, string $field_name, int $bucket ) {
+		$default = $this->default_marker( $value, $bucket );
+
+		if ( function_exists( 'apply_filters' ) ) {
+			return apply_filters( self::FILTER_REDACTED_VALUE, $default, $field_name, $bucket );
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Default marker for the given value type and bucket.
+	 *
+	 * @param mixed $value
+	 * @param int   $bucket
+	 * @return mixed
+	 */
+	private function default_marker( $value, int $bucket ) {
+		$tag = 'bucket_' . $bucket;
+
+		if ( null === $value ) {
+			return null;
+		}
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return null;
+		}
+		if ( is_string( $value ) ) {
+			return '[redacted:' . $tag . ']';
+		}
+		if ( is_array( $value ) ) {
+			return array( '[redacted:' . $tag . ']' );
+		}
+		if ( is_object( $value ) ) {
+			return (object) array(
+				'redacted' => true,
+				'reason'   => $tag,
+			);
+		}
+		return '[redacted:' . $tag . ']';
+	}
+
+	/**
+	 * Lower-case + flip a list of keywords into a hash-set for O(1) lookup.
+	 *
+	 * @param string[] $keywords
+	 * @return array<string,bool>
+	 */
+	private static function flip_lower( array $keywords ): array {
+		$out = array();
+		foreach ( $keywords as $kw ) {
+			if ( ! is_string( $kw ) || '' === $kw ) {
+				continue;
+			}
+			$out[ strtolower( $kw ) ] = true;
+		}
+		return $out;
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,7 +15,9 @@ declare(strict_types = 1);
 
 namespace WickedEvolutions\McpAdapter;
 
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
 use WickedEvolutions\McpAdapter\Admin\AbilitySettingsPage;
+use WickedEvolutions\McpAdapter\Admin\SafetySettingsPage;
 use WickedEvolutions\McpAdapter\Core\McpAdapter;
 
 /**
@@ -61,10 +63,14 @@ final class Plugin {
 
 		McpAdapter::instance();
 
-		// Register admin settings page for ability permissions.
+		// Register admin settings pages.
 		if ( is_admin() ) {
 			AbilitySettingsPage::register();
+			SafetySettingsPage::register();
 		}
+
+		// Register safety-settings abilities inside the Abilities API init hook.
+		add_action( 'wp_abilities_api_init', array( SettingsAbilities::class, 'register_all' ) );
 	}
 
 	/**

--- a/src/Settings/ConfirmationTokenStore.php
+++ b/src/Settings/ConfirmationTokenStore.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * In-chat 1/2 confirmation token store.
+ *
+ * Mints a one-time token bound to (session, ability, params hash). The
+ * token is stored as a WP transient with ~60s TTL; consume_token() deletes
+ * it on first valid use. Tokens are NOT proof of human consent — a malicious
+ * AI client could synthesise a "1" reply. They prevent accidental weakening.
+ *
+ * Cryptographic-trust paths (Bucket 2, master toggle off) intentionally bypass
+ * this mechanism and require the Admin UI checkbox.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Settings;
+
+/**
+ * Mint and consume confirmation tokens for safety-weakening abilities.
+ */
+final class ConfirmationTokenStore {
+
+	public const TRANSIENT_PREFIX = 'abilities_mcp_confirm_';
+	public const TTL_SECONDS      = 60;
+
+	/**
+	 * Mint a new token bound to (session, ability, params).
+	 *
+	 * Returns the opaque token string. Stored payload includes the binding
+	 * tuple so consume_token() can re-verify the call shape on redemption.
+	 *
+	 * @param string $session_id  Stable session identifier (MCP session, falls back to user+ip).
+	 * @param string $ability     Ability name being weakened.
+	 * @param array  $params      Sanitized scalar params (canonicalised before hashing).
+	 *
+	 * @return string The token.
+	 */
+	public static function mint( string $session_id, string $ability, array $params ): string {
+		$token = wp_generate_password( 32, false, false );
+
+		$payload = array(
+			'session_id'  => $session_id,
+			'ability'     => $ability,
+			'params_hash' => self::params_hash( $params ),
+			'created_at'  => time(),
+		);
+
+		set_transient( self::TRANSIENT_PREFIX . $token, $payload, self::TTL_SECONDS );
+
+		return $token;
+	}
+
+	/**
+	 * Consume a token. Returns true on a valid+matching one-time redemption,
+	 * \WP_Error otherwise. Always deletes the transient on lookup so a token
+	 * cannot be replayed.
+	 *
+	 * Returns specific error codes so callers can log fine-grained reasons:
+	 *   - missing_token        — no token presented
+	 *   - token_unknown        — transient expired or never minted
+	 *   - session_mismatch     — token bound to different session
+	 *   - ability_mismatch     — token minted for a different ability
+	 *   - params_mismatch      — same ability but different parameters
+	 *
+	 * @param string|null $token
+	 * @param string      $session_id
+	 * @param string      $ability
+	 * @param array       $params
+	 *
+	 * @return true|\WP_Error
+	 */
+	public static function consume( ?string $token, string $session_id, string $ability, array $params ) {
+		if ( ! is_string( $token ) || '' === $token ) {
+			return new \WP_Error( 'missing_token', 'No confirmation token presented.' );
+		}
+
+		$key     = self::TRANSIENT_PREFIX . $token;
+		$payload = get_transient( $key );
+
+		// Always invalidate on any lookup attempt — one-time only.
+		delete_transient( $key );
+
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'token_unknown', 'Confirmation token is unknown or has expired.' );
+		}
+
+		if ( ( $payload['session_id'] ?? '' ) !== $session_id ) {
+			return new \WP_Error( 'session_mismatch', 'Confirmation token belongs to a different session.' );
+		}
+		if ( ( $payload['ability'] ?? '' ) !== $ability ) {
+			return new \WP_Error( 'ability_mismatch', 'Confirmation token was minted for a different ability.' );
+		}
+		if ( ( $payload['params_hash'] ?? '' ) !== self::params_hash( $params ) ) {
+			return new \WP_Error( 'params_mismatch', 'Confirmation token does not match the call parameters.' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Best-effort session identifier used to bind tokens.
+	 *
+	 * MCP transports may set `Mcp-Session-Id`; if absent we fall back to
+	 * (user_id|ip) so a fresh user has a stable enough binding for the
+	 * 60-second window.
+	 */
+	public static function current_session_id(): string {
+		$header = isset( $_SERVER['HTTP_MCP_SESSION_ID'] ) ? (string) $_SERVER['HTTP_MCP_SESSION_ID'] : '';
+		if ( '' !== $header ) {
+			return substr( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $header ) ?? '', 0, 64 );
+		}
+
+		$user_id = function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0;
+		$ip      = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : '';
+		return 'fallback-' . $user_id . '-' . substr( md5( $ip ), 0, 16 );
+	}
+
+	/**
+	 * Stable hash of the canonicalised params array.
+	 */
+	private static function params_hash( array $params ): string {
+		// Lower-case keys + json-encode with sorted keys for determinism.
+		$normalised = array();
+		foreach ( $params as $k => $v ) {
+			$normalised[ strtolower( (string) $k ) ] = is_string( $v ) ? trim( $v ) : $v;
+		}
+		ksort( $normalised );
+		$json = wp_json_encode( $normalised );
+		return hash( 'sha256', $json !== false ? $json : '' );
+	}
+}

--- a/src/Settings/SafetySettingsRepository.php
+++ b/src/Settings/SafetySettingsRepository.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Safety settings repository — read/write the option keys configured by
+ * the Safety Settings UI and the AI-callable settings abilities.
+ *
+ * Option key contract (DB-2 + DB-3 share these):
+ *
+ *   abilities_mcp_redaction_master_enabled  (bool, default true)
+ *   abilities_mcp_redaction_keywords        (string[], custom Bucket 3 additions)
+ *   abilities_mcp_bucket2_keywords          (string[], custom Bucket 2 additions — written here, read by DB-2 after rebase)
+ *   abilities_mcp_bucket3_exemptions        (string[], ability names exempt from Bucket 3)
+ *   abilities_mcp_bucket2_exemptions        (string[], ability names exempt from Bucket 2 — Admin-UI only)
+ *   abilities_mcp_trusted_proxy_enabled     (bool, default false)
+ *   abilities_mcp_trusted_proxy_mode        (string, 'cloudflare' | 'custom', default 'cloudflare')
+ *   abilities_mcp_trusted_proxy_allowlist   (string, newline-separated CIDR list)
+ *
+ * Bucket 2 weakening (remove default keyword, exempt ability) and the master
+ * toggle off are Admin-UI-only — abilities cannot reach those write paths.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Settings;
+
+/**
+ * Single source of truth for safety-setting option I/O.
+ *
+ * Hardcoded Bucket 1 + Bucket 2 default lists live here too so the UI and
+ * abilities can render them without depending on DB-2's RedactionConfig
+ * before that branch merges. Once DB-2 is integrated, RedactionConfig will
+ * remain authoritative for the runtime filter — this class stays the
+ * authoritative configuration surface (UI/abilities), and the two stay
+ * aligned by referencing the same option keys.
+ */
+final class SafetySettingsRepository {
+
+	public const OPTION_MASTER_ENABLED         = 'abilities_mcp_redaction_master_enabled';
+	public const OPTION_BUCKET3_KEYWORDS       = 'abilities_mcp_redaction_keywords';
+	public const OPTION_BUCKET2_KEYWORDS       = 'abilities_mcp_bucket2_keywords';
+	public const OPTION_BUCKET3_EXEMPTIONS     = 'abilities_mcp_bucket3_exemptions';
+	public const OPTION_BUCKET2_EXEMPTIONS     = 'abilities_mcp_bucket2_exemptions';
+	public const OPTION_TRUSTED_PROXY_ENABLED  = 'abilities_mcp_trusted_proxy_enabled';
+	public const OPTION_TRUSTED_PROXY_MODE     = 'abilities_mcp_trusted_proxy_mode';
+	public const OPTION_TRUSTED_PROXY_ALLOWLIST = 'abilities_mcp_trusted_proxy_allowlist';
+
+	public const BUCKET_SECRETS = 1;
+	public const BUCKET_PAYMENT = 2;
+	public const BUCKET_CONTACT = 3;
+
+	public const PROXY_MODE_CLOUDFLARE = 'cloudflare';
+	public const PROXY_MODE_CUSTOM     = 'custom';
+
+	/**
+	 * Bucket 1 — always-on secrets. Hardcoded; not configurable.
+	 *
+	 * Mirrors DB-2's RedactionConfig::bucket1_keywords(). Kept in sync by
+	 * convention; both lists must agree at integration time.
+	 *
+	 * @return string[]
+	 */
+	public static function bucket1_default_keywords(): array {
+		return array(
+			'password', 'pass', 'passwd', 'user_pass', 'user_password',
+			'db_password', 'database_password', 'smtp_password',
+			'imap_password', 'pop_password', 'ftp_password', 'ssh_password',
+			'api_key', 'api_secret', 'consumer_key', 'consumer_secret',
+			'client_secret', 'client_key', 'private_key', 'license_key',
+			'serial_key', 'activation_key', 'app_key', 'app_secret',
+			'webhook_secret', 'webhook_key', 'signing_key', 'encryption_key',
+			'master_key', 'secret_key',
+			'access_token', 'refresh_token', 'bearer_token', 'auth_token',
+			'authentication_token', 'oauth_token', 'oauth_secret',
+			'session_token', 'session_tokens', 'session_secret', 'csrf_token',
+			'nonce_token', 'id_token', 'personal_access_token',
+			'auth_key', 'secure_auth_key', 'logged_in_key', 'nonce_key',
+			'auth_salt', 'secure_auth_salt', 'logged_in_salt', 'nonce_salt',
+		);
+	}
+
+	/**
+	 * Bucket 2 — payment + regulated identifiers (default list).
+	 *
+	 * @return string[]
+	 */
+	public static function bucket2_default_keywords(): array {
+		return array(
+			'card_number', 'cardnumber', 'cc_number', 'pan',
+			'cvv', 'cvc', 'cv2', 'card_cvv', 'card_cvc', 'card_pin',
+			'ssn', 'social_security_number', 'social_security',
+			'tax_id', 'ein', 'tin', 'vat_number', 'vat_id',
+		);
+	}
+
+	/**
+	 * Bucket 3 — contact PII / access labels (default list).
+	 *
+	 * @return string[]
+	 */
+	public static function bucket3_default_keywords(): array {
+		return array(
+			'email', 'user_email', 'customer_email', 'contact_email',
+			'billing_email', 'shipping_email', 'payment_email',
+			'phone', 'phone_number', 'mobile', 'mobile_number',
+			'tel', 'telephone', 'billing_phone', 'shipping_phone', 'contact_phone',
+			'address', 'street_address', 'address_line_1', 'address_line_2',
+			'street', 'street1', 'street2',
+			'billing_address', 'shipping_address',
+			'billing_address_1', 'shipping_address_1',
+			'user_login', 'username',
+			'ip', 'ip_address', 'user_ip', 'client_ip', 'remote_ip', 'last_ip',
+			'birthdate', 'birth_date', 'date_of_birth', 'dob',
+			'public_key',
+		);
+	}
+
+	/**
+	 * Removed-defaults storage option for Bucket 3.
+	 *
+	 * Default Bucket 3 keywords cannot be deleted; they can be marked as
+	 * removed so RedactionConfig::bucket3_keywords() can subtract them via
+	 * the `abilities_mcp_redaction_keywords` filter. Removal is reversible
+	 * by the operator (Restore defaults).
+	 */
+	public const OPTION_BUCKET3_REMOVED_DEFAULTS = 'abilities_mcp_redaction_keywords_removed_defaults';
+
+	/**
+	 * Removed-defaults storage option for Bucket 2.
+	 *
+	 * @see self::OPTION_BUCKET3_REMOVED_DEFAULTS
+	 */
+	public const OPTION_BUCKET2_REMOVED_DEFAULTS = 'abilities_mcp_bucket2_keywords_removed_defaults';
+
+	/**
+	 * Whether the master redaction toggle is on.
+	 */
+	public static function is_master_enabled(): bool {
+		return (bool) get_option( self::OPTION_MASTER_ENABLED, true );
+	}
+
+	/**
+	 * Set master toggle.
+	 *
+	 * Admin-UI-only callers should use this directly. Abilities never call
+	 * this with `$enabled = false` — that path requires the in-UI checkbox.
+	 *
+	 * @param bool $enabled
+	 */
+	public static function set_master_enabled( bool $enabled ): void {
+		update_option( self::OPTION_MASTER_ENABLED, $enabled );
+	}
+
+	/**
+	 * Custom keywords added by the operator for the given bucket.
+	 *
+	 * Bucket 1 always returns []: it is hardcoded and not extendable from
+	 * the operator surface.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_custom_keywords( int $bucket ): array {
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return array();
+		}
+		$option = self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_KEYWORDS
+			: self::OPTION_BUCKET3_KEYWORDS;
+
+		$value = get_option( $option, array() );
+		return self::clean_keyword_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Removed-defaults set for a bucket (operator-removed default keywords).
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_removed_defaults( int $bucket ): array {
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return array();
+		}
+		$option = self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_REMOVED_DEFAULTS
+			: self::OPTION_BUCKET3_REMOVED_DEFAULTS;
+
+		$value = get_option( $option, array() );
+		return self::clean_keyword_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Active keyword list for the given bucket: defaults minus removed-defaults
+	 * plus custom additions, deduped and lower-cased.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_active_keywords( int $bucket ): array {
+		switch ( $bucket ) {
+			case self::BUCKET_SECRETS:
+				$defaults = self::bucket1_default_keywords();
+				$customs  = array();
+				$removed  = array();
+				break;
+			case self::BUCKET_PAYMENT:
+				$defaults = self::bucket2_default_keywords();
+				$customs  = self::get_custom_keywords( self::BUCKET_PAYMENT );
+				$removed  = self::get_removed_defaults( self::BUCKET_PAYMENT );
+				break;
+			case self::BUCKET_CONTACT:
+				$defaults = self::bucket3_default_keywords();
+				$customs  = self::get_custom_keywords( self::BUCKET_CONTACT );
+				$removed  = self::get_removed_defaults( self::BUCKET_CONTACT );
+				break;
+			default:
+				return array();
+		}
+
+		$removed_set = array_flip( array_map( 'strtolower', $removed ) );
+		$active      = array();
+		foreach ( $defaults as $kw ) {
+			if ( ! isset( $removed_set[ strtolower( $kw ) ] ) ) {
+				$active[] = $kw;
+			}
+		}
+		foreach ( $customs as $kw ) {
+			$active[] = $kw;
+		}
+		return self::clean_keyword_list( $active );
+	}
+
+	/**
+	 * Add a custom keyword to a bucket. Returns true if newly added.
+	 *
+	 * Strengthening operation — no friction. Bucket 1 is rejected.
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function add_custom_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return new \WP_Error( 'bucket1_locked', 'Bucket 1 is hardcoded and cannot accept custom keywords.' );
+		}
+		if ( self::BUCKET_PAYMENT !== $bucket && self::BUCKET_CONTACT !== $bucket ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		// If this keyword is currently a removed default, restoring it is the right move.
+		$removed = self::get_removed_defaults( $bucket );
+		$removed_index = array_search( $keyword, array_map( 'strtolower', $removed ), true );
+		if ( false !== $removed_index ) {
+			unset( $removed[ $removed_index ] );
+			self::write_keyword_option( self::removed_defaults_option( $bucket ), array_values( $removed ) );
+			return true;
+		}
+
+		// Already present (default or custom)? No-op success.
+		$active = array_flip( self::get_active_keywords( $bucket ) );
+		if ( isset( $active[ $keyword ] ) ) {
+			return false;
+		}
+
+		$customs   = self::get_custom_keywords( $bucket );
+		$customs[] = $keyword;
+		self::write_keyword_option( self::custom_keywords_option( $bucket ), $customs );
+		return true;
+	}
+
+	/**
+	 * Remove a keyword the operator previously added (custom). Returns true
+	 * if a custom entry was removed; false if no matching custom entry.
+	 *
+	 * Reversal of the operator's own work — no friction. Does not touch
+	 * default-keyword removals (those go through remove_default_*).
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_custom_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+		if ( self::BUCKET_PAYMENT !== $bucket && self::BUCKET_CONTACT !== $bucket ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		$customs = self::get_custom_keywords( $bucket );
+		$lower   = array_map( 'strtolower', $customs );
+		$index   = array_search( $keyword, $lower, true );
+		if ( false === $index ) {
+			return false;
+		}
+		unset( $customs[ $index ] );
+		self::write_keyword_option( self::custom_keywords_option( $bucket ), array_values( $customs ) );
+		return true;
+	}
+
+	/**
+	 * Mark a default keyword as removed for the given bucket. Returns true
+	 * if newly removed.
+	 *
+	 * Bucket 3 path: friction = in-chat 1/2 confirmation token (enforced by ability).
+	 * Bucket 2 path: Admin-UI only — abilities must NOT call this with $bucket=2.
+	 *
+	 * Returns WP_Error on invalid bucket / non-default keyword / empty.
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_default_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+
+		if ( self::BUCKET_PAYMENT === $bucket ) {
+			$defaults = self::bucket2_default_keywords();
+		} elseif ( self::BUCKET_CONTACT === $bucket ) {
+			$defaults = self::bucket3_default_keywords();
+		} else {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		if ( ! in_array( $keyword, array_map( 'strtolower', $defaults ), true ) ) {
+			return new \WP_Error( 'not_a_default', sprintf( 'Keyword "%s" is not a default in bucket %d. Use remove_custom_keyword instead.', $keyword, $bucket ) );
+		}
+
+		$removed = self::get_removed_defaults( $bucket );
+		if ( in_array( $keyword, array_map( 'strtolower', $removed ), true ) ) {
+			return false;
+		}
+		$removed[] = $keyword;
+		self::write_keyword_option( self::removed_defaults_option( $bucket ), $removed );
+		return true;
+	}
+
+	/**
+	 * Restore Bucket 2 + Bucket 3 lists to factory defaults.
+	 *
+	 * Clears custom additions and removed-defaults for both buckets.
+	 */
+	public static function restore_defaults(): void {
+		delete_option( self::OPTION_BUCKET3_KEYWORDS );
+		delete_option( self::OPTION_BUCKET2_KEYWORDS );
+		delete_option( self::OPTION_BUCKET3_REMOVED_DEFAULTS );
+		delete_option( self::OPTION_BUCKET2_REMOVED_DEFAULTS );
+	}
+
+	/**
+	 * Per-ability exemption list for the given bucket.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_exemptions( int $bucket ): array {
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return array();
+		}
+		$value = get_option( $option, array() );
+		return self::clean_ability_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Add an ability to a bucket's exemption list. Returns true if newly added.
+	 *
+	 * Bucket 3 path: friction = in-chat 1/2 confirmation token (enforced by ability).
+	 * Bucket 2 path: Admin-UI only — abilities must NOT call this with $bucket=2.
+	 *
+	 * @param int    $bucket
+	 * @param string $ability_name
+	 * @return bool|\WP_Error
+	 */
+	public static function add_exemption( int $bucket, string $ability_name ) {
+		$ability_name = self::sanitize_ability_name( $ability_name );
+		if ( '' === $ability_name ) {
+			return new \WP_Error( 'empty_ability', 'Ability name must be a non-empty string.' );
+		}
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+		$current = self::get_exemptions( $bucket );
+		if ( in_array( $ability_name, $current, true ) ) {
+			return false;
+		}
+		$current[] = $ability_name;
+		update_option( $option, array_values( array_unique( $current ) ) );
+		return true;
+	}
+
+	/**
+	 * Remove an ability from a bucket's exemption list. Returns true if it was present.
+	 *
+	 * Strengthening operation — no friction.
+	 *
+	 * @param int    $bucket
+	 * @param string $ability_name
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_exemption( int $bucket, string $ability_name ) {
+		$ability_name = self::sanitize_ability_name( $ability_name );
+		if ( '' === $ability_name ) {
+			return new \WP_Error( 'empty_ability', 'Ability name must be a non-empty string.' );
+		}
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+		$current = self::get_exemptions( $bucket );
+		$filtered = array_values( array_filter( $current, static fn( $name ) => $name !== $ability_name ) );
+		if ( count( $filtered ) === count( $current ) ) {
+			return false;
+		}
+		update_option( $option, $filtered );
+		return true;
+	}
+
+	// Trusted proxy ------------------------------------------------------
+
+	public static function is_trusted_proxy_enabled(): bool {
+		return (bool) get_option( self::OPTION_TRUSTED_PROXY_ENABLED, false );
+	}
+
+	public static function set_trusted_proxy_enabled( bool $enabled ): void {
+		update_option( self::OPTION_TRUSTED_PROXY_ENABLED, $enabled );
+	}
+
+	public static function get_trusted_proxy_mode(): string {
+		$value = (string) get_option( self::OPTION_TRUSTED_PROXY_MODE, self::PROXY_MODE_CLOUDFLARE );
+		return self::PROXY_MODE_CUSTOM === $value ? self::PROXY_MODE_CUSTOM : self::PROXY_MODE_CLOUDFLARE;
+	}
+
+	public static function set_trusted_proxy_mode( string $mode ): void {
+		$mode = self::PROXY_MODE_CUSTOM === $mode ? self::PROXY_MODE_CUSTOM : self::PROXY_MODE_CLOUDFLARE;
+		update_option( self::OPTION_TRUSTED_PROXY_MODE, $mode );
+	}
+
+	/**
+	 * Stored allowlist as plain newline-delimited text (for round-trip in textarea).
+	 */
+	public static function get_trusted_proxy_allowlist_raw(): string {
+		return (string) get_option( self::OPTION_TRUSTED_PROXY_ALLOWLIST, '' );
+	}
+
+	public static function set_trusted_proxy_allowlist_raw( string $raw ): void {
+		update_option( self::OPTION_TRUSTED_PROXY_ALLOWLIST, $raw );
+	}
+
+	// Internals ----------------------------------------------------------
+
+	private static function clean_keyword_list( array $list ): array {
+		$out = array();
+		foreach ( $list as $kw ) {
+			if ( ! is_string( $kw ) ) {
+				continue;
+			}
+			$lower = strtolower( trim( $kw ) );
+			if ( '' === $lower ) {
+				continue;
+			}
+			$out[ $lower ] = true;
+		}
+		return array_keys( $out );
+	}
+
+	private static function clean_ability_list( array $list ): array {
+		$out = array();
+		foreach ( $list as $name ) {
+			if ( ! is_string( $name ) ) {
+				continue;
+			}
+			$clean = self::sanitize_ability_name( $name );
+			if ( '' !== $clean ) {
+				$out[ $clean ] = true;
+			}
+		}
+		return array_keys( $out );
+	}
+
+	private static function sanitize_keyword( string $keyword ): string {
+		// Field-name allowlist: lower alphanumeric + underscore + hyphen + dot, capped 64.
+		$keyword = strtolower( trim( $keyword ) );
+		$keyword = preg_replace( '/[^a-z0-9_\-\.]/', '', $keyword ) ?? '';
+		if ( strlen( $keyword ) > 64 ) {
+			$keyword = substr( $keyword, 0, 64 );
+		}
+		return $keyword;
+	}
+
+	private static function sanitize_ability_name( string $name ): string {
+		// Ability names are namespaced like `users/list` or `mcp-adapter/get-started`.
+		$name = trim( $name );
+		$name = preg_replace( '/[^a-zA-Z0-9_\-\/]/', '', $name ) ?? '';
+		if ( strlen( $name ) > 191 ) {
+			$name = substr( $name, 0, 191 );
+		}
+		return $name;
+	}
+
+	private static function custom_keywords_option( int $bucket ): string {
+		return self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_KEYWORDS
+			: self::OPTION_BUCKET3_KEYWORDS;
+	}
+
+	private static function removed_defaults_option( int $bucket ): string {
+		return self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_REMOVED_DEFAULTS
+			: self::OPTION_BUCKET3_REMOVED_DEFAULTS;
+	}
+
+	/**
+	 * Returns null when bucket invalid; never returns Bucket-1 option.
+	 */
+	private static function exemptions_option( int $bucket ): ?string {
+		if ( self::BUCKET_PAYMENT === $bucket ) {
+			return self::OPTION_BUCKET2_EXEMPTIONS;
+		}
+		if ( self::BUCKET_CONTACT === $bucket ) {
+			return self::OPTION_BUCKET3_EXEMPTIONS;
+		}
+		return null;
+	}
+
+	private static function write_keyword_option( string $option, array $list ): void {
+		update_option( $option, array_values( array_unique( self::clean_keyword_list( $list ) ) ) );
+	}
+}

--- a/src/Transport/Infrastructure/HttpRequestHandler.php
+++ b/src/Transport/Infrastructure/HttpRequestHandler.php
@@ -15,6 +15,7 @@ namespace WickedEvolutions\McpAdapter\Transport\Infrastructure;
 
 use WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\McpErrorFactory;
 use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactionGate;
 
 /**
  * Handles HTTP request routing and processing for MCP transports.
@@ -231,6 +232,15 @@ class HttpRequestHandler {
 			$this->get_transport_name(),
 			$context
 		);
+
+		// Redact at the response boundary BEFORE session-id extraction or formatting.
+		// The gate preserves _session_id/_session_token markers so the existing flow below
+		// continues to work unchanged.
+		$server                = $this->transport_context->mcp_server;
+		$observability_handler = $server && method_exists( $server, 'get_observability_handler' )
+			? $server->get_observability_handler()
+			: null;
+		$result = ResponseRedactionGate::apply( $result, $method, $params, $request_id, $observability_handler );
 
 		// Handle session headers if provided by router (session creation during initialize).
 		if ( isset( $result['_session_id'] ) ) {

--- a/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for the AI-callable settings abilities (DB-3).
+ *
+ * Focus on the in-chat 1/2 confirmation flow and the no-friction paths.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Abilities\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+final class SettingsAbilitiesTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options']    = array();
+		$GLOBALS['wp_test_transients'] = array();
+		unset( $_SERVER['HTTP_MCP_SESSION_ID'] );
+	}
+
+	public function test_get_redaction_list_returns_full_state(): void {
+		$out = SettingsAbilities::execute_get_redaction_list();
+		$this->assertArrayHasKey( 'master_enabled', $out );
+		$this->assertArrayHasKey( 'bucket1', $out );
+		$this->assertArrayHasKey( 'bucket2', $out );
+		$this->assertArrayHasKey( 'bucket3', $out );
+		$this->assertTrue( $out['master_enabled'] );
+		$this->assertContains( 'password', $out['bucket1'] );
+		$this->assertContains( 'email', $out['bucket3']['active'] );
+	}
+
+	public function test_add_redaction_keyword_strengthens_without_friction(): void {
+		$out = SettingsAbilities::execute_add_redaction_keyword( array(
+			'keyword' => 'gravity_forms_secret',
+			'bucket'  => 3,
+		) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['added'] );
+		$this->assertContains( 'gravity_forms_secret', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_first_call_returns_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertTrue( $out['confirmation_required'] );
+		$this->assertNotEmpty( $out['token'] );
+		$this->assertStringContainsString( 'email', $out['summary'] );
+		$this->assertCount( 2, $out['options'] );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ), 'No mutation on first call.' );
+	}
+
+	public function test_remove_default_bucket3_keyword_with_valid_token_executes(): void {
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+		$this->assertTrue( $first['confirmation_required'] );
+
+		$second = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_token_is_one_time(): void {
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$second = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+
+		// Replay with the same token must fail.
+		$third = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertFalse( $third['success'] );
+		$this->assertStringContainsString( 'unknown', strtolower( $third['message'] ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_rejects_param_swap(): void {
+		// Mint a token for `email`, then try to use it to remove `phone`.
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$swap = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'phone',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertFalse( $swap['success'] );
+		$this->assertStringContainsString( 'match', strtolower( $swap['message'] ) );
+
+		// Both keywords still present.
+		$active = Repo::get_active_keywords( Repo::BUCKET_CONTACT );
+		$this->assertContains( 'email', $active );
+		$this->assertContains( 'phone', $active );
+	}
+
+	public function test_exempt_ability_from_bucket3_first_call_returns_token(): void {
+		$out = SettingsAbilities::execute_exempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+		$this->assertTrue( $out['confirmation_required'] );
+		$this->assertNotEmpty( $out['token'] );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_exempt_ability_from_bucket3_with_valid_token_succeeds(): void {
+		$first = SettingsAbilities::execute_exempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+
+		$second = SettingsAbilities::execute_exempt_ability_from_bucket3( array(
+			'ability_name'       => 'users/list',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+		$this->assertContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_unexempt_strengthens_without_friction(): void {
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' );
+		$out = SettingsAbilities::execute_unexempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['removed'] );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_restore_defaults_strengthens_without_friction(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+
+		$out = SettingsAbilities::execute_restore_redaction_defaults();
+		$this->assertTrue( $out['success'] );
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_custom_keyword_strengthens_without_friction(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'temp_field' );
+		$out = SettingsAbilities::execute_remove_custom_keyword( array(
+			'keyword' => 'temp_field',
+			'bucket'  => 3,
+		) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['removed'] );
+	}
+}

--- a/tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php
+++ b/tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\PatternMatchers;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class PatternMatchersTest extends TestCase {
+
+	// ── is_password_hash ──────────────────────────────────────────────────────
+
+	public function test_password_hash_phpass(): void {
+		$this->assertTrue( PatternMatchers::is_password_hash( '$P$Bsomethinghashy123' ) );
+		$this->assertTrue( PatternMatchers::is_password_hash( '$H$9abcdef' ) );
+	}
+
+	public function test_password_hash_bcrypt(): void {
+		$this->assertTrue( PatternMatchers::is_password_hash( '$2a$12$abc' ) );
+		$this->assertTrue( PatternMatchers::is_password_hash( '$2b$12$abc' ) );
+		$this->assertTrue( PatternMatchers::is_password_hash( '$2y$12$abc' ) );
+	}
+
+	public function test_password_hash_modern(): void {
+		$this->assertTrue( PatternMatchers::is_password_hash( '$argon2id$v=19$m=65536' ) );
+		$this->assertTrue( PatternMatchers::is_password_hash( '$pbkdf2$1000$abc' ) );
+		$this->assertTrue( PatternMatchers::is_password_hash( '$scrypt$N=1024' ) );
+	}
+
+	public function test_password_hash_negatives(): void {
+		$this->assertFalse( PatternMatchers::is_password_hash( '' ) );
+		$this->assertFalse( PatternMatchers::is_password_hash( 'hunter2' ) );
+		$this->assertFalse( PatternMatchers::is_password_hash( null ) );
+		$this->assertFalse( PatternMatchers::is_password_hash( 12345 ) );
+		$this->assertFalse( PatternMatchers::is_password_hash( array( '$P$' ) ) );
+	}
+
+	// ── is_known_api_key ──────────────────────────────────────────────────────
+
+	public function test_known_api_key_stripe(): void {
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'sk_live_abc' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'sk_test_abc' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'pk_live_abc' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'pk_test_abc' ) );
+	}
+
+	public function test_known_api_key_slack(): void {
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'xoxb-1234-5678' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'xoxp-1234-5678' ) );
+	}
+
+	public function test_known_api_key_github(): void {
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'ghp_abcdef' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'gho_abcdef' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'ghu_abcdef' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'ghs_abcdef' ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'ghr_abcdef' ) );
+	}
+
+	public function test_known_api_key_aws(): void {
+		$this->assertTrue( PatternMatchers::is_known_api_key( 'AKIAIOSFODNN7EXAMPLE' ) );
+		// Wrong length:
+		$this->assertFalse( PatternMatchers::is_known_api_key( 'AKIAIOSF' ) );
+	}
+
+	public function test_known_api_key_google(): void {
+		// AIza + 35 url-safe chars (documented Google API key format).
+		$key = 'AIza' . str_pad( 'A', 35, 'b' );
+		$this->assertSame( 39, strlen( $key ) );
+		$this->assertTrue( PatternMatchers::is_known_api_key( $key ) );
+
+		// Wrong length (34 chars after prefix) → no match.
+		$this->assertFalse( PatternMatchers::is_known_api_key( 'AIza' . str_pad( '', 34, 'b' ) ) );
+	}
+
+	public function test_known_api_key_negatives(): void {
+		$this->assertFalse( PatternMatchers::is_known_api_key( '' ) );
+		$this->assertFalse( PatternMatchers::is_known_api_key( 'hello' ) );
+		$this->assertFalse( PatternMatchers::is_known_api_key( null ) );
+		$this->assertFalse( PatternMatchers::is_known_api_key( 12345 ) );
+	}
+
+	// ── passes_luhn ───────────────────────────────────────────────────────────
+
+	public function test_luhn_valid_test_pans(): void {
+		$this->assertTrue( PatternMatchers::passes_luhn( '4242424242424242' ) ); // Stripe test Visa.
+		$this->assertTrue( PatternMatchers::passes_luhn( '5555555555554444' ) ); // Stripe test Mastercard.
+		$this->assertTrue( PatternMatchers::passes_luhn( '378282246310005' ) );  // Amex test.
+	}
+
+	public function test_luhn_invalid_inputs(): void {
+		$this->assertFalse( PatternMatchers::passes_luhn( '4242424242424241' ) ); // off by one.
+		$this->assertFalse( PatternMatchers::passes_luhn( '12345' ) );             // too short.
+		$this->assertFalse( PatternMatchers::passes_luhn( '12345678901234567890' ) ); // too long (20 digits).
+		$this->assertFalse( PatternMatchers::passes_luhn( '4242-4242-4242-4242' ) );  // hyphens not stripped.
+		$this->assertFalse( PatternMatchers::passes_luhn( ' 4242424242424242' ) );    // leading space.
+		$this->assertFalse( PatternMatchers::passes_luhn( '' ) );
+		$this->assertFalse( PatternMatchers::passes_luhn( null ) );
+		$this->assertFalse( PatternMatchers::passes_luhn( 4242424242424242 ) );       // integer, not string.
+	}
+
+	public function test_luhn_minimum_length_13(): void {
+		// 13-digit number that passes Luhn.
+		$this->assertTrue( PatternMatchers::passes_luhn( '4222222222222' ) );
+	}
+}

--- a/tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php
+++ b/tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\RedactionConfig;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class RedactionConfigTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	public function test_master_enabled_default_true(): void {
+		$this->assertTrue( RedactionConfig::is_master_enabled() );
+	}
+
+	public function test_master_enabled_can_be_turned_off(): void {
+		update_option( RedactionConfig::OPTION_MASTER_ENABLED, false );
+		$this->assertFalse( RedactionConfig::is_master_enabled() );
+	}
+
+	public function test_bucket1_keywords_include_credentials(): void {
+		$kws = RedactionConfig::bucket1_keywords();
+		$this->assertContains( 'password', $kws );
+		$this->assertContains( 'user_pass', $kws );
+		$this->assertContains( 'api_key', $kws );
+		$this->assertContains( 'session_token', $kws );
+		$this->assertContains( 'auth_key', $kws );
+		// public_key MUST NOT be in Bucket 1 (per principle: public keys are configurable Bucket 3).
+		$this->assertNotContains( 'public_key', $kws );
+	}
+
+	public function test_bucket3_default_includes_public_key(): void {
+		$kws = RedactionConfig::bucket3_default_keywords();
+		$this->assertContains( 'public_key', $kws );
+		$this->assertContains( 'email', $kws );
+		$this->assertContains( 'user_login', $kws );
+	}
+
+	public function test_bucket3_keywords_merges_custom_additions(): void {
+		update_option(
+			RedactionConfig::OPTION_BUCKET3_KEYWORDS,
+			array( 'gravity_forms_secret', 'CustomField' )
+		);
+
+		$kws = RedactionConfig::bucket3_keywords();
+		$this->assertContains( 'email', $kws );           // default still present.
+		$this->assertContains( 'gravity_forms_secret', $kws );
+		$this->assertContains( 'customfield', $kws );     // lower-cased.
+	}
+
+	public function test_ability_exemption_bucket1_never_exempt(): void {
+		update_option( RedactionConfig::OPTION_BUCKET3_EXEMPTIONS, array( 'foo/bar' ) );
+		// Bucket 1 NEVER honours an exemption.
+		$this->assertFalse( RedactionConfig::is_ability_exempt( 'foo/bar', RedactionConfig::BUCKET_SECRETS ) );
+	}
+
+	public function test_ability_exemption_bucket3(): void {
+		update_option( RedactionConfig::OPTION_BUCKET3_EXEMPTIONS, array( 'fluent-cart/list-customers' ) );
+		$this->assertTrue( RedactionConfig::is_ability_exempt( 'fluent-cart/list-customers', RedactionConfig::BUCKET_CONTACT ) );
+		$this->assertFalse( RedactionConfig::is_ability_exempt( 'other/ability', RedactionConfig::BUCKET_CONTACT ) );
+	}
+
+	public function test_ability_exemption_bucket2_independent_of_bucket3(): void {
+		update_option( RedactionConfig::OPTION_BUCKET3_EXEMPTIONS, array( 'foo/bar' ) );
+		// Adding ability to Bucket 3 exemption does not exempt it from Bucket 2.
+		$this->assertFalse( RedactionConfig::is_ability_exempt( 'foo/bar', RedactionConfig::BUCKET_PAYMENT ) );
+
+		update_option( RedactionConfig::OPTION_BUCKET2_EXEMPTIONS, array( 'foo/bar' ) );
+		$this->assertTrue( RedactionConfig::is_ability_exempt( 'foo/bar', RedactionConfig::BUCKET_PAYMENT ) );
+	}
+}

--- a/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
+++ b/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
@@ -22,7 +22,19 @@ class ResponseRedactionGateTest extends TestCase {
 
 	protected function set_up(): void {
 		parent::set_up();
-		$GLOBALS['wp_test_options'] = array();
+		$GLOBALS['wp_test_options']   = array();
+		$GLOBALS['wp_test_abilities'] = array();
+		ResponseRedactionGate::reset_name_cache_for_testing();
+	}
+
+	/**
+	 * Register a fake ability so wp_get_abilities() returns it. Mirrors what
+	 * the real plugin does at `wp_abilities_api_init` time — gives the
+	 * gate's tool-name → ability-name translator a registry to consult.
+	 */
+	private function register_ability( string $slash_name ): void {
+		$GLOBALS['wp_test_abilities'][ $slash_name ] = new \WP_Ability( $slash_name );
+		ResponseRedactionGate::reset_name_cache_for_testing();
 	}
 
 	private function customer_response(): array {
@@ -283,5 +295,197 @@ class ResponseRedactionGateTest extends TestCase {
 		$out = ResponseRedactionGate::apply( $err, 'tools/call', array( 'name' => 'whatever' ), 1 );
 
 		$this->assertSame( $err, $out );
+	}
+
+	// ── C.4 round 2: dash-form names from the MCP wire ─────────────────────
+	//
+	// MCP tool names cannot contain `/`; RegisterAbilityAsMcpTool advertises
+	// abilities with dashes. params['name'] therefore arrives as the dash
+	// form on every real call. The gate must translate dash → slash before
+	// looking up exemptions (which are stored in slash form).
+
+	public function test_round2_dash_form_meta_tool_unwraps_inner_ability(): void {
+		// Register the inner ability so the dash→slash translator finds it.
+		$this->register_ability( 'fluent-cart/list-customers' );
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array(
+				// Dash form — what real MCP clients send.
+				'name'      => 'mcp-adapter-execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			'jacob@willow.se',
+			$out['data']['customers'][0]['email'],
+			'Dash-form meta-tool wrapper must still honour inner exemption.'
+		);
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['customers'][0]['session_token'] );
+	}
+
+	public function test_round2_dash_form_batch_execute_returns_null_scope(): void {
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$batch_response = array(
+			'results' => array(
+				array(
+					'content'           => array( array( 'type' => 'text', 'text' => '...' ) ),
+					'structuredContent' => array( 'email' => 'jacob@willow.se' ),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$batch_response,
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter-batch-execute',
+				'arguments' => array(
+					'requests' => array(
+						array( 'name' => 'fluent-cart-list-customers', 'arguments' => array() ),
+					),
+				),
+			),
+			1
+		);
+
+		// Same documented limitation as the slash-form case: full redaction wins inside batch.
+		$this->assertSame( '[redacted:bucket_3]', $out['results'][0]['structuredContent']['email'] );
+	}
+
+	public function test_round2_direct_call_dash_form_translates_to_slash_for_exemption(): void {
+		// Real wire: a user calls fluent-cart/list-customers directly via tools/call.
+		// MCP advertises the tool as `fluent-cart-list-customers` (dash form).
+		// Exemption is stored in slash form. Dash→slash translation must succeed.
+		$this->register_ability( 'fluent-cart/list-customers' );
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array( 'name' => 'fluent-cart-list-customers', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame(
+			'jacob@willow.se',
+			$out['data']['customers'][0]['email'],
+			'Direct dash-form tools/call must translate to slash for exemption lookup.'
+		);
+	}
+
+	public function test_round2_unregistered_dash_name_falls_back_safely(): void {
+		// No ability registered, so the translator can't find a slash form.
+		// Falls back to the dash input. is_ability_exempt() with the dash
+		// form returns false (exemptions are stored in slash form), so
+		// redaction proceeds — safe default.
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array( 'name' => 'unknown-dash-name', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['customers'][0]['email'] );
+	}
+
+	public function test_round2_translator_returns_slash_input_unchanged(): void {
+		// Defensive: if a caller (operator, batch-execute inner request,
+		// future code path) somehow passes slash form through, leave it alone.
+		$this->register_ability( 'fluent-cart/list-customers' );
+
+		$this->assertSame(
+			'fluent-cart/list-customers',
+			ResponseRedactionGate::tool_name_to_ability_name( 'fluent-cart/list-customers' )
+		);
+	}
+
+	public function test_round2_translator_maps_dash_to_slash_when_registered(): void {
+		$this->register_ability( 'fluent-cart/list-customers' );
+		$this->register_ability( 'users/list' );
+
+		$this->assertSame(
+			'fluent-cart/list-customers',
+			ResponseRedactionGate::tool_name_to_ability_name( 'fluent-cart-list-customers' )
+		);
+		$this->assertSame(
+			'users/list',
+			ResponseRedactionGate::tool_name_to_ability_name( 'users-list' )
+		);
+	}
+
+	public function test_round2_translator_returns_input_when_unregistered(): void {
+		$this->assertSame(
+			'no-such-ability',
+			ResponseRedactionGate::tool_name_to_ability_name( 'no-such-ability' )
+		);
+	}
+
+	public function test_round2_translator_handles_nested_namespaces(): void {
+		// Multi-segment slash names — every `/` becomes `-`. The dash form
+		// `wp-mcp-adapter-discover-abilities` is ambiguous in principle (could
+		// map to `wp/mcp-adapter/discover-abilities` or other splits), but
+		// the registry lookup resolves to the actual registered slash form.
+		$this->register_ability( 'wp/mcp-adapter/discover-abilities' );
+
+		$this->assertSame(
+			'wp/mcp-adapter/discover-abilities',
+			ResponseRedactionGate::tool_name_to_ability_name( 'wp-mcp-adapter-discover-abilities' )
+		);
+	}
+
+	public function test_round2_translator_first_write_wins_on_dash_collision(): void {
+		// `a/b-c` and `a-b/c` both produce dash form `a-b-c`. The first
+		// registered ability wins; the second collision is ignored. This
+		// is a naming convention the platform inherits from the MCP spec
+		// (tool names can't contain `/`); ability authors must avoid
+		// dash collisions.
+		$this->register_ability( 'a/b-c' );
+		// Register the colliding one — should NOT overwrite the first.
+		$GLOBALS['wp_test_abilities']['a-b/c'] = new \WP_Ability( 'a-b/c' );
+		ResponseRedactionGate::reset_name_cache_for_testing();
+
+		$this->assertSame( 'a/b-c', ResponseRedactionGate::tool_name_to_ability_name( 'a-b-c' ) );
+	}
+
+	public function test_round2_dash_form_cross_bucket_safety_preserved(): void {
+		// Repeat of the bucket-1-immunity test, this time over the dash-form
+		// wire path that was broken in round 1.
+		$this->register_ability( 'fluent-cart/list-customers' );
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$response = array(
+			'success' => true,
+			'data'    => array(
+				'email'         => 'jacob@willow.se',
+				'session_token' => 'st_live_secret',
+				'api_key'       => 'sk_live_xxx',
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter-execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( 'jacob@willow.se', $out['data']['email'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['session_token'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['api_key'] );
 	}
 }

--- a/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
+++ b/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Tests for ResponseRedactionGate — focused on Launch Gate bug C.4.
+ *
+ * The gate must apply per-ability Bucket 3 exemptions whether the ability
+ * is invoked directly via `tools/call` or wrapped through the
+ * `mcp-adapter/execute-ability` meta-tool. Bucket 1 (secrets) must always
+ * apply regardless of exemption.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactionGate;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class ResponseRedactionGateTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	private function customer_response(): array {
+		// Shape that ExecuteAbilityAbility wraps the underlying ability's data
+		// in: {success: true, data: <ability response>}.
+		return array(
+			'success' => true,
+			'data'    => array(
+				'customers' => array(
+					array(
+						'id'            => 5,
+						'email'         => 'jacob@willow.se',
+						'first_name'    => 'Jacob',
+						'session_token' => 'st_live_secret',
+					),
+				),
+			),
+		);
+	}
+
+	// ── Direct tools/call against a registered tool ────────────────────────
+
+	public function test_direct_tools_call_redacts_when_no_exemption(): void {
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array( 'name' => 'fluent-cart/list-customers', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['customers'][0]['email'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['customers'][0]['session_token'] );
+	}
+
+	public function test_direct_tools_call_skips_bucket3_when_ability_exempt(): void {
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array( 'name' => 'fluent-cart/list-customers', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( 'jacob@willow.se', $out['data']['customers'][0]['email'], 'Bucket 3 exemption should pass email through.' );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['customers'][0]['session_token'], 'Bucket 1 must always redact regardless of exemption.' );
+	}
+
+	// ── Wrapped through mcp-adapter/execute-ability (the real AI path) ──────
+
+	public function test_execute_ability_wrapper_redacts_when_no_exemption(): void {
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['customers'][0]['email'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['customers'][0]['session_token'] );
+	}
+
+	public function test_execute_ability_wrapper_honours_inner_ability_exemption(): void {
+		// THIS is bug C.4: exemption on the inner ability was being ignored
+		// because the gate looked up the wrapper's name instead.
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( 'jacob@willow.se', $out['data']['customers'][0]['email'], 'Bucket 3 exemption on the inner ability must pass email through.' );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['customers'][0]['session_token'], 'Bucket 1 must still redact even with Bucket 3 exempt.' );
+	}
+
+	public function test_execute_ability_wrapper_with_other_ability_does_not_borrow_exemption(): void {
+		// Exempt fluent-cart/list-customers, but call users/list — should still redact.
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$response = array(
+			'success' => true,
+			'data'    => array(
+				'users' => array(
+					array( 'id' => 1, 'email' => 'admin@example.com' ),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(
+					'ability_name' => 'users/list',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['users'][0]['email'] );
+	}
+
+	public function test_execute_ability_wrapper_missing_ability_name_redacts_normally(): void {
+		// Defensive: malformed wrapper call without ability_name.
+		// Falls back to "no ability scope" — full redaction applies.
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['customers'][0]['email'] );
+	}
+
+	// ── batch-execute ───────────────────────────────────────────────────────
+
+	public function test_batch_execute_does_not_apply_per_ability_exemptions(): void {
+		// Documented limitation: a single redaction pass over a multi-ability
+		// batch response cannot honour per-ability exemptions. Exempt
+		// abilities lose their exemption inside batch — full redaction wins.
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$batch_response = array(
+			'results' => array(
+				array(
+					'content'           => array( array( 'type' => 'text', 'text' => '...' ) ),
+					'structuredContent' => array( 'email' => 'jacob@willow.se' ),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$batch_response,
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/batch-execute',
+				'arguments' => array(
+					'requests' => array(
+						array( 'name' => 'fluent-cart/list-customers', 'arguments' => array() ),
+					),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['results'][0]['structuredContent']['email'] );
+	}
+
+	// ── Exempt-then-unexempt round-trip ─────────────────────────────────────
+
+	public function test_unexempting_clears_correctly(): void {
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+		Repo::remove_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$out = ResponseRedactionGate::apply(
+			$this->customer_response(),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['customers'][0]['email'], 'After unexempt, email should redact again.' );
+	}
+
+	// ── Cross-bucket safety: exempting Bucket 3 must not exempt Bucket 1 ───
+
+	public function test_bucket3_exemption_does_not_affect_bucket1_redaction(): void {
+		// The repository deliberately exposes no API for Bucket 1 exemption.
+		// But the redactor's defensive logic must hardcode Bucket 1 as
+		// always-on, even if the exemption list somehow contained the ability.
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$response = array(
+			'success' => true,
+			'data'    => array(
+				'email'         => 'jacob@willow.se',
+				'session_token' => 'st_live_secret',
+				'api_key'       => 'sk_live_xxx',
+				'password'      => 'hunter2',
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter/execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( 'jacob@willow.se', $out['data']['email'], 'Bucket 3 exempt — email passes.' );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['session_token'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['api_key'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['data']['password'] );
+	}
+
+	// ── Non-tools/call methods don't extract ability names ──────────────────
+
+	public function test_non_tools_call_methods_have_no_ability_scope(): void {
+		// initialize / ping / etc. carry no ability — gate falls back to
+		// "no scope" which means no exemption applies. The body wouldn't
+		// normally contain PII at this method anyway, but a sentinel
+		// e-mail in the body must redact.
+		$response = array( 'data' => array( 'email' => 'jacob@willow.se' ) );
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'initialize',
+			array(),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['email'] );
+	}
+
+	// ── Pass-through for protocol error envelopes ───────────────────────────
+
+	public function test_protocol_error_envelope_is_not_redacted(): void {
+		$err = array(
+			'error' => array(
+				'code'    => -32600,
+				'message' => 'Invalid Request',
+			),
+		);
+
+		$out = ResponseRedactionGate::apply( $err, 'tools/call', array( 'name' => 'whatever' ), 1 );
+
+		$this->assertSame( $err, $out );
+	}
+}

--- a/tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php
+++ b/tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\RedactionConfig;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\RedactionLimitExceeded;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactor;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class ResponseRedactorTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	// ── Behavioral acceptance ─────────────────────────────────────────────────
+
+	public function test_users_list_default_redacts_email_and_user_login(): void {
+		$response = array(
+			'users' => array(
+				array(
+					'id'         => 5,
+					'email'      => 'jacob@willow.se',
+					'user_login' => 'jacob',
+					'first_name' => 'Jacob',
+					'last_name'  => 'Willow',
+					'roles'      => array( 'administrator' ),
+				),
+			),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['users'][0]['email'] );
+		$this->assertSame( '[redacted:bucket_3]', $out['users'][0]['user_login'] );
+		$this->assertSame( 'Jacob', $out['users'][0]['first_name'] );
+		$this->assertSame( 'Willow', $out['users'][0]['last_name'] );
+		$this->assertSame( 5, $out['users'][0]['id'] );
+		$this->assertSame( array( 'administrator' ), $out['users'][0]['roles'] );
+	}
+
+	public function test_fluent_cart_list_customers_redacts_email_passes_lifetime_value(): void {
+		$response = array(
+			'customers' => array(
+				array(
+					'id'             => 12,
+					'contact_id'     => 'c_99',
+					'first_name'     => 'A',
+					'last_name'      => 'B',
+					'email'          => 'a@b.com',
+					'lifetime_value' => 1234.56,
+				),
+			),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['customers'][0]['email'] );
+		$this->assertSame( 'A', $out['customers'][0]['first_name'] );
+		$this->assertSame( 'B', $out['customers'][0]['last_name'] );
+		$this->assertSame( 12, $out['customers'][0]['id'] );
+		$this->assertSame( 'c_99', $out['customers'][0]['contact_id'] );
+		$this->assertSame( 1234.56, $out['customers'][0]['lifetime_value'] );
+	}
+
+	public function test_user_meta_redacts_session_tokens_and_user_pass(): void {
+		$response = array(
+			'meta' => array(
+				'session_tokens' => array( 'abcd1234', 'efgh5678' ),
+				'user_pass'      => '$P$Bsomethinghashy',
+				'last_login'     => '2026-04-26',
+			),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		// session_tokens is Bucket 1 by name → array shape preserved.
+		$this->assertSame( array( '[redacted:bucket_1]' ), $out['meta']['session_tokens'] );
+		// user_pass is Bucket 1 by name → scalar string marker.
+		$this->assertSame( '[redacted:bucket_1]', $out['meta']['user_pass'] );
+		$this->assertSame( '2026-04-26', $out['meta']['last_login'] );
+	}
+
+	public function test_master_toggle_off_keeps_bucket_1_active_and_passes_bucket_3(): void {
+		update_option( RedactionConfig::OPTION_MASTER_ENABLED, false );
+
+		$response = array(
+			'email'    => 'a@b.com',          // Bucket 3 → passes through.
+			'password' => 'hunter2',          // Bucket 1 → still redacted.
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( 'a@b.com', $out['email'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['password'] );
+	}
+
+	public function test_per_ability_bucket3_exemption_unblocks_email_keeps_bucket2(): void {
+		update_option(
+			RedactionConfig::OPTION_BUCKET3_EXEMPTIONS,
+			array( 'fluent-cart/list-customers' )
+		);
+
+		$response = array(
+			'email'       => 'a@b.com',
+			'card_number' => '4242424242424242', // Bucket 2 → still redacted.
+		);
+
+		$out = ( new ResponseRedactor( 'fluent-cart/list-customers' ) )->redact( $response );
+
+		$this->assertSame( 'a@b.com', $out['email'] );
+		$this->assertSame( '[redacted:bucket_2]', $out['card_number'] );
+	}
+
+	public function test_string_email_redacts_to_scalar_string_marker(): void {
+		$out = ( new ResponseRedactor() )->redact( array( 'email' => 'a@b.com' ) );
+		$this->assertIsString( $out['email'] );
+		$this->assertSame( '[redacted:bucket_3]', $out['email'] );
+	}
+
+	public function test_object_address_redacts_to_object_marker(): void {
+		$response = array(
+			'address' => (object) array(
+				'street' => '1 Foo St',
+				'city'   => 'Bar',
+			),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertIsObject( $out['address'] );
+		$this->assertTrue( $out['address']->redacted );
+		$this->assertSame( 'bucket_3', $out['address']->reason );
+	}
+
+	public function test_array_of_phones_redacts_to_single_element_array(): void {
+		$response = array(
+			'phone' => array( '+46-700-000-000', '+46-700-000-001' ),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( array( '[redacted:bucket_3]' ), $out['phone'] );
+	}
+
+	public function test_custom_keyword_added_to_bucket3_list(): void {
+		update_option(
+			RedactionConfig::OPTION_BUCKET3_KEYWORDS,
+			array( 'gravity_forms_secret' )
+		);
+
+		$out = ( new ResponseRedactor() )->redact(
+			array( 'gravity_forms_secret' => 'something' )
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['gravity_forms_secret'] );
+	}
+
+	// ── Implementation acceptance ─────────────────────────────────────────────
+
+	public function test_type_detection_handles_six_type_cases(): void {
+		$response = array(
+			'email_string' => 'a@b.com',
+			'email_number' => 99,             // not a redaction target by name; included to verify pass-through
+			'email'        => 1234,            // numeric value of a redacted field → null
+			'flag'         => true,            // booleans untouched
+			'address'      => (object) array( 'x' => 1 ),
+			'phone'        => array( 'a', 'b' ),
+			'unknown'      => null,
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( 'a@b.com', $out['email_string'] );        // wrong key → pass.
+		$this->assertSame( 99, $out['email_number'] );               // wrong key → pass.
+		$this->assertNull( $out['email'] );                          // numeric of redacted → null.
+		$this->assertTrue( $out['flag'] );
+		$this->assertIsObject( $out['address'] );
+		$this->assertSame( array( '[redacted:bucket_3]' ), $out['phone'] );
+		$this->assertNull( $out['unknown'] );
+	}
+
+	public function test_recursive_traversal_through_nested_arrays(): void {
+		$response = array(
+			'level1' => array(
+				'level2' => array(
+					'level3' => array(
+						'email' => 'deep@example.com',
+						'name'  => 'OK',
+					),
+				),
+			),
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['level1']['level2']['level3']['email'] );
+		$this->assertSame( 'OK', $out['level1']['level2']['level3']['name'] );
+	}
+
+	public function test_max_nodes_guard_throws(): void {
+		$big = array();
+		for ( $i = 0; $i < ResponseRedactor::MAX_NODES + 10; $i++ ) {
+			$big[ 'k' . $i ] = $i;
+		}
+
+		$this->expectException( RedactionLimitExceeded::class );
+		( new ResponseRedactor() )->redact( $big );
+	}
+
+	public function test_max_depth_guard_throws(): void {
+		// Build a deeply nested array beyond MAX_DEPTH.
+		$leaf = array( 'leaf' => 1 );
+		for ( $i = 0; $i < ResponseRedactor::MAX_DEPTH + 5; $i++ ) {
+			$leaf = array( 'n' => $leaf );
+		}
+
+		$this->expectException( RedactionLimitExceeded::class );
+		( new ResponseRedactor() )->redact( $leaf );
+	}
+
+	public function test_pattern_matcher_only_runs_on_scalar_strings(): void {
+		// Mixed-type fixture; values that LOOK like card numbers but aren't strings should pass.
+		$response = array(
+			'note'        => 'normal text 4242424242424242 in body',  // SCALAR STRING — Luhn-pattern PAN as part of free text.
+			'note_array'  => array( '4242424242424242' ),              // string-in-array — also a scalar string at depth 1.
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		// The string `4242424242424242` standalone should be redacted by Luhn.
+		// But "normal text 4242424242424242 in body" is NOT a contiguous 13-19 digit string, so it passes.
+		$this->assertSame( 'normal text 4242424242424242 in body', $out['note'] );
+		// The array element IS a contiguous Luhn-passing PAN → redacted.
+		$this->assertSame( array( '[redacted:bucket_2]' ), $out['note_array'] );
+	}
+
+	public function test_case_insensitive_field_match(): void {
+		$response = array(
+			'EMAIL' => 'a@b.com',
+			'Email' => 'c@d.com',
+			'email' => 'e@f.com',
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['EMAIL'] );
+		$this->assertSame( '[redacted:bucket_3]', $out['Email'] );
+		$this->assertSame( '[redacted:bucket_3]', $out['email'] );
+	}
+
+	public function test_no_regex_over_full_json_document(): void {
+		$response = array(
+			'note' => 'hi my email is jacob@willow.se thanks',
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( 'hi my email is jacob@willow.se thanks', $out['note'] );
+	}
+
+	// ── Adversarial acceptance ────────────────────────────────────────────────
+
+	public function test_meta_key_field_passes_through(): void {
+		// A field named `meta_key` is NOT in any bucket and a suffix-match would have caught it.
+		$response = array( 'meta_key' => 'last_login_ip' );
+		$out      = ( new ResponseRedactor() )->redact( $response );
+		$this->assertSame( 'last_login_ip', $out['meta_key'] );
+	}
+
+	public function test_cache_key_field_passes_through(): void {
+		$response = array( 'cache_key' => 'transient_xyz' );
+		$out      = ( new ResponseRedactor() )->redact( $response );
+		$this->assertSame( 'transient_xyz', $out['cache_key'] );
+	}
+
+	public function test_blog_post_body_with_word_password_passes_through(): void {
+		$response = array(
+			'post_content' => 'In this guide we cover how to choose a strong password for your account.',
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame(
+			'In this guide we cover how to choose a strong password for your account.',
+			$out['post_content']
+		);
+	}
+
+	public function test_comment_body_with_email_in_text_passes_through(): void {
+		$response = array(
+			'comment_content' => 'Reply to jacob@willow.se for more info.',
+		);
+
+		$out = ( new ResponseRedactor() )->redact( $response );
+
+		$this->assertSame( 'Reply to jacob@willow.se for more info.', $out['comment_content'] );
+	}
+
+	public function test_bucket1_cannot_be_disabled_via_master_toggle(): void {
+		update_option( RedactionConfig::OPTION_MASTER_ENABLED, false );
+
+		$out = ( new ResponseRedactor() )->redact( array( 'password' => 'secret' ) );
+		$this->assertSame( '[redacted:bucket_1]', $out['password'] );
+	}
+
+	public function test_bucket1_cannot_be_disabled_via_per_ability_exemption(): void {
+		// Even if both Bucket 2 and Bucket 3 exemptions list the ability, Bucket 1 still redacts.
+		update_option( RedactionConfig::OPTION_BUCKET2_EXEMPTIONS, array( 'foo/bar' ) );
+		update_option( RedactionConfig::OPTION_BUCKET3_EXEMPTIONS, array( 'foo/bar' ) );
+
+		$out = ( new ResponseRedactor( 'foo/bar' ) )->redact(
+			array( 'password' => 'secret' )
+		);
+		$this->assertSame( '[redacted:bucket_1]', $out['password'] );
+	}
+
+	// ── Counts ────────────────────────────────────────────────────────────────
+
+	public function test_counts_reflect_redactions_per_bucket(): void {
+		$response = array(
+			'password' => 'a',                     // b1
+			'email'    => 'b@c.com',               // b3
+			'phone'    => '+46',                   // b3
+			'card_number' => '4242424242424242',   // b2
+		);
+
+		$redactor = new ResponseRedactor();
+		$redactor->redact( $response );
+		$counts = $redactor->get_counts();
+
+		$this->assertSame( 1, $counts[ RedactionConfig::BUCKET_SECRETS ] );
+		$this->assertSame( 1, $counts[ RedactionConfig::BUCKET_PAYMENT ] );
+		$this->assertSame( 2, $counts[ RedactionConfig::BUCKET_CONTACT ] );
+	}
+}

--- a/tests/Unit/Settings/ConfirmationTokenStoreTest.php
+++ b/tests/Unit/Settings/ConfirmationTokenStoreTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Unit tests for ConfirmationTokenStore.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Settings\ConfirmationTokenStore as Store;
+
+final class ConfirmationTokenStoreTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_transients'] = array();
+	}
+
+	public function test_mint_returns_non_empty_token(): void {
+		$token = Store::mint( 'sess1', 'settings/remove-default-bucket3-keyword', array( 'keyword' => 'email' ) );
+		$this->assertIsString( $token );
+		$this->assertNotEmpty( $token );
+	}
+
+	public function test_consume_valid_token_succeeds(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$result = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$this->assertTrue( $result );
+	}
+
+	public function test_token_is_one_time(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$first  = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$second = Store::consume( $token, 'sess1', 'ability_a', $params );
+
+		$this->assertTrue( $first );
+		$this->assertInstanceOf( \WP_Error::class, $second );
+		$this->assertSame( 'token_unknown', $second->get_error_code() );
+	}
+
+	public function test_missing_token_rejected(): void {
+		$err = Store::consume( '', 'sess1', 'ability_a', array() );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'missing_token', $err->get_error_code() );
+	}
+
+	public function test_session_mismatch_rejected(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess_other', 'ability_a', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'session_mismatch', $err->get_error_code() );
+	}
+
+	public function test_ability_mismatch_rejected(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess1', 'ability_b', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'ability_mismatch', $err->get_error_code() );
+	}
+
+	public function test_params_mismatch_rejected(): void {
+		$token = Store::mint( 'sess1', 'ability_a', array( 'keyword' => 'email' ) );
+
+		$err = Store::consume( $token, 'sess1', 'ability_a', array( 'keyword' => 'phone' ) );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'params_mismatch', $err->get_error_code() );
+	}
+
+	public function test_failed_lookup_invalidates_token_anyway(): void {
+		// Replay protection: even when consume() fails because of a binding
+		// mismatch, the transient must be deleted so an attacker cannot
+		// retry the same token after fixing the mismatch.
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		Store::consume( $token, 'sess_wrong', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'token_unknown', $err->get_error_code() );
+	}
+}

--- a/tests/Unit/Settings/SafetySettingsRepositoryTest.php
+++ b/tests/Unit/Settings/SafetySettingsRepositoryTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Unit tests for SafetySettingsRepository.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+final class SafetySettingsRepositoryTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	public function test_master_toggle_default_on(): void {
+		$this->assertTrue( Repo::is_master_enabled() );
+	}
+
+	public function test_master_toggle_can_be_disabled_then_re_enabled(): void {
+		Repo::set_master_enabled( false );
+		$this->assertFalse( Repo::is_master_enabled() );
+		Repo::set_master_enabled( true );
+		$this->assertTrue( Repo::is_master_enabled() );
+	}
+
+	public function test_bucket1_keywords_are_hardcoded_and_non_empty(): void {
+		$kws = Repo::bucket1_default_keywords();
+		$this->assertNotEmpty( $kws );
+		$this->assertContains( 'password', $kws );
+		$this->assertContains( 'auth_token', $kws );
+	}
+
+	public function test_add_custom_bucket3_keyword(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		$this->assertTrue( $result );
+		$this->assertContains( 'gravity_forms_secret', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_add_custom_bucket2_keyword(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_PAYMENT, 'wallet_id' );
+		$this->assertTrue( $result );
+		$this->assertContains( 'wallet_id', Repo::get_active_keywords( Repo::BUCKET_PAYMENT ) );
+	}
+
+	public function test_cannot_add_keyword_to_bucket1(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_SECRETS, 'whatever' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bucket1_locked', $result->get_error_code() );
+	}
+
+	public function test_invalid_bucket_rejected(): void {
+		$result = Repo::add_custom_keyword( 9, 'whatever' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_bucket', $result->get_error_code() );
+	}
+
+	public function test_empty_keyword_rejected(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_CONTACT, '   ' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'empty_keyword', $result->get_error_code() );
+	}
+
+	public function test_remove_custom_keyword_returns_false_for_unknown(): void {
+		$result = Repo::remove_custom_keyword( Repo::BUCKET_CONTACT, 'never_added' );
+		$this->assertFalse( $result );
+	}
+
+	public function test_remove_custom_keyword_removes_added_entry(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'foo_secret' );
+		$this->assertContains( 'foo_secret', Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertTrue( Repo::remove_custom_keyword( Repo::BUCKET_CONTACT, 'foo_secret' ) );
+		$this->assertNotContains( 'foo_secret', Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_marks_as_removed(): void {
+		$this->assertTrue( in_array( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ), true ) );
+		$this->assertTrue( Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' ) );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_rejects_non_default(): void {
+		$result = Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'not_a_default_keyword' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_a_default', $result->get_error_code() );
+	}
+
+	public function test_re_adding_removed_default_restores_it(): void {
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'email' );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertNotContains( 'email', Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_restore_defaults_clears_customs_and_removed(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+		Repo::add_custom_keyword( Repo::BUCKET_PAYMENT, 'wallet_id' );
+
+		Repo::restore_defaults();
+
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_PAYMENT ) );
+		$this->assertEmpty( Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_keyword_sanitisation_lowercases_and_strips_invalid_chars(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'Custom Field!@#' );
+		$customs = Repo::get_custom_keywords( Repo::BUCKET_CONTACT );
+		$this->assertContains( 'customfield', $customs );
+	}
+
+	public function test_exemption_add_remove(): void {
+		$this->assertTrue( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+		$this->assertTrue( Repo::remove_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_exemption_idempotent(): void {
+		$this->assertTrue( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertFalse( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertFalse( Repo::remove_exemption( Repo::BUCKET_CONTACT, 'never-added' ) );
+	}
+
+	public function test_exemption_invalid_bucket_rejected(): void {
+		$err = Repo::add_exemption( Repo::BUCKET_SECRETS, 'users/list' );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'invalid_bucket', $err->get_error_code() );
+	}
+
+	public function test_trusted_proxy_defaults(): void {
+		$this->assertFalse( Repo::is_trusted_proxy_enabled() );
+		$this->assertSame( Repo::PROXY_MODE_CLOUDFLARE, Repo::get_trusted_proxy_mode() );
+		$this->assertSame( '', Repo::get_trusted_proxy_allowlist_raw() );
+	}
+
+	public function test_trusted_proxy_round_trip(): void {
+		Repo::set_trusted_proxy_enabled( true );
+		Repo::set_trusted_proxy_mode( Repo::PROXY_MODE_CUSTOM );
+		Repo::set_trusted_proxy_allowlist_raw( "10.0.0.0/8\n192.168.1.1" );
+
+		$this->assertTrue( Repo::is_trusted_proxy_enabled() );
+		$this->assertSame( Repo::PROXY_MODE_CUSTOM, Repo::get_trusted_proxy_mode() );
+		$this->assertStringContainsString( '10.0.0.0/8', Repo::get_trusted_proxy_allowlist_raw() );
+	}
+
+	public function test_trusted_proxy_mode_falls_back_to_cloudflare_for_unknown(): void {
+		Repo::set_trusted_proxy_mode( 'something_else' );
+		$this->assertSame( Repo::PROXY_MODE_CLOUDFLARE, Repo::get_trusted_proxy_mode() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -174,6 +174,33 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
+// In-memory ability registry for tests that need to exercise
+// `wp_get_abilities()` (e.g. ResponseRedactionGate's tool-name → ability-name
+// translator). The real Abilities API isn't loaded here.
+if ( ! isset( $GLOBALS['wp_test_abilities'] ) ) {
+	$GLOBALS['wp_test_abilities'] = array();
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $args = array() ) {
+		$ability = new \WP_Ability( $name, $args );
+		$GLOBALS['wp_test_abilities'][ $name ] = $ability;
+		return $ability;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		return $GLOBALS['wp_test_abilities'][ $name ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'wp_get_abilities' ) ) {
+	function wp_get_abilities() {
+		return $GLOBALS['wp_test_abilities'];
+	}
+}
+
 if ( ! class_exists( 'WP_Ability' ) ) {
 	class WP_Ability {
 		private $name;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,103 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $option ) {
+		unset( $GLOBALS['wp_test_options'][ $option ] );
+		return true;
+	}
+}
+
+if ( ! isset( $GLOBALS['wp_test_transients'] ) ) {
+	$GLOBALS['wp_test_transients'] = array();
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $key, $value, $ttl = 0 ) {
+		$GLOBALS['wp_test_transients'][ $key ] = array(
+			'value'   => $value,
+			'expires' => time() + (int) $ttl,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $key ) {
+		$entry = $GLOBALS['wp_test_transients'][ $key ] ?? null;
+		if ( ! $entry ) {
+			return false;
+		}
+		if ( $entry['expires'] < time() ) {
+			unset( $GLOBALS['wp_test_transients'][ $key ] );
+			return false;
+		}
+		return $entry['value'];
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $key ) {
+		unset( $GLOBALS['wp_test_transients'][ $key ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_password' ) ) {
+	function wp_generate_password( $length = 12, $special_chars = true, $extra_special_chars = false ) {
+		return bin2hex( random_bytes( max( 1, (int) ( $length / 2 ) ) ) );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return $GLOBALS['wp_test_current_user'] ?? 0;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_]/', '', $key ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		// no-op for unit tests
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return ! empty( $GLOBALS['wp_test_current_user'] );
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $capability ) {
+		return ! empty( $GLOBALS['wp_test_caps'][ $capability ] );
+	}
+}
+
 if ( ! function_exists( 'esc_html__' ) ) {
 	function esc_html__( $text, $domain = 'default' ) {
 		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -150,6 +150,30 @@ if ( ! function_exists( 'esc_html__' ) ) {
 	}
 }
 
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		return null;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
 if ( ! class_exists( 'WP_Ability' ) ) {
 	class WP_Ability {
 		private $name;


### PR DESCRIPTION
Held for public-alpha hardening sprint Launch Gate. Part of the six-brief integrated release. See SYNTHESIS — Alpha Hardening Workstream 2026-04-26 v1.3.0.

Closes #18.

## Summary

Plugin-agnostic redaction filter at the adapter response boundary. Three buckets, recursive traversal, type-aware markers, configurable per-ability exemptions. No third-party plugin awareness — only well-known field names and scalar-string pattern matchers.

- **Bucket 1 (secrets):** always-on; credentials, API/named keys, tokens, wp-config salts, plus scalar-string pattern matchers (password hash formats; Stripe/Slack/GitHub/AWS/Google API-key prefixes).
- **Bucket 2 (payment / regulated IDs):** default-on, master-toggle gated; PAN, CVV, SSN, tax IDs, Luhn-passing 13–19 digit scalar strings.
- **Bucket 3 (contact PII / access labels):** default-on, master-toggle gated; email, phone, address, IP, login identity, DOB, `public_key`.

## Where it runs

`HttpRequestHandler::process_jsonrpc_request` and `StdioServerBridge::handle_request`, after `RequestRouter` returns and before `JsonRpcResponseBuilder` serializes. Internal `_session_id` / `_session_token` markers are stripped before redaction and re-attached on the way out — existing session/header flow is unchanged.

## Storage (filed for DB-3 to wire UI)

- `abilities_mcp_redaction_master_enabled` (default `true`)
- `abilities_mcp_redaction_keywords` — Bucket 3 custom additions
- `abilities_mcp_bucket3_exemptions` — per-ability Bucket 3 exemptions (Admin UI **or** AI per DB-3)
- `abilities_mcp_bucket2_exemptions` — per-ability Bucket 2 exemptions (Admin UI **only** per DB-3)

## Filter hooks for power users

- `abilities_mcp_redaction_keywords`
- `abilities_mcp_redaction_master_enabled`
- `abilities_mcp_redacted_value` `(value, field_name, bucket_number)`

## Telemetry

Emits `boundary.redaction_applied` via `BoundaryEventEmitter` with per-bucket counts (no values). Allowlist extended with `redaction_count_b1/b2/b3`. Depth/node-limit breach emits `boundary.transport.error` and returns a JSON-RPC internal error rather than a partially-redacted response — partial redaction is treated as a leak, not a degradation.

DB-1 (`abilities-for-ai#132`) is the writer that catches these events; this PR doesn't depend on the writer being merged — events flow through the existing `mcp_adapter_boundary_event` action regardless.

## Coordination

DB-5 (#19) also touches `HttpTransport.php` / request handling. This PR's changes to `HttpRequestHandler.php` are confined to import + a single call site in `process_jsonrpc_request`. DB-5 should rebase on top of this when Launch Gate runs.

## Test plan

- [x] `vendor/bin/phpunit` — 326 / 326 pass (44 new in `tests/Unit/Infrastructure/Redaction/`)
- [x] Behavioral ACs: users/list, fluent-cart/list-customers, meta/get-user-meta
- [x] Implementation ACs: 6 type cases, recursion ≤64, max-nodes guard throws, case-insensitive match, no regex over full JSON
- [x] Adversarial ACs: `meta_key` / `cache_key` pass through; blog post body containing the word "password" passes; comment body containing an email passes; Bucket 1 indelible under master-off + per-ability exemption
- [ ] Integration smoke against a live `helenawillow.com` `/mcp` endpoint — deferred to Launch Gate
- [ ] Response-time impact <5ms on `users/list` 100-row response — deferred to Launch Gate (synthesis §5)
- [ ] Coordinated rebase with DB-5 at Launch Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)