### PR TITLE
DB-3: Safety Settings UI + AI-callable settings abilities (held)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased] — DB-3 (held for public-alpha hardening Launch Gate)
+
+### Added — Safety Settings UI + AI-callable settings abilities
+- New admin page **Settings → MCP Safety** with four sections:
+  1. Master toggle (off requires checkbox confirmation; Bucket 1 secrets always filtered).
+  2. Redaction keyword list — Bucket 1 read-only; Bucket 2 with per-default warning; Bucket 3 with per-default no warning; custom-add input (Bucket 2 or 3 only); restore defaults.
+  3. Per-ability exemptions — two columns (Bucket 3 left, Bucket 2 right with confirm-on-add warning).
+  4. Trusted proxy — Cloudflare preset / custom CIDR allowlist (consumed by the rate limiter in DB-4).
+- Seven AI-callable abilities, all gated by `manage_options`:
+  - `settings/get-redaction-list` — read state, no friction.
+  - `settings/add-redaction-keyword` — strengthen, no friction.
+  - `settings/remove-custom-keyword` — reverse own additions, no friction.
+  - `settings/restore-redaction-defaults` — restore baseline, no friction.
+  - `settings/remove-default-bucket3-keyword` — weaken Bucket 3 default, **in-chat 1/2 confirmation required**.
+  - `settings/exempt-ability-from-bucket3` — per-ability Bucket 3 unlock, **in-chat 1/2 confirmation required**.
+  - `settings/unexempt-ability-from-bucket3` — re-lock exemption, no friction.
+- One-time confirmation tokens stored as WP transients with 60s TTL, bound to (session, ability, params); single-use; replay-safe.
+- All settings writes emit `boundary.master_toggle.changed`, `boundary.redaction_keywords.changed`, `boundary.ability_exemption.changed`, `boundary.confirmation.failed` events through the existing `BoundaryEventEmitter`.
+- New option keys: `abilities_mcp_redaction_master_enabled`, `abilities_mcp_redaction_keywords` (Bucket 3 customs), `abilities_mcp_bucket2_keywords` (Bucket 2 customs — DB-2 to read after rebase), `abilities_mcp_bucket3_exemptions`, `abilities_mcp_bucket2_exemptions`, `abilities_mcp_redaction_keywords_removed_defaults`, `abilities_mcp_bucket2_keywords_removed_defaults`, `abilities_mcp_trusted_proxy_enabled`, `abilities_mcp_trusted_proxy_mode`, `abilities_mcp_trusted_proxy_allowlist`.
+
+### Held
+- Bucket 2 default-removal, Bucket 2 ability-exemption, master-toggle-off — Admin UI only by design. No ability paths exist for these.
+- Released together with DB-1, DB-2, DB-4, DB-5, DB-6 at the Launch Gate.
+
 ## [1.2.0] - 2026-03-20
 
 ### Added

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -45,13 +45,19 @@ if ( file_exists( $autoloader ) ) {
 	return;
 }
 
-use WickedEvolutions\McpAdapter\Core\McpAdapter;
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
 use WickedEvolutions\McpAdapter\Admin\AbilitySettingsPage;
+use WickedEvolutions\McpAdapter\Admin\SafetySettingsPage;
+use WickedEvolutions\McpAdapter\Core\McpAdapter;
 
-// Register admin settings page (license + ability permissions).
+// Register admin settings pages (license + ability permissions + safety settings).
 if ( is_admin() ) {
 	AbilitySettingsPage::register();
+	SafetySettingsPage::register();
 }
+
+// Register safety-settings abilities inside the Abilities API init hook.
+add_action( 'wp_abilities_api_init', array( SettingsAbilities::class, 'register_all' ) );
 
 // Enable MCP tool validation — silently drops invalid tools instead of breaking all tools.
 add_filter( 'mcp_adapter_validation_enabled', '__return_true' );

--- a/src/Abilities/Settings/SettingsAbilities.php
+++ b/src/Abilities/Settings/SettingsAbilities.php
@@ -64,6 +64,123 @@ final class SettingsAbilities {
 		return true;
 	}
 
+	/**
+	 * Reject a keyword that is not actually in the Bucket 3 defaults BEFORE
+	 * minting a confirmation token. Synthesis Decision 3 forbids weakening
+	 * Bucket 2 via chat at any granularity — a Bucket 2 keyword arriving on
+	 * the Bucket 3 path must never produce a confirmation prompt.
+	 *
+	 * Returns null when the keyword is a valid Bucket 3 default and the
+	 * caller should proceed. Returns a structured error response array
+	 * otherwise; the caller should return it directly.
+	 *
+	 * @param string $keyword Already lowercased / trimmed.
+	 * @return array<string,mixed>|null
+	 */
+	private static function guard_bucket3_default_keyword( string $keyword ): ?array {
+		if ( '' === $keyword ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => 'Keyword must be a non-empty string.',
+			);
+		}
+
+		$bucket3 = array_map( 'strtolower', Repo::bucket3_default_keywords() );
+		if ( in_array( $keyword, $bucket3, true ) ) {
+			return null;
+		}
+
+		$bucket2 = array_map( 'strtolower', Repo::bucket2_default_keywords() );
+		if ( in_array( $keyword, $bucket2, true ) ) {
+			BoundaryEventEmitter::emit(
+				null,
+				'boundary.confirmation.failed',
+				array(
+					'severity'   => 'warn',
+					'user_id'    => (int) get_current_user_id(),
+					'method'     => 'settings/remove-default-bucket3-keyword',
+					'error_code' => 'bucket2_keyword_rejected',
+					'name'       => sanitize_key( $keyword ),
+					'reason'     => 'Bucket 2 weakening is not available via chat — Admin UI only.',
+				)
+			);
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => sprintf(
+					"'%s' is a Bucket 2 (payment / regulated) keyword. Bucket 2 weakening is not available via chat. To make this change, use WP Admin → Settings → MCP Safety.",
+					$keyword
+				),
+			);
+		}
+
+		return array(
+			'success'               => false,
+			'confirmation_required' => false,
+			'message'               => sprintf(
+				"'%s' is not in any default redaction list (Bucket 2 or Bucket 3). If it was added as a custom keyword, use settings/remove-custom-keyword instead.",
+				$keyword
+			),
+		);
+	}
+
+	/**
+	 * Reject an unknown ability name BEFORE minting a confirmation token.
+	 *
+	 * Returns null when the ability is known (or when the abilities API is
+	 * unavailable in this context — fail-open is acceptable here because
+	 * exempting a non-existent ability is a no-op at redaction time, just
+	 * a UX nuisance). Returns a structured error response otherwise.
+	 *
+	 * @param string $ability_name
+	 * @param string $caller_ability  The ability invoking this guard (for telemetry).
+	 * @return array<string,mixed>|null
+	 */
+	private static function guard_known_ability_name( string $ability_name, string $caller_ability ): ?array {
+		if ( '' === $ability_name ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => 'ability_name must be a non-empty string.',
+			);
+		}
+
+		// If the WP Abilities API isn't loaded (unit tests without the real
+		// plugin), skip the existence check — the repository write itself
+		// will accept any sanitised string and the operator can clean up.
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return null;
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( null !== $ability ) {
+			return null;
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.confirmation.failed',
+			array(
+				'severity'   => 'warn',
+				'user_id'    => (int) get_current_user_id(),
+				'method'     => $caller_ability,
+				'error_code' => 'unknown_ability_name',
+				'name'       => sanitize_text_field( $ability_name ),
+				'reason'     => 'No ability registered under this name.',
+			)
+		);
+
+		return array(
+			'success'               => false,
+			'confirmation_required' => false,
+			'message'               => sprintf(
+				"No ability registered under the name '%s'. Use settings/get-redaction-list or the discover-abilities tool to find the correct ability name.",
+				$ability_name
+			),
+		);
+	}
+
 	// settings/get-redaction-list ----------------------------------------
 
 	private static function register_get_redaction_list(): void {
@@ -381,6 +498,15 @@ final class SettingsAbilities {
 		$ability = 'settings/remove-default-bucket3-keyword';
 		$params  = array( 'keyword' => strtolower( trim( $keyword ) ) );
 
+		// Bucket-membership pre-check (synthesis Decision 3).
+		// Bucket 2 cannot be weakened through chat at any granularity.
+		// Reject before minting a token so the operator is never shown a
+		// confirmation prompt for a keyword that doesn't belong here.
+		$bucket_check = self::guard_bucket3_default_keyword( $params['keyword'] );
+		if ( null !== $bucket_check ) {
+			return $bucket_check;
+		}
+
 		if ( '' === $token ) {
 			$session = ConfirmationTokenStore::current_session_id();
 			$minted  = ConfirmationTokenStore::mint( $session, $ability, $params );
@@ -502,6 +628,13 @@ final class SettingsAbilities {
 
 		$ability = 'settings/exempt-ability-from-bucket3';
 		$params  = array( 'ability_name' => trim( $ability_name ) );
+
+		// Reject unknown ability names BEFORE minting a confirmation token —
+		// otherwise the operator is shown a confirmation for a no-op write.
+		$ability_check = self::guard_known_ability_name( $params['ability_name'], $ability );
+		if ( null !== $ability_check ) {
+			return $ability_check;
+		}
 
 		if ( '' === $token ) {
 			$session = ConfirmationTokenStore::current_session_id();

--- a/src/Abilities/Settings/SettingsAbilities.php
+++ b/src/Abilities/Settings/SettingsAbilities.php
@@ -1,0 +1,648 @@
+<?php
+/**
+ * AI-callable safety-settings abilities (DB-3).
+ *
+ * Seven abilities for managing the redaction filter from chat. All abilities
+ * require `manage_options`. Bucket 2 weakening and master-toggle changes
+ * have NO ability paths — those are Admin-UI only by design.
+ *
+ * Friction model:
+ *   - Strengthen / reverse own additions / restore defaults: zero friction.
+ *   - Weaken Bucket 3 default keyword OR exempt ability from Bucket 3:
+ *     in-chat 1/2 confirmation token (60s, session-bound, params-bound).
+ *
+ * Confirmation flow:
+ *   1. AI calls ability without `confirmation_token`.
+ *   2. Adapter mints a token bound to (session, ability, params) and returns
+ *      { confirmation_required: true, token, summary, options[1=yes,2=no] }.
+ *   3. AI surfaces the warning + options to the operator.
+ *   4. Operator picks 1 → AI re-issues with the token.
+ *   5. Adapter consumes the token (one-time, TTL 60s) and executes.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Abilities\Settings;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Settings\ConfirmationTokenStore;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+/**
+ * Registers the seven `settings/*` abilities.
+ */
+final class SettingsAbilities {
+
+	/**
+	 * Hook into `wp_abilities_api_init` to register all settings abilities.
+	 */
+	public static function register_all(): void {
+		self::register_get_redaction_list();
+		self::register_add_redaction_keyword();
+		self::register_remove_custom_keyword();
+		self::register_restore_redaction_defaults();
+		self::register_remove_default_bucket3_keyword();
+		self::register_exempt_ability_from_bucket3();
+		self::register_unexempt_ability_from_bucket3();
+	}
+
+	// Permission callback (shared) ---------------------------------------
+
+	public static function check_permission( $input = array() ) {
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error( 'authentication_required', 'Settings abilities require an authenticated administrator.' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'insufficient_capability', 'Settings abilities require the manage_options capability.' );
+		}
+		return true;
+	}
+
+	// settings/get-redaction-list ----------------------------------------
+
+	private static function register_get_redaction_list(): void {
+		wp_register_ability(
+			'settings/get-redaction-list',
+			array(
+				'label'               => 'Get redaction list',
+				'description'         => 'Read the current redaction configuration: master toggle, bucket-1/2/3 keyword lists, per-ability exemptions. No friction.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'master_enabled'      => array( 'type' => 'boolean' ),
+						'bucket1'             => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+						'bucket2'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'active'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'custom'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'removed' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							),
+						),
+						'bucket3'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'active'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'custom'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'removed' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							),
+						),
+						'exemptions_bucket3'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+						'exemptions_bucket2'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_get_redaction_list' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_get_redaction_list( $input = array() ): array {
+		return array(
+			'master_enabled'     => Repo::is_master_enabled(),
+			'bucket1'            => Repo::bucket1_default_keywords(),
+			'bucket2'            => array(
+				'active'  => Repo::get_active_keywords( Repo::BUCKET_PAYMENT ),
+				'custom'  => Repo::get_custom_keywords( Repo::BUCKET_PAYMENT ),
+				'removed' => Repo::get_removed_defaults( Repo::BUCKET_PAYMENT ),
+			),
+			'bucket3'            => array(
+				'active'  => Repo::get_active_keywords( Repo::BUCKET_CONTACT ),
+				'custom'  => Repo::get_custom_keywords( Repo::BUCKET_CONTACT ),
+				'removed' => Repo::get_removed_defaults( Repo::BUCKET_CONTACT ),
+			),
+			'exemptions_bucket3' => Repo::get_exemptions( Repo::BUCKET_CONTACT ),
+			'exemptions_bucket2' => Repo::get_exemptions( Repo::BUCKET_PAYMENT ),
+		);
+	}
+
+	// settings/add-redaction-keyword (no friction) -----------------------
+
+	private static function register_add_redaction_keyword(): void {
+		wp_register_ability(
+			'settings/add-redaction-keyword',
+			array(
+				'label'               => 'Add redaction keyword',
+				'description'         => 'Add a custom keyword to Bucket 2 (payment / regulated) or Bucket 3 (contact PII). Strengthens defaults — no confirmation required. Bucket 1 is hardcoded and not addable.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword', 'bucket' ),
+					'properties' => array(
+						'keyword' => array( 'type' => 'string', 'description' => 'Field-name keyword to redact (lower-cased automatically).' ),
+						'bucket'  => array( 'type' => 'integer', 'enum' => array( 2, 3 ) ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'added'   => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_add_redaction_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_add_redaction_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$bucket  = isset( $input['bucket'] ) ? (int) $input['bucket'] : 0;
+
+		$result = Repo::add_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'added'   => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'add_custom',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+				'method'    => 'settings/add-redaction-keyword',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'added'   => (bool) $result,
+			'message' => $result ? 'Keyword added.' : 'Keyword already present.',
+		);
+	}
+
+	// settings/remove-custom-keyword (no friction) -----------------------
+
+	private static function register_remove_custom_keyword(): void {
+		wp_register_ability(
+			'settings/remove-custom-keyword',
+			array(
+				'label'               => 'Remove custom redaction keyword',
+				'description'         => 'Reverse a previously-added custom keyword (Bucket 2 or 3). Reversal of operator additions only — does not remove default keywords. No confirmation required.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword', 'bucket' ),
+					'properties' => array(
+						'keyword' => array( 'type' => 'string' ),
+						'bucket'  => array( 'type' => 'integer', 'enum' => array( 2, 3 ) ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'removed' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_remove_custom_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_remove_custom_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$bucket  = isset( $input['bucket'] ) ? (int) $input['bucket'] : 0;
+
+		$result = Repo::remove_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'removed' => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove_custom',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+				'method'    => 'settings/remove-custom-keyword',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'removed' => (bool) $result,
+			'message' => $result ? 'Custom keyword removed.' : 'Keyword was not in the custom list.',
+		);
+	}
+
+	// settings/restore-redaction-defaults (no friction) ------------------
+
+	private static function register_restore_redaction_defaults(): void {
+		wp_register_ability(
+			'settings/restore-redaction-defaults',
+			array(
+				'label'               => 'Restore redaction defaults',
+				'description'         => 'Restore Bucket 2 + Bucket 3 redaction lists to factory defaults. Clears custom additions and removed-defaults. No confirmation required (strengthens safety).',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_restore_redaction_defaults' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_restore_redaction_defaults( $input = array() ): array {
+		Repo::restore_defaults();
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'restore_defaults',
+				'method'    => 'settings/restore-redaction-defaults',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'message' => 'Redaction lists restored to defaults.',
+		);
+	}
+
+	// settings/remove-default-bucket3-keyword (1/2 confirmation) ---------
+
+	private static function register_remove_default_bucket3_keyword(): void {
+		wp_register_ability(
+			'settings/remove-default-bucket3-keyword',
+			array(
+				'label'               => 'Remove default Bucket 3 keyword',
+				'description'         => 'Weaken the default Bucket 3 redaction list by removing a default keyword. Requires in-chat 1/2 confirmation. Bucket 2 default removal is not available via abilities — it is admin-UI only.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'keyword' ),
+					'properties' => array(
+						'keyword'            => array( 'type' => 'string' ),
+						'confirmation_token' => array( 'type' => 'string', 'description' => 'One-time token returned by the first call. Required on the second call.' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'                => array( 'type' => 'boolean' ),
+						'confirmation_required'  => array( 'type' => 'boolean' ),
+						'token'                  => array( 'type' => 'string' ),
+						'summary'                => array( 'type' => 'string' ),
+						'options'                => array( 'type' => 'array' ),
+						'message'                => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_remove_default_bucket3_keyword' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_remove_default_bucket3_keyword( $input = array() ): array {
+		$keyword = isset( $input['keyword'] ) ? (string) $input['keyword'] : '';
+		$token   = isset( $input['confirmation_token'] ) ? (string) $input['confirmation_token'] : '';
+
+		$ability = 'settings/remove-default-bucket3-keyword';
+		$params  = array( 'keyword' => strtolower( trim( $keyword ) ) );
+
+		if ( '' === $token ) {
+			$session = ConfirmationTokenStore::current_session_id();
+			$minted  = ConfirmationTokenStore::mint( $session, $ability, $params );
+
+			return array(
+				'success'               => false,
+				'confirmation_required' => true,
+				'token'                 => $minted,
+				'summary'               => sprintf(
+					"Remove '%s' from Bucket 3 redaction defaults — exposes this contact field in all subsequent ability responses until re-added. This weakens the default safety posture.",
+					$params['keyword']
+				),
+				'options'               => array(
+					array( 'key' => '1', 'label' => 'Yes, confirm' ),
+					array( 'key' => '2', 'label' => 'No' ),
+				),
+				'message'               => 'Confirmation required. Re-issue the call with this token within 60 seconds.',
+			);
+		}
+
+		$session = ConfirmationTokenStore::current_session_id();
+		$consume = ConfirmationTokenStore::consume( $token, $session, $ability, $params );
+		if ( is_wp_error( $consume ) ) {
+			BoundaryEventEmitter::emit(
+				null,
+				'boundary.confirmation.failed',
+				array(
+					'severity'   => 'warn',
+					'user_id'    => (int) get_current_user_id(),
+					'method'     => $ability,
+					'error_code' => $consume->get_error_code(),
+					'reason'     => $consume->get_error_message(),
+				)
+			);
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $consume->get_error_message(),
+			);
+		}
+
+		$result = Repo::remove_default_keyword( Repo::BUCKET_CONTACT, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity'  => 'warn',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove_default',
+				'name'      => sanitize_key( $keyword ),
+				'dimension' => 'bucket_3',
+				'method'    => $ability,
+			)
+		);
+
+		return array(
+			'success'               => true,
+			'confirmation_required' => false,
+			'message'               => $result
+				? 'Default keyword removed. Use settings/restore-redaction-defaults or add-redaction-keyword to re-enable.'
+				: 'Keyword was already removed.',
+		);
+	}
+
+	// settings/exempt-ability-from-bucket3 (1/2 confirmation) ------------
+
+	private static function register_exempt_ability_from_bucket3(): void {
+		wp_register_ability(
+			'settings/exempt-ability-from-bucket3',
+			array(
+				'label'               => 'Exempt ability from Bucket 3 redaction',
+				'description'         => 'Allow contact PII (email, phone, address, IP) to flow through one specific ability\'s response. Requires in-chat 1/2 confirmation. Bucket 2 exemptions are admin-UI only.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'ability_name' ),
+					'properties' => array(
+						'ability_name'       => array( 'type' => 'string', 'description' => 'Namespaced ability name (e.g. "users/list").' ),
+						'confirmation_token' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'               => array( 'type' => 'boolean' ),
+						'confirmation_required' => array( 'type' => 'boolean' ),
+						'token'                 => array( 'type' => 'string' ),
+						'summary'               => array( 'type' => 'string' ),
+						'options'               => array( 'type' => 'array' ),
+						'message'               => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_exempt_ability_from_bucket3' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_exempt_ability_from_bucket3( $input = array() ): array {
+		$ability_name = isset( $input['ability_name'] ) ? (string) $input['ability_name'] : '';
+		$token        = isset( $input['confirmation_token'] ) ? (string) $input['confirmation_token'] : '';
+
+		$ability = 'settings/exempt-ability-from-bucket3';
+		$params  = array( 'ability_name' => trim( $ability_name ) );
+
+		if ( '' === $token ) {
+			$session = ConfirmationTokenStore::current_session_id();
+			$minted  = ConfirmationTokenStore::mint( $session, $ability, $params );
+
+			return array(
+				'success'               => false,
+				'confirmation_required' => true,
+				'token'                 => $minted,
+				'summary'               => sprintf(
+					"Exempt '%s' from Bucket 3 redaction — its responses will return contact PII (email, phone, address, IP) un-redacted. This weakens the default safety posture for this specific ability only.",
+					$params['ability_name']
+				),
+				'options'               => array(
+					array( 'key' => '1', 'label' => 'Yes, confirm' ),
+					array( 'key' => '2', 'label' => 'No' ),
+				),
+				'message'               => 'Confirmation required. Re-issue the call with this token within 60 seconds.',
+			);
+		}
+
+		$session = ConfirmationTokenStore::current_session_id();
+		$consume = ConfirmationTokenStore::consume( $token, $session, $ability, $params );
+		if ( is_wp_error( $consume ) ) {
+			BoundaryEventEmitter::emit(
+				null,
+				'boundary.confirmation.failed',
+				array(
+					'severity'   => 'warn',
+					'user_id'    => (int) get_current_user_id(),
+					'method'     => $ability,
+					'error_code' => $consume->get_error_code(),
+					'reason'     => $consume->get_error_message(),
+				)
+			);
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $consume->get_error_message(),
+			);
+		}
+
+		$result = Repo::add_exemption( Repo::BUCKET_CONTACT, $ability_name );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'               => false,
+				'confirmation_required' => false,
+				'message'               => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.ability_exemption.changed',
+			array(
+				'severity'  => 'warn',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'add',
+				'name'      => sanitize_text_field( $ability_name ),
+				'dimension' => 'bucket_3',
+				'method'    => $ability,
+			)
+		);
+
+		return array(
+			'success'               => true,
+			'confirmation_required' => false,
+			'message'               => $result
+				? 'Ability exempted from Bucket 3 redaction.'
+				: 'Ability was already exempt.',
+		);
+	}
+
+	// settings/unexempt-ability-from-bucket3 (no friction) ---------------
+
+	private static function register_unexempt_ability_from_bucket3(): void {
+		wp_register_ability(
+			'settings/unexempt-ability-from-bucket3',
+			array(
+				'label'               => 'Re-lock ability under Bucket 3',
+				'description'         => 'Remove a previously-granted Bucket 3 exemption. Strengthens safety — no confirmation required.',
+				'category'            => 'mcp-adapter',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'ability_name' ),
+					'properties' => array(
+						'ability_name' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'removed' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'execute_callback'    => array( self::class, 'execute_unexempt_ability_from_bucket3' ),
+				'meta'                => array(
+					'mcp'         => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations' => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	public static function execute_unexempt_ability_from_bucket3( $input = array() ): array {
+		$ability_name = isset( $input['ability_name'] ) ? (string) $input['ability_name'] : '';
+
+		$result = Repo::remove_exemption( Repo::BUCKET_CONTACT, $ability_name );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'removed' => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		BoundaryEventEmitter::emit(
+			null,
+			'boundary.ability_exemption.changed',
+			array(
+				'severity'  => 'info',
+				'user_id'   => (int) get_current_user_id(),
+				'reason'    => 'remove',
+				'name'      => sanitize_text_field( $ability_name ),
+				'dimension' => 'bucket_3',
+				'method'    => 'settings/unexempt-ability-from-bucket3',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'removed' => (bool) $result,
+			'message' => $result ? 'Bucket 3 exemption removed.' : 'Ability was not exempt.',
+		);
+	}
+}

--- a/src/Admin/SafetySettingsPage.php
+++ b/src/Admin/SafetySettingsPage.php
@@ -1,0 +1,715 @@
+<?php
+/**
+ * Safety Settings — admin page.
+ *
+ * Operator-facing surface for the redaction filter (DB-2) and trusted-proxy
+ * configuration (DB-4). Four sections:
+ *   1. Master toggle (off requires checkbox confirmation)
+ *   2. Redaction keyword list — Bucket 1 read-only, Bucket 2 (warning per remove),
+ *      Bucket 3 (no warning), custom add input.
+ *   3. Per-ability exemptions — two columns (Bucket 3 left, Bucket 2 right).
+ *   4. Trusted proxy (Cloudflare preset / custom CIDR allowlist).
+ *
+ * All writes log boundary.* events to the kl_boundary log via the adapter's
+ * existing BoundaryEventEmitter.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Admin;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Observability\BoundaryEventEmitter;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+/**
+ * Safety Settings admin page (Settings → MCP Safety).
+ */
+final class SafetySettingsPage {
+
+	public const PAGE_SLUG   = 'mcp-adapter-safety';
+	private const NONCE_FORM = 'mcp_adapter_safety_save';
+
+	public static function register(): void {
+		add_action( 'admin_menu', array( self::class, 'add_menu_page' ) );
+		add_action( 'admin_init', array( self::class, 'handle_save' ) );
+	}
+
+	public static function add_menu_page(): void {
+		add_options_page(
+			__( 'MCP Safety Settings', 'mcp-adapter' ),
+			__( 'MCP Safety', 'mcp-adapter' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( self::class, 'render_page' )
+		);
+	}
+
+	public static function page_url( array $args = array() ): string {
+		$args['page'] = self::PAGE_SLUG;
+		return add_query_arg( $args, admin_url( 'options-general.php' ) );
+	}
+
+	/**
+	 * Process the settings form. The form has multiple "actions" multiplexed
+	 * onto a single endpoint via the `mcp_safety_action` hidden field.
+	 */
+	public static function handle_save(): void {
+		if ( ! isset( $_POST['mcp_safety_action'] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage safety settings.', 'mcp-adapter' ) );
+		}
+		check_admin_referer( self::NONCE_FORM, 'mcp_safety_nonce' );
+
+		$action = sanitize_key( wp_unslash( $_POST['mcp_safety_action'] ) );
+		$notice = '';
+
+		switch ( $action ) {
+			case 'master_toggle':
+				$notice = self::handle_master_toggle();
+				break;
+			case 'add_keyword':
+				$notice = self::handle_add_keyword();
+				break;
+			case 'remove_custom_keyword':
+				$notice = self::handle_remove_custom_keyword();
+				break;
+			case 'remove_default_keyword':
+				$notice = self::handle_remove_default_keyword();
+				break;
+			case 'restore_defaults':
+				$notice = self::handle_restore_defaults();
+				break;
+			case 'set_exemption':
+				$notice = self::handle_set_exemption();
+				break;
+			case 'unset_exemption':
+				$notice = self::handle_unset_exemption();
+				break;
+			case 'trusted_proxy':
+				$notice = self::handle_trusted_proxy();
+				break;
+		}
+
+		wp_safe_redirect( self::page_url( array( 'updated' => '1', 'msg' => rawurlencode( $notice ) ) ) );
+		exit;
+	}
+
+	private static function handle_master_toggle(): string {
+		$desired = isset( $_POST['mcp_master_enabled'] ) ? '1' === $_POST['mcp_master_enabled'] : true;
+		$confirmed = isset( $_POST['mcp_master_confirm'] ) && '1' === $_POST['mcp_master_confirm'];
+
+		$current = Repo::is_master_enabled();
+		if ( $desired === $current ) {
+			return __( 'No change to master toggle.', 'mcp-adapter' );
+		}
+
+		// Disabling requires the inner checkbox.
+		if ( ! $desired && ! $confirmed ) {
+			return __( 'Disabling personal-data filtering requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		Repo::set_master_enabled( $desired );
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.master_toggle.changed',
+			array(
+				'severity' => $desired ? 'info' : 'warn',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => $desired ? 'enabled' : 'disabled',
+			)
+		);
+
+		return $desired
+			? __( 'Personal-data filtering enabled.', 'mcp-adapter' )
+			: __( 'Personal-data filtering disabled. Bucket 1 secrets remain redacted regardless.', 'mcp-adapter' );
+	}
+
+	private static function handle_add_keyword(): string {
+		$keyword = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		if ( Repo::BUCKET_PAYMENT !== $bucket && Repo::BUCKET_CONTACT !== $bucket ) {
+			return __( 'Bucket must be 2 or 3.', 'mcp-adapter' );
+		}
+
+		$result = Repo::add_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'add_custom',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Keyword added.', 'mcp-adapter' )
+			: __( 'Keyword already present.', 'mcp-adapter' );
+	}
+
+	private static function handle_remove_custom_keyword(): string {
+		$keyword = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		$result = Repo::remove_custom_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove_custom',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Custom keyword removed.', 'mcp-adapter' )
+			: __( 'Keyword was not in the custom list.', 'mcp-adapter' );
+	}
+
+	private static function handle_remove_default_keyword(): string {
+		$keyword   = isset( $_POST['mcp_keyword'] ) ? (string) wp_unslash( $_POST['mcp_keyword'] ) : '';
+		$bucket    = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+		$confirmed = isset( $_POST['mcp_default_confirm'] ) && '1' === $_POST['mcp_default_confirm'];
+
+		// Bucket 2 default removal requires the in-form checkbox confirmation.
+		if ( Repo::BUCKET_PAYMENT === $bucket && ! $confirmed ) {
+			return __( 'Removing a Bucket 2 default keyword requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		$result = Repo::remove_default_keyword( $bucket, $keyword );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => Repo::BUCKET_PAYMENT === $bucket ? 'warn' : 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove_default',
+				'name'     => sanitize_key( $keyword ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Default keyword removed. Restore defaults to bring it back.', 'mcp-adapter' )
+			: __( 'Keyword was already removed.', 'mcp-adapter' );
+	}
+
+	private static function handle_restore_defaults(): string {
+		Repo::restore_defaults();
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.redaction_keywords.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'restore_defaults',
+			)
+		);
+
+		return __( 'Redaction lists restored to defaults.', 'mcp-adapter' );
+	}
+
+	private static function handle_set_exemption(): string {
+		$ability   = isset( $_POST['mcp_ability'] ) ? (string) wp_unslash( $_POST['mcp_ability'] ) : '';
+		$bucket    = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+		$confirmed = isset( $_POST['mcp_exempt_confirm'] ) && '1' === $_POST['mcp_exempt_confirm'];
+
+		if ( Repo::BUCKET_PAYMENT === $bucket && ! $confirmed ) {
+			return __( 'Exempting an ability from Bucket 2 requires confirming the warning checkbox.', 'mcp-adapter' );
+		}
+
+		$result = Repo::add_exemption( $bucket, $ability );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.ability_exemption.changed',
+			array(
+				'severity' => Repo::BUCKET_PAYMENT === $bucket ? 'warn' : 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'add',
+				'name'     => sanitize_text_field( $ability ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Exemption added.', 'mcp-adapter' )
+			: __( 'Ability was already exempt.', 'mcp-adapter' );
+	}
+
+	private static function handle_unset_exemption(): string {
+		$ability = isset( $_POST['mcp_ability'] ) ? (string) wp_unslash( $_POST['mcp_ability'] ) : '';
+		$bucket  = isset( $_POST['mcp_bucket'] ) ? (int) $_POST['mcp_bucket'] : 0;
+
+		$result = Repo::remove_exemption( $bucket, $ability );
+		if ( is_wp_error( $result ) ) {
+			return $result->get_error_message();
+		}
+
+		BoundaryEventEmitter::emit(
+			self::observability_handler(),
+			'boundary.ability_exemption.changed',
+			array(
+				'severity' => 'info',
+				'user_id'  => (int) get_current_user_id(),
+				'reason'   => 'remove',
+				'name'     => sanitize_text_field( $ability ),
+				'dimension' => 'bucket_' . $bucket,
+			)
+		);
+
+		return $result
+			? __( 'Exemption removed.', 'mcp-adapter' )
+			: __( 'Ability was not exempt.', 'mcp-adapter' );
+	}
+
+	private static function handle_trusted_proxy(): string {
+		$enabled   = isset( $_POST['mcp_proxy_enabled'] ) && '1' === $_POST['mcp_proxy_enabled'];
+		$mode      = isset( $_POST['mcp_proxy_mode'] ) ? sanitize_key( wp_unslash( $_POST['mcp_proxy_mode'] ) ) : Repo::PROXY_MODE_CLOUDFLARE;
+		$allowlist = isset( $_POST['mcp_proxy_allowlist'] ) ? (string) wp_unslash( $_POST['mcp_proxy_allowlist'] ) : '';
+		// Sanitize allowlist: keep one CIDR/IP per line, strip blanks/comments.
+		$lines = preg_split( "/\r?\n/", $allowlist ) ?: array();
+		$clean = array();
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+			if ( '' === $line || str_starts_with( $line, '#' ) ) {
+				continue;
+			}
+			$line = preg_replace( '/[^0-9a-fA-F:.\\/]/', '', $line ) ?? '';
+			if ( '' !== $line ) {
+				$clean[] = $line;
+			}
+		}
+		$allowlist = implode( "\n", $clean );
+
+		Repo::set_trusted_proxy_enabled( $enabled );
+		Repo::set_trusted_proxy_mode( $mode );
+		Repo::set_trusted_proxy_allowlist_raw( $allowlist );
+
+		return __( 'Trusted proxy settings saved.', 'mcp-adapter' );
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public static function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'MCP Safety Settings', 'mcp-adapter' ); ?></h1>
+			<p><?php esc_html_e( 'Controls the redaction filter that runs at the /mcp response boundary, plus trusted-proxy IP detection used by the rate limiter.', 'mcp-adapter' ); ?></p>
+
+			<?php if ( isset( $_GET['updated'] ) && '1' === $_GET['updated'] ) : ?>
+				<div class="notice notice-success is-dismissible">
+					<p><?php echo esc_html( isset( $_GET['msg'] ) ? rawurldecode( wp_unslash( (string) $_GET['msg'] ) ) : __( 'Settings saved.', 'mcp-adapter' ) ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<?php
+			self::render_master_toggle_section();
+			self::render_keyword_list_section();
+			self::render_exemptions_section();
+			self::render_trusted_proxy_section();
+			?>
+		</div>
+		<?php
+	}
+
+	private static function render_master_toggle_section(): void {
+		$enabled = Repo::is_master_enabled();
+		?>
+		<h2><?php esc_html_e( '1. Master Toggle', 'mcp-adapter' ); ?></h2>
+		<form method="post" action="" style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:16px;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="master_toggle" />
+
+			<label style="display:flex;align-items:flex-start;gap:8px;">
+				<input type="checkbox" name="mcp_master_enabled" value="1" <?php checked( $enabled ); ?> id="mcp-master-toggle" />
+				<span>
+					<strong><?php esc_html_e( 'Filter personal data and payment identifiers in AI responses', 'mcp-adapter' ); ?></strong><br>
+					<span style="color:#646970;font-size:13px;"><?php esc_html_e( 'Default ON. Bucket 1 secrets (passwords, API keys, tokens) are filtered regardless.', 'mcp-adapter' ); ?></span>
+				</span>
+			</label>
+
+			<div id="mcp-master-warning" style="margin-top:12px;<?php echo $enabled ? '' : 'display:none;'; ?>padding:12px;background:#fcf0f1;border-left:4px solid #d63638;">
+				<p style="margin:0 0 8px;font-weight:600;color:#d63638;">⚠️ <?php esc_html_e( 'Disabling personal-data and payment-identifier filtering', 'mcp-adapter' ); ?></p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<?php esc_html_e( 'When this is off, AI clients connected to your site will receive the full contents of every ability response — including email addresses, phone numbers, postal addresses, IP addresses, payment-related identifiers, and other personal data attached to your users and customers.', 'mcp-adapter' ); ?>
+				</p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<em><?php esc_html_e( 'Note: Authentication credentials, password hashes, API keys, and session tokens remain filtered regardless of this setting.', 'mcp-adapter' ); ?></em>
+				</p>
+				<p style="margin:0 0 8px;font-size:13px;">
+					<?php esc_html_e( 'If you handle personal data, payment data, or operate in a regulated industry, disabling personal-data filtering may put you out of compliance with GDPR, PCI-DSS, HIPAA, or similar laws.', 'mcp-adapter' ); ?>
+				</p>
+				<label style="display:flex;align-items:center;gap:6px;font-size:13px;">
+					<input type="checkbox" name="mcp_master_confirm" value="1" />
+					<?php esc_html_e( 'I understand and accept the risk. Disable personal-data filtering.', 'mcp-adapter' ); ?>
+				</label>
+			</div>
+
+			<p style="margin-top:12px;">
+				<?php submit_button( __( 'Save Master Toggle', 'mcp-adapter' ), 'primary', 'submit', false ); ?>
+			</p>
+		</form>
+		<script>
+		(function(){
+			var t = document.getElementById('mcp-master-toggle');
+			var w = document.getElementById('mcp-master-warning');
+			if (!t || !w) return;
+			function sync(){ w.style.display = t.checked ? 'none' : 'block'; }
+			t.addEventListener('change', sync);
+			sync();
+		})();
+		</script>
+		<?php
+	}
+
+	private static function render_keyword_list_section(): void {
+		?>
+		<h2><?php esc_html_e( '2. Redaction Keyword List', 'mcp-adapter' ); ?></h2>
+
+		<h3><?php esc_html_e( 'Bucket 1 — Secrets (always-on)', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'These secrets are always filtered. They cannot be disabled.', 'mcp-adapter' ); ?></p>
+		<div style="background:#f6f7f7;border:1px solid #dcdcde;border-radius:4px;padding:12px;max-width:780px;font-family:monospace;font-size:12px;line-height:1.6;">
+			<?php echo esc_html( implode( ', ', Repo::bucket1_default_keywords() ) ); ?>
+		</div>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Bucket 2 — Payment / Regulated Identifiers', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'Configurable via this admin UI ONLY. Cannot be weakened by AI.', 'mcp-adapter' ); ?></p>
+		<?php self::render_bucket_table( Repo::BUCKET_PAYMENT ); ?>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Bucket 3 — Contact PII / Access Labels', 'mcp-adapter' ); ?></h3>
+		<p style="color:#646970;"><?php esc_html_e( 'Configurable via admin UI or AI ability. Default keyword removal does not require an extra warning here (matches the AI confirmation friction).', 'mcp-adapter' ); ?></p>
+		<?php self::render_bucket_table( Repo::BUCKET_CONTACT ); ?>
+
+		<h3 style="margin-top:24px;"><?php esc_html_e( 'Add a custom keyword', 'mcp-adapter' ); ?></h3>
+		<form method="post" action="" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="add_keyword" />
+			<input type="text" name="mcp_keyword" placeholder="e.g. gravity_forms_secret" required
+				style="flex:1;min-width:240px;padding:6px 8px;font-family:monospace;" />
+			<select name="mcp_bucket">
+				<option value="3"><?php esc_html_e( 'Bucket 3 (contact PII)', 'mcp-adapter' ); ?></option>
+				<option value="2"><?php esc_html_e( 'Bucket 2 (payment / regulated)', 'mcp-adapter' ); ?></option>
+			</select>
+			<?php submit_button( __( 'Add', 'mcp-adapter' ), 'secondary', 'submit', false ); ?>
+		</form>
+		<p style="color:#646970;font-size:12px;margin-top:6px;">
+			<?php esc_html_e( 'Bucket 1 is hardcoded. Custom keywords go to Bucket 2 or Bucket 3 only.', 'mcp-adapter' ); ?>
+		</p>
+
+		<form method="post" action="" style="margin-top:16px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="restore_defaults" />
+			<?php submit_button( __( 'Restore default redaction lists', 'mcp-adapter' ), 'secondary', 'submit', false, array( 'onclick' => "return confirm('Restore both Bucket 2 and Bucket 3 to factory defaults? Custom additions and removed defaults will be cleared.')" ) ); ?>
+		</form>
+		<?php
+	}
+
+	private static function render_bucket_table( int $bucket ): void {
+		$active   = Repo::get_active_keywords( $bucket );
+		$customs  = array_flip( Repo::get_custom_keywords( $bucket ) );
+		$defaults = Repo::BUCKET_PAYMENT === $bucket
+			? Repo::bucket2_default_keywords()
+			: Repo::bucket3_default_keywords();
+		$default_set = array_flip( array_map( 'strtolower', $defaults ) );
+
+		// Build merged list: active + recently-removed defaults so the operator can see both states.
+		$removed_defaults = Repo::get_removed_defaults( $bucket );
+
+		?>
+		<table class="widefat striped" style="max-width:780px;">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Keyword', 'mcp-adapter' ); ?></th>
+					<th style="width:120px;"><?php esc_html_e( 'Source', 'mcp-adapter' ); ?></th>
+					<th style="width:200px;"><?php esc_html_e( 'Action', 'mcp-adapter' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $active as $kw ) : ?>
+					<tr>
+						<td><code><?php echo esc_html( $kw ); ?></code></td>
+						<td>
+							<?php
+							if ( isset( $customs[ $kw ] ) ) {
+								esc_html_e( 'Custom', 'mcp-adapter' );
+							} elseif ( isset( $default_set[ $kw ] ) ) {
+								esc_html_e( 'Default', 'mcp-adapter' );
+							} else {
+								esc_html_e( 'Active', 'mcp-adapter' );
+							}
+							?>
+						</td>
+						<td>
+							<?php if ( isset( $customs[ $kw ] ) ) : ?>
+								<form method="post" action="" style="margin:0;">
+									<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+									<input type="hidden" name="mcp_safety_action" value="remove_custom_keyword" />
+									<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+									<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+									<button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove (custom)', 'mcp-adapter' ); ?></button>
+								</form>
+							<?php elseif ( isset( $default_set[ $kw ] ) ) : ?>
+								<?php if ( Repo::BUCKET_PAYMENT === $bucket ) : ?>
+									<form method="post" action="" style="margin:0;" onsubmit="return confirm('Remove default Bucket 2 keyword \'<?php echo esc_js( $kw ); ?>\'? This exposes payment / regulated identifiers in matching field names.')">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="remove_default_keyword" />
+										<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+										<input type="hidden" name="mcp_default_confirm" value="1" />
+										<button type="submit" class="button-link-delete">
+											⚠️ <?php esc_html_e( 'Remove default (warning)', 'mcp-adapter' ); ?>
+										</button>
+									</form>
+								<?php else : ?>
+									<form method="post" action="" style="margin:0;">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="remove_default_keyword" />
+										<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+										<button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove default', 'mcp-adapter' ); ?></button>
+									</form>
+								<?php endif; ?>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				<?php foreach ( $removed_defaults as $kw ) : ?>
+					<tr style="opacity:0.55;">
+						<td><code style="text-decoration:line-through;"><?php echo esc_html( $kw ); ?></code></td>
+						<td><em><?php esc_html_e( 'Default removed', 'mcp-adapter' ); ?></em></td>
+						<td>
+							<form method="post" action="" style="margin:0;">
+								<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+								<input type="hidden" name="mcp_safety_action" value="add_keyword" />
+								<input type="hidden" name="mcp_keyword" value="<?php echo esc_attr( $kw ); ?>" />
+								<input type="hidden" name="mcp_bucket" value="<?php echo esc_attr( (string) $bucket ); ?>" />
+								<button type="submit" class="button"><?php esc_html_e( 'Restore', 'mcp-adapter' ); ?></button>
+							</form>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				<?php if ( empty( $active ) && empty( $removed_defaults ) ) : ?>
+					<tr><td colspan="3"><em><?php esc_html_e( 'No keywords configured.', 'mcp-adapter' ); ?></em></td></tr>
+				<?php endif; ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	private static function render_exemptions_section(): void {
+		$abilities  = self::list_public_abilities();
+		$exempt_b3  = array_flip( Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+		$exempt_b2  = array_flip( Repo::get_exemptions( Repo::BUCKET_PAYMENT ) );
+		?>
+		<h2><?php esc_html_e( '3. Per-Ability Exemptions', 'mcp-adapter' ); ?></h2>
+		<p><?php esc_html_e( 'Exempt specific abilities from redaction. Bucket 2 exemptions can only be granted from this admin UI.', 'mcp-adapter' ); ?></p>
+
+		<div style="display:flex;gap:24px;flex-wrap:wrap;max-width:1200px;">
+			<div style="flex:1;min-width:380px;">
+				<h3><?php esc_html_e( 'Exempt from Bucket 3 (contact PII)', 'mcp-adapter' ); ?></h3>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th style="width:60px;"><?php esc_html_e( 'Exempt', 'mcp-adapter' ); ?></th>
+							<th><?php esc_html_e( 'Ability', 'mcp-adapter' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $abilities as $name ) : ?>
+							<?php $is_exempt = isset( $exempt_b3[ $name ] ); ?>
+							<tr>
+								<td>
+									<form method="post" action="" style="margin:0;">
+										<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+										<input type="hidden" name="mcp_safety_action" value="<?php echo $is_exempt ? 'unset_exemption' : 'set_exemption'; ?>" />
+										<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+										<input type="hidden" name="mcp_bucket" value="3" />
+										<button type="submit" class="button" style="padding:1px 8px;">
+											<?php echo $is_exempt ? esc_html__( 'Yes ✓', 'mcp-adapter' ) : esc_html__( 'No', 'mcp-adapter' ); ?>
+										</button>
+									</form>
+								</td>
+								<td><code><?php echo esc_html( $name ); ?></code></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+
+			<div style="flex:1;min-width:380px;">
+				<h3><?php esc_html_e( 'Exempt from Bucket 2 (payment / regulated)', 'mcp-adapter' ); ?></h3>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th style="width:60px;"><?php esc_html_e( 'Exempt', 'mcp-adapter' ); ?></th>
+							<th><?php esc_html_e( 'Ability', 'mcp-adapter' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $abilities as $name ) : ?>
+							<?php $is_exempt = isset( $exempt_b2[ $name ] ); ?>
+							<tr>
+								<td>
+									<?php if ( $is_exempt ) : ?>
+										<form method="post" action="" style="margin:0;">
+											<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+											<input type="hidden" name="mcp_safety_action" value="unset_exemption" />
+											<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+											<input type="hidden" name="mcp_bucket" value="2" />
+											<button type="submit" class="button" style="padding:1px 8px;"><?php esc_html_e( 'Yes ✓', 'mcp-adapter' ); ?></button>
+										</form>
+									<?php else : ?>
+										<form method="post" action="" style="margin:0;"
+											onsubmit="return confirm('Are you sure? Exempting <?php echo esc_js( $name ); ?> from Bucket 2 will expose card_number, ssn, etc. for this specific ability.')">
+											<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+											<input type="hidden" name="mcp_safety_action" value="set_exemption" />
+											<input type="hidden" name="mcp_ability" value="<?php echo esc_attr( $name ); ?>" />
+											<input type="hidden" name="mcp_bucket" value="2" />
+											<input type="hidden" name="mcp_exempt_confirm" value="1" />
+											<button type="submit" class="button" style="padding:1px 8px;">⚠️ <?php esc_html_e( 'No', 'mcp-adapter' ); ?></button>
+										</form>
+									<?php endif; ?>
+								</td>
+								<td><code><?php echo esc_html( $name ); ?></code></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+		</div>
+		<?php
+	}
+
+	private static function render_trusted_proxy_section(): void {
+		$enabled   = Repo::is_trusted_proxy_enabled();
+		$mode      = Repo::get_trusted_proxy_mode();
+		$allowlist = Repo::get_trusted_proxy_allowlist_raw();
+		?>
+		<h2><?php esc_html_e( '4. Trusted Proxy', 'mcp-adapter' ); ?></h2>
+		<p><?php esc_html_e( 'Configure how the rate limiter detects the real client IP when your site is behind a CDN or load balancer.', 'mcp-adapter' ); ?></p>
+
+		<form method="post" action="" style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:16px;max-width:780px;">
+			<?php wp_nonce_field( self::NONCE_FORM, 'mcp_safety_nonce' ); ?>
+			<input type="hidden" name="mcp_safety_action" value="trusted_proxy" />
+
+			<label style="display:flex;align-items:center;gap:8px;">
+				<input type="checkbox" name="mcp_proxy_enabled" value="1" <?php checked( $enabled ); ?> />
+				<strong><?php esc_html_e( 'Enable trusted proxy IP detection', 'mcp-adapter' ); ?></strong>
+			</label>
+
+			<fieldset style="margin-top:16px;border:1px solid #dcdcde;border-radius:4px;padding:12px;">
+				<legend style="padding:0 6px;font-weight:600;"><?php esc_html_e( 'Mode', 'mcp-adapter' ); ?></legend>
+
+				<label style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+					<input type="radio" name="mcp_proxy_mode" value="cloudflare" <?php checked( $mode, Repo::PROXY_MODE_CLOUDFLARE ); ?> />
+					<span>
+						<strong><?php esc_html_e( 'Cloudflare preset', 'mcp-adapter' ); ?></strong><br>
+						<span style="color:#646970;font-size:13px;">
+							<?php esc_html_e( 'Adapter accepts CF-Connecting-IP only when REMOTE_ADDR is a Cloudflare edge IP.', 'mcp-adapter' ); ?>
+						</span>
+					</span>
+				</label>
+
+				<label style="display:flex;align-items:flex-start;gap:8px;">
+					<input type="radio" name="mcp_proxy_mode" value="custom" <?php checked( $mode, Repo::PROXY_MODE_CUSTOM ); ?> />
+					<span style="flex:1;">
+						<strong><?php esc_html_e( 'Custom IP allowlist', 'mcp-adapter' ); ?></strong><br>
+						<span style="color:#646970;font-size:13px;"><?php esc_html_e( 'One IP or CIDR range per line. Lines starting with # are ignored.', 'mcp-adapter' ); ?></span><br>
+						<textarea name="mcp_proxy_allowlist" rows="4" style="width:100%;font-family:monospace;font-size:12px;margin-top:6px;"
+							placeholder="10.0.0.0/8&#10;192.168.1.1"><?php echo esc_textarea( $allowlist ); ?></textarea>
+					</span>
+				</label>
+			</fieldset>
+
+			<p style="margin-top:12px;font-size:12px;color:#646970;">
+				<?php esc_html_e( 'Why this matters: when the rate limiter cannot trust X-Forwarded-For, attackers behind the CDN can spoof the client IP and bypass rate limits. The allowlist ensures only requests originating from your CDN edge are trusted.', 'mcp-adapter' ); ?>
+			</p>
+
+			<?php submit_button( __( 'Save Trusted Proxy Settings', 'mcp-adapter' ) ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * MCP-public ability names, sorted, namespaced.
+	 *
+	 * @return string[]
+	 */
+	private static function list_public_abilities(): array {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return array();
+		}
+		$abilities = wp_get_abilities();
+		$names     = array();
+		foreach ( $abilities as $ability ) {
+			if ( ! self::is_mcp_public( $ability ) ) {
+				continue;
+			}
+			$names[] = $ability->get_name();
+		}
+		sort( $names );
+		return $names;
+	}
+
+	private static function is_mcp_public( \WP_Ability $ability ): bool {
+		if ( method_exists( $ability, 'get_show_in_rest' ) ) {
+			$show = $ability->get_show_in_rest();
+			if ( null !== $show ) {
+				return (bool) $show;
+			}
+		}
+		$meta = $ability->get_meta();
+		if ( isset( $meta['show_in_rest'] ) ) {
+			return (bool) $meta['show_in_rest'];
+		}
+		return (bool) ( $meta['mcp']['public'] ?? false );
+	}
+
+	/**
+	 * Best-effort observability handler from the live adapter, or null.
+	 *
+	 * Settings writes happen in admin context where the MCP request loop
+	 * isn't running, so the typed handler may not be wired. The action
+	 * hook (Path 2) still fires regardless — that is the path DB-1's
+	 * BoundaryEventLogger uses anyway.
+	 */
+	private static function observability_handler(): ?\WickedEvolutions\McpAdapter\Infrastructure\Observability\Contracts\McpObservabilityHandlerInterface {
+		return null;
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,7 +15,9 @@ declare(strict_types = 1);
 
 namespace WickedEvolutions\McpAdapter;
 
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
 use WickedEvolutions\McpAdapter\Admin\AbilitySettingsPage;
+use WickedEvolutions\McpAdapter\Admin\SafetySettingsPage;
 use WickedEvolutions\McpAdapter\Core\McpAdapter;
 
 /**
@@ -61,10 +63,14 @@ final class Plugin {
 
 		McpAdapter::instance();
 
-		// Register admin settings page for ability permissions.
+		// Register admin settings pages.
 		if ( is_admin() ) {
 			AbilitySettingsPage::register();
+			SafetySettingsPage::register();
 		}
+
+		// Register safety-settings abilities inside the Abilities API init hook.
+		add_action( 'wp_abilities_api_init', array( SettingsAbilities::class, 'register_all' ) );
 	}
 
 	/**

--- a/src/Settings/ConfirmationTokenStore.php
+++ b/src/Settings/ConfirmationTokenStore.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * In-chat 1/2 confirmation token store.
+ *
+ * Mints a one-time token bound to (session, ability, params hash). The
+ * token is stored as a WP transient with ~60s TTL; consume_token() deletes
+ * it on first valid use. Tokens are NOT proof of human consent — a malicious
+ * AI client could synthesise a "1" reply. They prevent accidental weakening.
+ *
+ * Cryptographic-trust paths (Bucket 2, master toggle off) intentionally bypass
+ * this mechanism and require the Admin UI checkbox.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Settings;
+
+/**
+ * Mint and consume confirmation tokens for safety-weakening abilities.
+ */
+final class ConfirmationTokenStore {
+
+	public const TRANSIENT_PREFIX = 'abilities_mcp_confirm_';
+	public const TTL_SECONDS      = 60;
+
+	/**
+	 * Mint a new token bound to (session, ability, params).
+	 *
+	 * Returns the opaque token string. Stored payload includes the binding
+	 * tuple so consume_token() can re-verify the call shape on redemption.
+	 *
+	 * @param string $session_id  Stable session identifier (MCP session, falls back to user+ip).
+	 * @param string $ability     Ability name being weakened.
+	 * @param array  $params      Sanitized scalar params (canonicalised before hashing).
+	 *
+	 * @return string The token.
+	 */
+	public static function mint( string $session_id, string $ability, array $params ): string {
+		$token = wp_generate_password( 32, false, false );
+
+		$payload = array(
+			'session_id'  => $session_id,
+			'ability'     => $ability,
+			'params_hash' => self::params_hash( $params ),
+			'created_at'  => time(),
+		);
+
+		set_transient( self::TRANSIENT_PREFIX . $token, $payload, self::TTL_SECONDS );
+
+		return $token;
+	}
+
+	/**
+	 * Consume a token. Returns true on a valid+matching one-time redemption,
+	 * \WP_Error otherwise. Always deletes the transient on lookup so a token
+	 * cannot be replayed.
+	 *
+	 * Returns specific error codes so callers can log fine-grained reasons:
+	 *   - missing_token        — no token presented
+	 *   - token_unknown        — transient expired or never minted
+	 *   - session_mismatch     — token bound to different session
+	 *   - ability_mismatch     — token minted for a different ability
+	 *   - params_mismatch      — same ability but different parameters
+	 *
+	 * @param string|null $token
+	 * @param string      $session_id
+	 * @param string      $ability
+	 * @param array       $params
+	 *
+	 * @return true|\WP_Error
+	 */
+	public static function consume( ?string $token, string $session_id, string $ability, array $params ) {
+		if ( ! is_string( $token ) || '' === $token ) {
+			return new \WP_Error( 'missing_token', 'No confirmation token presented.' );
+		}
+
+		$key     = self::TRANSIENT_PREFIX . $token;
+		$payload = get_transient( $key );
+
+		// Always invalidate on any lookup attempt — one-time only.
+		delete_transient( $key );
+
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'token_unknown', 'Confirmation token is unknown or has expired.' );
+		}
+
+		if ( ( $payload['session_id'] ?? '' ) !== $session_id ) {
+			return new \WP_Error( 'session_mismatch', 'Confirmation token belongs to a different session.' );
+		}
+		if ( ( $payload['ability'] ?? '' ) !== $ability ) {
+			return new \WP_Error( 'ability_mismatch', 'Confirmation token was minted for a different ability.' );
+		}
+		if ( ( $payload['params_hash'] ?? '' ) !== self::params_hash( $params ) ) {
+			return new \WP_Error( 'params_mismatch', 'Confirmation token does not match the call parameters.' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Best-effort session identifier used to bind tokens.
+	 *
+	 * MCP transports may set `Mcp-Session-Id`; if absent we fall back to
+	 * (user_id|ip) so a fresh user has a stable enough binding for the
+	 * 60-second window.
+	 */
+	public static function current_session_id(): string {
+		$header = isset( $_SERVER['HTTP_MCP_SESSION_ID'] ) ? (string) $_SERVER['HTTP_MCP_SESSION_ID'] : '';
+		if ( '' !== $header ) {
+			return substr( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $header ) ?? '', 0, 64 );
+		}
+
+		$user_id = function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0;
+		$ip      = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : '';
+		return 'fallback-' . $user_id . '-' . substr( md5( $ip ), 0, 16 );
+	}
+
+	/**
+	 * Stable hash of the canonicalised params array.
+	 */
+	private static function params_hash( array $params ): string {
+		// Lower-case keys + json-encode with sorted keys for determinism.
+		$normalised = array();
+		foreach ( $params as $k => $v ) {
+			$normalised[ strtolower( (string) $k ) ] = is_string( $v ) ? trim( $v ) : $v;
+		}
+		ksort( $normalised );
+		$json = wp_json_encode( $normalised );
+		return hash( 'sha256', $json !== false ? $json : '' );
+	}
+}

--- a/src/Settings/SafetySettingsRepository.php
+++ b/src/Settings/SafetySettingsRepository.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Safety settings repository — read/write the option keys configured by
+ * the Safety Settings UI and the AI-callable settings abilities.
+ *
+ * Option key contract (DB-2 + DB-3 share these):
+ *
+ *   abilities_mcp_redaction_master_enabled  (bool, default true)
+ *   abilities_mcp_redaction_keywords        (string[], custom Bucket 3 additions)
+ *   abilities_mcp_bucket2_keywords          (string[], custom Bucket 2 additions — written here, read by DB-2 after rebase)
+ *   abilities_mcp_bucket3_exemptions        (string[], ability names exempt from Bucket 3)
+ *   abilities_mcp_bucket2_exemptions        (string[], ability names exempt from Bucket 2 — Admin-UI only)
+ *   abilities_mcp_trusted_proxy_enabled     (bool, default false)
+ *   abilities_mcp_trusted_proxy_mode        (string, 'cloudflare' | 'custom', default 'cloudflare')
+ *   abilities_mcp_trusted_proxy_allowlist   (string, newline-separated CIDR list)
+ *
+ * Bucket 2 weakening (remove default keyword, exempt ability) and the master
+ * toggle off are Admin-UI-only — abilities cannot reach those write paths.
+ *
+ * Copyright (C) 2026 Influencentricity | Wicked Evolutions
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Settings;
+
+/**
+ * Single source of truth for safety-setting option I/O.
+ *
+ * Hardcoded Bucket 1 + Bucket 2 default lists live here too so the UI and
+ * abilities can render them without depending on DB-2's RedactionConfig
+ * before that branch merges. Once DB-2 is integrated, RedactionConfig will
+ * remain authoritative for the runtime filter — this class stays the
+ * authoritative configuration surface (UI/abilities), and the two stay
+ * aligned by referencing the same option keys.
+ */
+final class SafetySettingsRepository {
+
+	public const OPTION_MASTER_ENABLED         = 'abilities_mcp_redaction_master_enabled';
+	public const OPTION_BUCKET3_KEYWORDS       = 'abilities_mcp_redaction_keywords';
+	public const OPTION_BUCKET2_KEYWORDS       = 'abilities_mcp_bucket2_keywords';
+	public const OPTION_BUCKET3_EXEMPTIONS     = 'abilities_mcp_bucket3_exemptions';
+	public const OPTION_BUCKET2_EXEMPTIONS     = 'abilities_mcp_bucket2_exemptions';
+	public const OPTION_TRUSTED_PROXY_ENABLED  = 'abilities_mcp_trusted_proxy_enabled';
+	public const OPTION_TRUSTED_PROXY_MODE     = 'abilities_mcp_trusted_proxy_mode';
+	public const OPTION_TRUSTED_PROXY_ALLOWLIST = 'abilities_mcp_trusted_proxy_allowlist';
+
+	public const BUCKET_SECRETS = 1;
+	public const BUCKET_PAYMENT = 2;
+	public const BUCKET_CONTACT = 3;
+
+	public const PROXY_MODE_CLOUDFLARE = 'cloudflare';
+	public const PROXY_MODE_CUSTOM     = 'custom';
+
+	/**
+	 * Bucket 1 — always-on secrets. Hardcoded; not configurable.
+	 *
+	 * Mirrors DB-2's RedactionConfig::bucket1_keywords(). Kept in sync by
+	 * convention; both lists must agree at integration time.
+	 *
+	 * @return string[]
+	 */
+	public static function bucket1_default_keywords(): array {
+		return array(
+			'password', 'pass', 'passwd', 'user_pass', 'user_password',
+			'db_password', 'database_password', 'smtp_password',
+			'imap_password', 'pop_password', 'ftp_password', 'ssh_password',
+			'api_key', 'api_secret', 'consumer_key', 'consumer_secret',
+			'client_secret', 'client_key', 'private_key', 'license_key',
+			'serial_key', 'activation_key', 'app_key', 'app_secret',
+			'webhook_secret', 'webhook_key', 'signing_key', 'encryption_key',
+			'master_key', 'secret_key',
+			'access_token', 'refresh_token', 'bearer_token', 'auth_token',
+			'authentication_token', 'oauth_token', 'oauth_secret',
+			'session_token', 'session_tokens', 'session_secret', 'csrf_token',
+			'nonce_token', 'id_token', 'personal_access_token',
+			'auth_key', 'secure_auth_key', 'logged_in_key', 'nonce_key',
+			'auth_salt', 'secure_auth_salt', 'logged_in_salt', 'nonce_salt',
+		);
+	}
+
+	/**
+	 * Bucket 2 — payment + regulated identifiers (default list).
+	 *
+	 * @return string[]
+	 */
+	public static function bucket2_default_keywords(): array {
+		return array(
+			'card_number', 'cardnumber', 'cc_number', 'pan',
+			'cvv', 'cvc', 'cv2', 'card_cvv', 'card_cvc', 'card_pin',
+			'ssn', 'social_security_number', 'social_security',
+			'tax_id', 'ein', 'tin', 'vat_number', 'vat_id',
+		);
+	}
+
+	/**
+	 * Bucket 3 — contact PII / access labels (default list).
+	 *
+	 * @return string[]
+	 */
+	public static function bucket3_default_keywords(): array {
+		return array(
+			'email', 'user_email', 'customer_email', 'contact_email',
+			'billing_email', 'shipping_email', 'payment_email',
+			'phone', 'phone_number', 'mobile', 'mobile_number',
+			'tel', 'telephone', 'billing_phone', 'shipping_phone', 'contact_phone',
+			'address', 'street_address', 'address_line_1', 'address_line_2',
+			'street', 'street1', 'street2',
+			'billing_address', 'shipping_address',
+			'billing_address_1', 'shipping_address_1',
+			'user_login', 'username',
+			'ip', 'ip_address', 'user_ip', 'client_ip', 'remote_ip', 'last_ip',
+			'birthdate', 'birth_date', 'date_of_birth', 'dob',
+			'public_key',
+		);
+	}
+
+	/**
+	 * Removed-defaults storage option for Bucket 3.
+	 *
+	 * Default Bucket 3 keywords cannot be deleted; they can be marked as
+	 * removed so RedactionConfig::bucket3_keywords() can subtract them via
+	 * the `abilities_mcp_redaction_keywords` filter. Removal is reversible
+	 * by the operator (Restore defaults).
+	 */
+	public const OPTION_BUCKET3_REMOVED_DEFAULTS = 'abilities_mcp_redaction_keywords_removed_defaults';
+
+	/**
+	 * Removed-defaults storage option for Bucket 2.
+	 *
+	 * @see self::OPTION_BUCKET3_REMOVED_DEFAULTS
+	 */
+	public const OPTION_BUCKET2_REMOVED_DEFAULTS = 'abilities_mcp_bucket2_keywords_removed_defaults';
+
+	/**
+	 * Whether the master redaction toggle is on.
+	 */
+	public static function is_master_enabled(): bool {
+		return (bool) get_option( self::OPTION_MASTER_ENABLED, true );
+	}
+
+	/**
+	 * Set master toggle.
+	 *
+	 * Admin-UI-only callers should use this directly. Abilities never call
+	 * this with `$enabled = false` — that path requires the in-UI checkbox.
+	 *
+	 * @param bool $enabled
+	 */
+	public static function set_master_enabled( bool $enabled ): void {
+		update_option( self::OPTION_MASTER_ENABLED, $enabled );
+	}
+
+	/**
+	 * Custom keywords added by the operator for the given bucket.
+	 *
+	 * Bucket 1 always returns []: it is hardcoded and not extendable from
+	 * the operator surface.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_custom_keywords( int $bucket ): array {
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return array();
+		}
+		$option = self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_KEYWORDS
+			: self::OPTION_BUCKET3_KEYWORDS;
+
+		$value = get_option( $option, array() );
+		return self::clean_keyword_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Removed-defaults set for a bucket (operator-removed default keywords).
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_removed_defaults( int $bucket ): array {
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return array();
+		}
+		$option = self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_REMOVED_DEFAULTS
+			: self::OPTION_BUCKET3_REMOVED_DEFAULTS;
+
+		$value = get_option( $option, array() );
+		return self::clean_keyword_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Active keyword list for the given bucket: defaults minus removed-defaults
+	 * plus custom additions, deduped and lower-cased.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_active_keywords( int $bucket ): array {
+		switch ( $bucket ) {
+			case self::BUCKET_SECRETS:
+				$defaults = self::bucket1_default_keywords();
+				$customs  = array();
+				$removed  = array();
+				break;
+			case self::BUCKET_PAYMENT:
+				$defaults = self::bucket2_default_keywords();
+				$customs  = self::get_custom_keywords( self::BUCKET_PAYMENT );
+				$removed  = self::get_removed_defaults( self::BUCKET_PAYMENT );
+				break;
+			case self::BUCKET_CONTACT:
+				$defaults = self::bucket3_default_keywords();
+				$customs  = self::get_custom_keywords( self::BUCKET_CONTACT );
+				$removed  = self::get_removed_defaults( self::BUCKET_CONTACT );
+				break;
+			default:
+				return array();
+		}
+
+		$removed_set = array_flip( array_map( 'strtolower', $removed ) );
+		$active      = array();
+		foreach ( $defaults as $kw ) {
+			if ( ! isset( $removed_set[ strtolower( $kw ) ] ) ) {
+				$active[] = $kw;
+			}
+		}
+		foreach ( $customs as $kw ) {
+			$active[] = $kw;
+		}
+		return self::clean_keyword_list( $active );
+	}
+
+	/**
+	 * Add a custom keyword to a bucket. Returns true if newly added.
+	 *
+	 * Strengthening operation — no friction. Bucket 1 is rejected.
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function add_custom_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+		if ( self::BUCKET_SECRETS === $bucket ) {
+			return new \WP_Error( 'bucket1_locked', 'Bucket 1 is hardcoded and cannot accept custom keywords.' );
+		}
+		if ( self::BUCKET_PAYMENT !== $bucket && self::BUCKET_CONTACT !== $bucket ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		// If this keyword is currently a removed default, restoring it is the right move.
+		$removed = self::get_removed_defaults( $bucket );
+		$removed_index = array_search( $keyword, array_map( 'strtolower', $removed ), true );
+		if ( false !== $removed_index ) {
+			unset( $removed[ $removed_index ] );
+			self::write_keyword_option( self::removed_defaults_option( $bucket ), array_values( $removed ) );
+			return true;
+		}
+
+		// Already present (default or custom)? No-op success.
+		$active = array_flip( self::get_active_keywords( $bucket ) );
+		if ( isset( $active[ $keyword ] ) ) {
+			return false;
+		}
+
+		$customs   = self::get_custom_keywords( $bucket );
+		$customs[] = $keyword;
+		self::write_keyword_option( self::custom_keywords_option( $bucket ), $customs );
+		return true;
+	}
+
+	/**
+	 * Remove a keyword the operator previously added (custom). Returns true
+	 * if a custom entry was removed; false if no matching custom entry.
+	 *
+	 * Reversal of the operator's own work — no friction. Does not touch
+	 * default-keyword removals (those go through remove_default_*).
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_custom_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+		if ( self::BUCKET_PAYMENT !== $bucket && self::BUCKET_CONTACT !== $bucket ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		$customs = self::get_custom_keywords( $bucket );
+		$lower   = array_map( 'strtolower', $customs );
+		$index   = array_search( $keyword, $lower, true );
+		if ( false === $index ) {
+			return false;
+		}
+		unset( $customs[ $index ] );
+		self::write_keyword_option( self::custom_keywords_option( $bucket ), array_values( $customs ) );
+		return true;
+	}
+
+	/**
+	 * Mark a default keyword as removed for the given bucket. Returns true
+	 * if newly removed.
+	 *
+	 * Bucket 3 path: friction = in-chat 1/2 confirmation token (enforced by ability).
+	 * Bucket 2 path: Admin-UI only — abilities must NOT call this with $bucket=2.
+	 *
+	 * Returns WP_Error on invalid bucket / non-default keyword / empty.
+	 *
+	 * @param int    $bucket
+	 * @param string $keyword
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_default_keyword( int $bucket, string $keyword ) {
+		$keyword = self::sanitize_keyword( $keyword );
+		if ( '' === $keyword ) {
+			return new \WP_Error( 'empty_keyword', 'Keyword must be a non-empty string.' );
+		}
+
+		if ( self::BUCKET_PAYMENT === $bucket ) {
+			$defaults = self::bucket2_default_keywords();
+		} elseif ( self::BUCKET_CONTACT === $bucket ) {
+			$defaults = self::bucket3_default_keywords();
+		} else {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+
+		if ( ! in_array( $keyword, array_map( 'strtolower', $defaults ), true ) ) {
+			return new \WP_Error( 'not_a_default', sprintf( 'Keyword "%s" is not a default in bucket %d. Use remove_custom_keyword instead.', $keyword, $bucket ) );
+		}
+
+		$removed = self::get_removed_defaults( $bucket );
+		if ( in_array( $keyword, array_map( 'strtolower', $removed ), true ) ) {
+			return false;
+		}
+		$removed[] = $keyword;
+		self::write_keyword_option( self::removed_defaults_option( $bucket ), $removed );
+		return true;
+	}
+
+	/**
+	 * Restore Bucket 2 + Bucket 3 lists to factory defaults.
+	 *
+	 * Clears custom additions and removed-defaults for both buckets.
+	 */
+	public static function restore_defaults(): void {
+		delete_option( self::OPTION_BUCKET3_KEYWORDS );
+		delete_option( self::OPTION_BUCKET2_KEYWORDS );
+		delete_option( self::OPTION_BUCKET3_REMOVED_DEFAULTS );
+		delete_option( self::OPTION_BUCKET2_REMOVED_DEFAULTS );
+	}
+
+	/**
+	 * Per-ability exemption list for the given bucket.
+	 *
+	 * @param int $bucket
+	 * @return string[]
+	 */
+	public static function get_exemptions( int $bucket ): array {
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return array();
+		}
+		$value = get_option( $option, array() );
+		return self::clean_ability_list( is_array( $value ) ? $value : array() );
+	}
+
+	/**
+	 * Add an ability to a bucket's exemption list. Returns true if newly added.
+	 *
+	 * Bucket 3 path: friction = in-chat 1/2 confirmation token (enforced by ability).
+	 * Bucket 2 path: Admin-UI only — abilities must NOT call this with $bucket=2.
+	 *
+	 * @param int    $bucket
+	 * @param string $ability_name
+	 * @return bool|\WP_Error
+	 */
+	public static function add_exemption( int $bucket, string $ability_name ) {
+		$ability_name = self::sanitize_ability_name( $ability_name );
+		if ( '' === $ability_name ) {
+			return new \WP_Error( 'empty_ability', 'Ability name must be a non-empty string.' );
+		}
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+		$current = self::get_exemptions( $bucket );
+		if ( in_array( $ability_name, $current, true ) ) {
+			return false;
+		}
+		$current[] = $ability_name;
+		update_option( $option, array_values( array_unique( $current ) ) );
+		return true;
+	}
+
+	/**
+	 * Remove an ability from a bucket's exemption list. Returns true if it was present.
+	 *
+	 * Strengthening operation — no friction.
+	 *
+	 * @param int    $bucket
+	 * @param string $ability_name
+	 * @return bool|\WP_Error
+	 */
+	public static function remove_exemption( int $bucket, string $ability_name ) {
+		$ability_name = self::sanitize_ability_name( $ability_name );
+		if ( '' === $ability_name ) {
+			return new \WP_Error( 'empty_ability', 'Ability name must be a non-empty string.' );
+		}
+		$option = self::exemptions_option( $bucket );
+		if ( null === $option ) {
+			return new \WP_Error( 'invalid_bucket', 'Bucket must be 2 or 3.' );
+		}
+		$current = self::get_exemptions( $bucket );
+		$filtered = array_values( array_filter( $current, static fn( $name ) => $name !== $ability_name ) );
+		if ( count( $filtered ) === count( $current ) ) {
+			return false;
+		}
+		update_option( $option, $filtered );
+		return true;
+	}
+
+	// Trusted proxy ------------------------------------------------------
+
+	public static function is_trusted_proxy_enabled(): bool {
+		return (bool) get_option( self::OPTION_TRUSTED_PROXY_ENABLED, false );
+	}
+
+	public static function set_trusted_proxy_enabled( bool $enabled ): void {
+		update_option( self::OPTION_TRUSTED_PROXY_ENABLED, $enabled );
+	}
+
+	public static function get_trusted_proxy_mode(): string {
+		$value = (string) get_option( self::OPTION_TRUSTED_PROXY_MODE, self::PROXY_MODE_CLOUDFLARE );
+		return self::PROXY_MODE_CUSTOM === $value ? self::PROXY_MODE_CUSTOM : self::PROXY_MODE_CLOUDFLARE;
+	}
+
+	public static function set_trusted_proxy_mode( string $mode ): void {
+		$mode = self::PROXY_MODE_CUSTOM === $mode ? self::PROXY_MODE_CUSTOM : self::PROXY_MODE_CLOUDFLARE;
+		update_option( self::OPTION_TRUSTED_PROXY_MODE, $mode );
+	}
+
+	/**
+	 * Stored allowlist as plain newline-delimited text (for round-trip in textarea).
+	 */
+	public static function get_trusted_proxy_allowlist_raw(): string {
+		return (string) get_option( self::OPTION_TRUSTED_PROXY_ALLOWLIST, '' );
+	}
+
+	public static function set_trusted_proxy_allowlist_raw( string $raw ): void {
+		update_option( self::OPTION_TRUSTED_PROXY_ALLOWLIST, $raw );
+	}
+
+	// Internals ----------------------------------------------------------
+
+	private static function clean_keyword_list( array $list ): array {
+		$out = array();
+		foreach ( $list as $kw ) {
+			if ( ! is_string( $kw ) ) {
+				continue;
+			}
+			$lower = strtolower( trim( $kw ) );
+			if ( '' === $lower ) {
+				continue;
+			}
+			$out[ $lower ] = true;
+		}
+		return array_keys( $out );
+	}
+
+	private static function clean_ability_list( array $list ): array {
+		$out = array();
+		foreach ( $list as $name ) {
+			if ( ! is_string( $name ) ) {
+				continue;
+			}
+			$clean = self::sanitize_ability_name( $name );
+			if ( '' !== $clean ) {
+				$out[ $clean ] = true;
+			}
+		}
+		return array_keys( $out );
+	}
+
+	private static function sanitize_keyword( string $keyword ): string {
+		// Field-name allowlist: lower alphanumeric + underscore + hyphen + dot, capped 64.
+		$keyword = strtolower( trim( $keyword ) );
+		$keyword = preg_replace( '/[^a-z0-9_\-\.]/', '', $keyword ) ?? '';
+		if ( strlen( $keyword ) > 64 ) {
+			$keyword = substr( $keyword, 0, 64 );
+		}
+		return $keyword;
+	}
+
+	private static function sanitize_ability_name( string $name ): string {
+		// Ability names are namespaced like `users/list` or `mcp-adapter/get-started`.
+		$name = trim( $name );
+		$name = preg_replace( '/[^a-zA-Z0-9_\-\/]/', '', $name ) ?? '';
+		if ( strlen( $name ) > 191 ) {
+			$name = substr( $name, 0, 191 );
+		}
+		return $name;
+	}
+
+	private static function custom_keywords_option( int $bucket ): string {
+		return self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_KEYWORDS
+			: self::OPTION_BUCKET3_KEYWORDS;
+	}
+
+	private static function removed_defaults_option( int $bucket ): string {
+		return self::BUCKET_PAYMENT === $bucket
+			? self::OPTION_BUCKET2_REMOVED_DEFAULTS
+			: self::OPTION_BUCKET3_REMOVED_DEFAULTS;
+	}
+
+	/**
+	 * Returns null when bucket invalid; never returns Bucket-1 option.
+	 */
+	private static function exemptions_option( int $bucket ): ?string {
+		if ( self::BUCKET_PAYMENT === $bucket ) {
+			return self::OPTION_BUCKET2_EXEMPTIONS;
+		}
+		if ( self::BUCKET_CONTACT === $bucket ) {
+			return self::OPTION_BUCKET3_EXEMPTIONS;
+		}
+		return null;
+	}
+
+	private static function write_keyword_option( string $option, array $list ): void {
+		update_option( $option, array_values( array_unique( self::clean_keyword_list( $list ) ) ) );
+	}
+}

--- a/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
@@ -147,4 +147,104 @@ final class SettingsAbilitiesTest extends TestCase {
 		$this->assertTrue( $out['success'] );
 		$this->assertTrue( $out['removed'] );
 	}
+
+	// --- B.1: Bucket-membership pre-check on remove-default-bucket3-keyword ---
+
+	public function test_b1_rejects_bucket2_card_number_without_minting_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'card_number' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'Bucket 2', $out['message'] );
+		$this->assertStringContainsString( 'Admin', $out['message'] );
+		// Repo state unchanged.
+		$this->assertContains( 'card_number', Repo::get_active_keywords( Repo::BUCKET_PAYMENT ) );
+	}
+
+	public function test_b1_rejects_bucket2_ssn_without_minting_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'ssn' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'Bucket 2', $out['message'] );
+	}
+
+	public function test_b1_rejects_bucket2_tax_id_without_minting_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'tax_id' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'Bucket 2', $out['message'] );
+	}
+
+	public function test_b1_rejects_unknown_keyword_without_minting_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'not_a_real_keyword' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'not in any default redaction list', $out['message'] );
+		$this->assertStringContainsString( 'remove-custom-keyword', $out['message'] );
+	}
+
+	public function test_b1_rejects_empty_keyword_without_minting_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => '' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'non-empty', $out['message'] );
+	}
+
+	public function test_b1_happy_path_bucket3_keyword_still_mints_token(): void {
+		// Bucket 3 default — should still flow through the confirmation path.
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'phone' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertTrue( $out['confirmation_required'] );
+		$this->assertNotEmpty( $out['token'] );
+		$this->assertStringContainsString( 'phone', $out['summary'] );
+	}
+
+	public function test_b1_bucket2_keyword_with_token_still_rejected(): void {
+		// Even if a (somehow-obtained) token were presented for a Bucket 2 keyword,
+		// the pre-check fires before token consumption.
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'card_number',
+			'confirmation_token' => 'whatever-token-the-attacker-supplied',
+		) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertStringContainsString( 'Bucket 2', $out['message'] );
+		// The Bucket 2 default is still in place.
+		$this->assertContains( 'card_number', Repo::get_active_keywords( Repo::BUCKET_PAYMENT ) );
+	}
+
+	public function test_b1_bucket3_case_insensitive_match(): void {
+		// Inputs are lowercased before comparison.
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'EMAIL' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertTrue( $out['confirmation_required'] );
+	}
+
+	// --- B.1: exempt-ability-from-bucket3 ability-name guard ---
+	//
+	// `wp_get_ability()` is not stubbed in unit tests, so the guard fail-opens
+	// per its documented contract. The existing happy-path test
+	// (test_exempt_ability_from_bucket3_first_call_returns_token) covers that.
+	// When the function exists at runtime on real WP, unknown ability names
+	// short-circuit; integration coverage for that path lives downstream.
+
+	public function test_b1_exempt_ability_rejects_empty_name(): void {
+		$out = SettingsAbilities::execute_exempt_ability_from_bucket3( array( 'ability_name' => '' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertFalse( $out['confirmation_required'] );
+		$this->assertArrayNotHasKey( 'token', $out );
+		$this->assertStringContainsString( 'non-empty', $out['message'] );
+	}
 }

--- a/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for the AI-callable settings abilities (DB-3).
+ *
+ * Focus on the in-chat 1/2 confirmation flow and the no-friction paths.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Abilities\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+final class SettingsAbilitiesTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options']    = array();
+		$GLOBALS['wp_test_transients'] = array();
+		unset( $_SERVER['HTTP_MCP_SESSION_ID'] );
+	}
+
+	public function test_get_redaction_list_returns_full_state(): void {
+		$out = SettingsAbilities::execute_get_redaction_list();
+		$this->assertArrayHasKey( 'master_enabled', $out );
+		$this->assertArrayHasKey( 'bucket1', $out );
+		$this->assertArrayHasKey( 'bucket2', $out );
+		$this->assertArrayHasKey( 'bucket3', $out );
+		$this->assertTrue( $out['master_enabled'] );
+		$this->assertContains( 'password', $out['bucket1'] );
+		$this->assertContains( 'email', $out['bucket3']['active'] );
+	}
+
+	public function test_add_redaction_keyword_strengthens_without_friction(): void {
+		$out = SettingsAbilities::execute_add_redaction_keyword( array(
+			'keyword' => 'gravity_forms_secret',
+			'bucket'  => 3,
+		) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['added'] );
+		$this->assertContains( 'gravity_forms_secret', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_first_call_returns_token(): void {
+		$out = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$this->assertFalse( $out['success'] );
+		$this->assertTrue( $out['confirmation_required'] );
+		$this->assertNotEmpty( $out['token'] );
+		$this->assertStringContainsString( 'email', $out['summary'] );
+		$this->assertCount( 2, $out['options'] );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ), 'No mutation on first call.' );
+	}
+
+	public function test_remove_default_bucket3_keyword_with_valid_token_executes(): void {
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+		$this->assertTrue( $first['confirmation_required'] );
+
+		$second = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_token_is_one_time(): void {
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$second = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+
+		// Replay with the same token must fail.
+		$third = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'email',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertFalse( $third['success'] );
+		$this->assertStringContainsString( 'unknown', strtolower( $third['message'] ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_rejects_param_swap(): void {
+		// Mint a token for `email`, then try to use it to remove `phone`.
+		$first = SettingsAbilities::execute_remove_default_bucket3_keyword( array( 'keyword' => 'email' ) );
+
+		$swap = SettingsAbilities::execute_remove_default_bucket3_keyword( array(
+			'keyword'            => 'phone',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertFalse( $swap['success'] );
+		$this->assertStringContainsString( 'match', strtolower( $swap['message'] ) );
+
+		// Both keywords still present.
+		$active = Repo::get_active_keywords( Repo::BUCKET_CONTACT );
+		$this->assertContains( 'email', $active );
+		$this->assertContains( 'phone', $active );
+	}
+
+	public function test_exempt_ability_from_bucket3_first_call_returns_token(): void {
+		$out = SettingsAbilities::execute_exempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+		$this->assertTrue( $out['confirmation_required'] );
+		$this->assertNotEmpty( $out['token'] );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_exempt_ability_from_bucket3_with_valid_token_succeeds(): void {
+		$first = SettingsAbilities::execute_exempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+
+		$second = SettingsAbilities::execute_exempt_ability_from_bucket3( array(
+			'ability_name'       => 'users/list',
+			'confirmation_token' => $first['token'],
+		) );
+		$this->assertTrue( $second['success'] );
+		$this->assertContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_unexempt_strengthens_without_friction(): void {
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' );
+		$out = SettingsAbilities::execute_unexempt_ability_from_bucket3( array( 'ability_name' => 'users/list' ) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['removed'] );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_restore_defaults_strengthens_without_friction(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+
+		$out = SettingsAbilities::execute_restore_redaction_defaults();
+		$this->assertTrue( $out['success'] );
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_custom_keyword_strengthens_without_friction(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'temp_field' );
+		$out = SettingsAbilities::execute_remove_custom_keyword( array(
+			'keyword' => 'temp_field',
+			'bucket'  => 3,
+		) );
+		$this->assertTrue( $out['success'] );
+		$this->assertTrue( $out['removed'] );
+	}
+}

--- a/tests/Unit/Settings/ConfirmationTokenStoreTest.php
+++ b/tests/Unit/Settings/ConfirmationTokenStoreTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Unit tests for ConfirmationTokenStore.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Settings\ConfirmationTokenStore as Store;
+
+final class ConfirmationTokenStoreTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_transients'] = array();
+	}
+
+	public function test_mint_returns_non_empty_token(): void {
+		$token = Store::mint( 'sess1', 'settings/remove-default-bucket3-keyword', array( 'keyword' => 'email' ) );
+		$this->assertIsString( $token );
+		$this->assertNotEmpty( $token );
+	}
+
+	public function test_consume_valid_token_succeeds(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$result = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$this->assertTrue( $result );
+	}
+
+	public function test_token_is_one_time(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$first  = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$second = Store::consume( $token, 'sess1', 'ability_a', $params );
+
+		$this->assertTrue( $first );
+		$this->assertInstanceOf( \WP_Error::class, $second );
+		$this->assertSame( 'token_unknown', $second->get_error_code() );
+	}
+
+	public function test_missing_token_rejected(): void {
+		$err = Store::consume( '', 'sess1', 'ability_a', array() );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'missing_token', $err->get_error_code() );
+	}
+
+	public function test_session_mismatch_rejected(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess_other', 'ability_a', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'session_mismatch', $err->get_error_code() );
+	}
+
+	public function test_ability_mismatch_rejected(): void {
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess1', 'ability_b', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'ability_mismatch', $err->get_error_code() );
+	}
+
+	public function test_params_mismatch_rejected(): void {
+		$token = Store::mint( 'sess1', 'ability_a', array( 'keyword' => 'email' ) );
+
+		$err = Store::consume( $token, 'sess1', 'ability_a', array( 'keyword' => 'phone' ) );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'params_mismatch', $err->get_error_code() );
+	}
+
+	public function test_failed_lookup_invalidates_token_anyway(): void {
+		// Replay protection: even when consume() fails because of a binding
+		// mismatch, the transient must be deleted so an attacker cannot
+		// retry the same token after fixing the mismatch.
+		$params = array( 'keyword' => 'email' );
+		$token  = Store::mint( 'sess1', 'ability_a', $params );
+
+		Store::consume( $token, 'sess_wrong', 'ability_a', $params );
+
+		$err = Store::consume( $token, 'sess1', 'ability_a', $params );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'token_unknown', $err->get_error_code() );
+	}
+}

--- a/tests/Unit/Settings/SafetySettingsRepositoryTest.php
+++ b/tests/Unit/Settings/SafetySettingsRepositoryTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Unit tests for SafetySettingsRepository.
+ *
+ * @package WickedEvolutions\McpAdapter
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Settings\SafetySettingsRepository as Repo;
+
+final class SafetySettingsRepositoryTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	public function test_master_toggle_default_on(): void {
+		$this->assertTrue( Repo::is_master_enabled() );
+	}
+
+	public function test_master_toggle_can_be_disabled_then_re_enabled(): void {
+		Repo::set_master_enabled( false );
+		$this->assertFalse( Repo::is_master_enabled() );
+		Repo::set_master_enabled( true );
+		$this->assertTrue( Repo::is_master_enabled() );
+	}
+
+	public function test_bucket1_keywords_are_hardcoded_and_non_empty(): void {
+		$kws = Repo::bucket1_default_keywords();
+		$this->assertNotEmpty( $kws );
+		$this->assertContains( 'password', $kws );
+		$this->assertContains( 'auth_token', $kws );
+	}
+
+	public function test_add_custom_bucket3_keyword(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		$this->assertTrue( $result );
+		$this->assertContains( 'gravity_forms_secret', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_add_custom_bucket2_keyword(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_PAYMENT, 'wallet_id' );
+		$this->assertTrue( $result );
+		$this->assertContains( 'wallet_id', Repo::get_active_keywords( Repo::BUCKET_PAYMENT ) );
+	}
+
+	public function test_cannot_add_keyword_to_bucket1(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_SECRETS, 'whatever' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bucket1_locked', $result->get_error_code() );
+	}
+
+	public function test_invalid_bucket_rejected(): void {
+		$result = Repo::add_custom_keyword( 9, 'whatever' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_bucket', $result->get_error_code() );
+	}
+
+	public function test_empty_keyword_rejected(): void {
+		$result = Repo::add_custom_keyword( Repo::BUCKET_CONTACT, '   ' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'empty_keyword', $result->get_error_code() );
+	}
+
+	public function test_remove_custom_keyword_returns_false_for_unknown(): void {
+		$result = Repo::remove_custom_keyword( Repo::BUCKET_CONTACT, 'never_added' );
+		$this->assertFalse( $result );
+	}
+
+	public function test_remove_custom_keyword_removes_added_entry(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'foo_secret' );
+		$this->assertContains( 'foo_secret', Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertTrue( Repo::remove_custom_keyword( Repo::BUCKET_CONTACT, 'foo_secret' ) );
+		$this->assertNotContains( 'foo_secret', Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_bucket3_keyword_marks_as_removed(): void {
+		$this->assertTrue( in_array( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ), true ) );
+		$this->assertTrue( Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' ) );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_remove_default_rejects_non_default(): void {
+		$result = Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'not_a_default_keyword' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_a_default', $result->get_error_code() );
+	}
+
+	public function test_re_adding_removed_default_restores_it(): void {
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+		$this->assertNotContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'email' );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertNotContains( 'email', Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_restore_defaults_clears_customs_and_removed(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'gravity_forms_secret' );
+		Repo::remove_default_keyword( Repo::BUCKET_CONTACT, 'email' );
+		Repo::add_custom_keyword( Repo::BUCKET_PAYMENT, 'wallet_id' );
+
+		Repo::restore_defaults();
+
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_CONTACT ) );
+		$this->assertEmpty( Repo::get_custom_keywords( Repo::BUCKET_PAYMENT ) );
+		$this->assertEmpty( Repo::get_removed_defaults( Repo::BUCKET_CONTACT ) );
+		$this->assertContains( 'email', Repo::get_active_keywords( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_keyword_sanitisation_lowercases_and_strips_invalid_chars(): void {
+		Repo::add_custom_keyword( Repo::BUCKET_CONTACT, 'Custom Field!@#' );
+		$customs = Repo::get_custom_keywords( Repo::BUCKET_CONTACT );
+		$this->assertContains( 'customfield', $customs );
+	}
+
+	public function test_exemption_add_remove(): void {
+		$this->assertTrue( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+		$this->assertTrue( Repo::remove_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertNotContains( 'users/list', Repo::get_exemptions( Repo::BUCKET_CONTACT ) );
+	}
+
+	public function test_exemption_idempotent(): void {
+		$this->assertTrue( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertFalse( Repo::add_exemption( Repo::BUCKET_CONTACT, 'users/list' ) );
+		$this->assertFalse( Repo::remove_exemption( Repo::BUCKET_CONTACT, 'never-added' ) );
+	}
+
+	public function test_exemption_invalid_bucket_rejected(): void {
+		$err = Repo::add_exemption( Repo::BUCKET_SECRETS, 'users/list' );
+		$this->assertInstanceOf( \WP_Error::class, $err );
+		$this->assertSame( 'invalid_bucket', $err->get_error_code() );
+	}
+
+	public function test_trusted_proxy_defaults(): void {
+		$this->assertFalse( Repo::is_trusted_proxy_enabled() );
+		$this->assertSame( Repo::PROXY_MODE_CLOUDFLARE, Repo::get_trusted_proxy_mode() );
+		$this->assertSame( '', Repo::get_trusted_proxy_allowlist_raw() );
+	}
+
+	public function test_trusted_proxy_round_trip(): void {
+		Repo::set_trusted_proxy_enabled( true );
+		Repo::set_trusted_proxy_mode( Repo::PROXY_MODE_CUSTOM );
+		Repo::set_trusted_proxy_allowlist_raw( "10.0.0.0/8\n192.168.1.1" );
+
+		$this->assertTrue( Repo::is_trusted_proxy_enabled() );
+		$this->assertSame( Repo::PROXY_MODE_CUSTOM, Repo::get_trusted_proxy_mode() );
+		$this->assertStringContainsString( '10.0.0.0/8', Repo::get_trusted_proxy_allowlist_raw() );
+	}
+
+	public function test_trusted_proxy_mode_falls_back_to_cloudflare_for_unknown(): void {
+		Repo::set_trusted_proxy_mode( 'something_else' );
+		$this->assertSame( Repo::PROXY_MODE_CLOUDFLARE, Repo::get_trusted_proxy_mode() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,103 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $option ) {
+		unset( $GLOBALS['wp_test_options'][ $option ] );
+		return true;
+	}
+}
+
+if ( ! isset( $GLOBALS['wp_test_transients'] ) ) {
+	$GLOBALS['wp_test_transients'] = array();
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $key, $value, $ttl = 0 ) {
+		$GLOBALS['wp_test_transients'][ $key ] = array(
+			'value'   => $value,
+			'expires' => time() + (int) $ttl,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $key ) {
+		$entry = $GLOBALS['wp_test_transients'][ $key ] ?? null;
+		if ( ! $entry ) {
+			return false;
+		}
+		if ( $entry['expires'] < time() ) {
+			unset( $GLOBALS['wp_test_transients'][ $key ] );
+			return false;
+		}
+		return $entry['value'];
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $key ) {
+		unset( $GLOBALS['wp_test_transients'][ $key ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_password' ) ) {
+	function wp_generate_password( $length = 12, $special_chars = true, $extra_special_chars = false ) {
+		return bin2hex( random_bytes( max( 1, (int) ( $length / 2 ) ) ) );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return $GLOBALS['wp_test_current_user'] ?? 0;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_]/', '', $key ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		// no-op for unit tests
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return ! empty( $GLOBALS['wp_test_current_user'] );
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $capability ) {
+		return ! empty( $GLOBALS['wp_test_caps'][ $capability ] );
+	}
+}
+
 if ( ! function_exists( 'esc_html__' ) ) {
 	function esc_html__( $text, $domain = 'default' ) {
 		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );


### PR DESCRIPTION
**Held for public-alpha hardening sprint Launch Gate. Part of the six-brief integrated release. See SYNTHESIS — Alpha Hardening Workstream 2026-04-26 v1.3.0.**

Closes #20.

## Summary

Phase 3 of the alpha hardening workstream — the operator-facing surface for the redaction filter (DB-2) plus trusted-proxy configuration (DB-4).

### Admin UI — Settings → MCP Safety

- **Master toggle** — disabling requires the inline checkbox confirmation; Bucket 1 secrets remain filtered regardless.
- **Redaction keyword list** — Bucket 1 read-only, Bucket 2 with per-default warning (`onsubmit confirm`), Bucket 3 no per-default warning (matches the AI ability friction), custom add input (Bucket 2 or 3 only), restore defaults.
- **Per-ability exemptions** — two columns. Bucket 3 left, Bucket 2 right with `onsubmit confirm` + `mcp_exempt_confirm` server-side gate.
- **Trusted proxy** — toggle, Cloudflare preset radio, custom IP-allowlist radio with textarea. Allowlist sanitized to one CIDR/IP per line.

### AI-callable abilities (all `manage_options`)

| Ability | Friction |
|---|---|
| `settings/get-redaction-list` | none |
| `settings/add-redaction-keyword` | none |
| `settings/remove-custom-keyword` | none |
| `settings/restore-redaction-defaults` | none |
| `settings/unexempt-ability-from-bucket3` | none |
| `settings/remove-default-bucket3-keyword` | **in-chat 1/2 confirmation** |
| `settings/exempt-ability-from-bucket3` | **in-chat 1/2 confirmation** |

Bucket 2 default removal, Bucket 2 ability exemption, and master-toggle-off intentionally have **no ability paths** — Admin UI only. The cryptographic-trust anchor for payment / regulated identifiers cannot be weakened from chat at any granularity.

### In-chat confirmation tokens

- WP transients with 60s TTL, key prefix `abilities_mcp_confirm_`.
- Bound to `(session_id, ability, params_hash)` so a token cannot be reused for a different ability or different parameters.
- Single-use: any lookup deletes the transient (replay-safe even when the binding fails).
- Honest framing in the spec — the token mechanism prevents accidental weakening; it does **not** prove human consent (a malicious AI client could synthesise a "1" reply). That is exactly why Bucket 2 + master-toggle-off remain Admin UI only.
- Session ID resolution prefers `Mcp-Session-Id` header; falls back to `(user_id|ip-hash)` for the 60-second window.

### Boundary events emitted

All settings writes go through the existing `BoundaryEventEmitter` so DB-1's `BoundaryEventLogger` (or any third-party listener on `mcp_adapter_boundary_event`) receives them with sanitized tags:

- `boundary.master_toggle.changed`
- `boundary.redaction_keywords.changed`
- `boundary.ability_exemption.changed`
- `boundary.confirmation.failed`

Note: `confirmation.failed` is added in this brief and worth coordinating with DB-1 author so it lands in the v0.1 event taxonomy. If DB-1 sticks to the strict 5-event taxonomy, the writer simply ignores it (the action hook still fires; downstream listeners can decide).

### Option keys introduced/used

| Key | Purpose | Owner |
|---|---|---|
| `abilities_mcp_redaction_master_enabled` | bool, default true | shared (DB-2 reads, DB-3 writes) |
| `abilities_mcp_redaction_keywords` | string[], Bucket 3 customs | shared |
| `abilities_mcp_bucket2_keywords` | string[], Bucket 2 customs | **new — DB-2 reads after rebase** |
| `abilities_mcp_redaction_keywords_removed_defaults` | string[] | new |
| `abilities_mcp_bucket2_keywords_removed_defaults` | string[] | new |
| `abilities_mcp_bucket3_exemptions` | string[] | shared |
| `abilities_mcp_bucket2_exemptions` | string[] | shared (Admin-UI-only writes) |
| `abilities_mcp_trusted_proxy_enabled` | bool | new — for DB-4 |
| `abilities_mcp_trusted_proxy_mode` | string | new — for DB-4 |
| `abilities_mcp_trusted_proxy_allowlist` | string | new — for DB-4 |

## Tests

\`vendor/bin/phpunit\` — **322 / 322 pass, 538 assertions**. 40 new tests covering:
- Repository: master toggle, custom add/remove, default removal + restore, sanitisation, exemptions, trusted proxy round-trip.
- Token store: mint/consume happy path, replay protection, session/ability/params mismatch rejection, failed-lookup invalidation.
- Ability execution: confirmation flow (first call returns token, second executes, third rejected), param-swap rejection, no-friction strengthen paths.

## Coordination notes

1. **DB-2 rebase** — DB-2's `RedactionConfig::bucket2_keywords()` is currently hardcoded. After DB-2 rebases on this branch (or vice versa) it should additionally merge `abilities_mcp_bucket2_keywords` for parity with `bucket3_keywords()`. Drop a `Repo::get_active_keywords( BUCKET_PAYMENT )` call into `bucket2_keywords()` when integrating, or replace the hardcoded list in `RedactionConfig` with a call into `SafetySettingsRepository`.

2. **DB-1 boundary event taxonomy** — this brief emits `boundary.master_toggle.changed`, `boundary.redaction_keywords.changed`, `boundary.ability_exemption.changed`, `boundary.confirmation.failed`. DB-1 currently lists 5 events. Either extend the taxonomy on the DB-1 side or document these as v0.1 settings-emit-only events.

3. **DB-4 trusted proxy** — option keys are written by this PR; DB-4's rate limiter should read them via `SafetySettingsRepository::is_trusted_proxy_enabled()` / `get_trusted_proxy_mode()` / `get_trusted_proxy_allowlist_raw()`.

## Test plan

- [ ] Manual: WP admin → Settings → MCP Safety. Toggle master OFF — must reject without inner checkbox; accept with it.
- [ ] Manual: Add custom keyword to Bucket 3, verify in `get_active_keywords`. Remove it. Repeat for Bucket 2.
- [ ] Manual: Remove default Bucket 2 keyword — JS confirm appears; remove default Bucket 3 — no JS confirm. Both produce a `boundary.redaction_keywords.changed` log row.
- [ ] Manual: Exempt ability from Bucket 3 — single-click toggle. Exempt from Bucket 2 — JS confirm fires.
- [ ] AI: Connect via MCP. Call `settings/get-redaction-list` → returns full state. Call `settings/add-redaction-keyword {keyword:"foo", bucket:3}` → success. Call `settings/remove-default-bucket3-keyword {keyword:"email"}` → confirmation_required+token. Re-issue with token → success. Re-issue same token → token_unknown.
- [ ] Negative: Re-issue token from a different `Mcp-Session-Id` → session_mismatch.
- [ ] Negative: Try to call `settings/remove-default-bucket2-keyword` or `settings/exempt-ability-from-bucket2` — ability does not exist (404 in tools/list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)