### PR TITLE
fix(redaction): close tools/call text-channel PII leak

### DIFF
--- a/src/Infrastructure/Redaction/ResponseRedactionGate.php
+++ b/src/Infrastructure/Redaction/ResponseRedactionGate.php
@@ -80,6 +80,21 @@ final class ResponseRedactionGate {
 			);
 		}
 
+		// `tools/call` responses ship two parallel channels:
+		//   - structuredContent: the typed result tree (just redacted in place)
+		//   - content[i].text:   a JSON-encoded snapshot of the SAME tree, captured
+		//                        before redaction runs, so it still holds the raw
+		//                        values. The keyword-based redactor only matches
+		//                        field names — a serialized string slips through
+		//                        unchanged. Regenerate the text channel from the
+		//                        redacted tree to close the leak.
+		//
+		// Image responses (content[0].type === 'image') carry base64 binary in
+		// `data`, no `text` field, no `structuredContent` — left untouched.
+		// Text-only responses without `structuredContent` get a best-effort
+		// JSON-decode/redact/re-encode so single-channel callers don't leak.
+		$redacted = self::reconcile_tool_channels( $redacted, $redactor );
+
 		if ( null !== $session_id ) {
 			$redacted['_session_id'] = $session_id;
 		}
@@ -96,6 +111,95 @@ final class ResponseRedactionGate {
 
 		if ( $total > 0 ) {
 			self::emit_redaction_event( $observability, $method, $ability_name, $counts );
+		}
+
+		return $redacted;
+	}
+
+	/**
+	 * Reconcile the dual response channels after redaction. See the call site
+	 * for the leak this closes.
+	 *
+	 * Strategy:
+	 *   - If `content[i].text` and a top-level `structuredContent` are both
+	 *     present, the text channel is a stale JSON snapshot — re-encode the
+	 *     (now redacted) `structuredContent` and stamp it into ALL text parts.
+	 *     Stamping every text part rather than just `[0]` is defensive: the
+	 *     adapter writes only `content[0].text` today, but a future
+	 *     (or third-party) handler might emit several text parts derived
+	 *     from the same structured payload.
+	 *   - If `content[i].text` is present without `structuredContent`
+	 *     (single-channel text response), best-effort redact the text in
+	 *     place: JSON-decode, re-redact, re-encode. A non-JSON string is
+	 *     left alone — keyword redaction has no field-name surface in a
+	 *     free-form string.
+	 *   - Image parts (`type === 'image'`) carry base64 binary in `data`,
+	 *     not `text`; they are skipped.
+	 *   - Anything that doesn't look like a tools/call response (no
+	 *     `content` array, or no parts with a `text` key) is returned
+	 *     unchanged. `initialize` and other non-tools/call results pass
+	 *     through unaffected.
+	 *
+	 * @param array            $redacted Result with structuredContent already redacted.
+	 * @param ResponseRedactor $redactor Reusable redactor for the per-text-part fallback.
+	 * @return array
+	 */
+	private static function reconcile_tool_channels( array $redacted, ResponseRedactor $redactor ): array {
+		if ( ! isset( $redacted['content'] ) || ! is_array( $redacted['content'] ) ) {
+			return $redacted;
+		}
+
+		$has_structured     = array_key_exists( 'structuredContent', $redacted );
+		$structured_payload = $has_structured ? $redacted['structuredContent'] : null;
+
+		foreach ( $redacted['content'] as $i => $part ) {
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+			if ( isset( $part['type'] ) && 'text' !== $part['type'] ) {
+				// Image / future binary parts — skip.
+				continue;
+			}
+			if ( ! array_key_exists( 'text', $part ) ) {
+				continue;
+			}
+
+			if ( $has_structured ) {
+				// Canonical fix path: regenerate from the redacted typed payload.
+				$encoded = function_exists( 'wp_json_encode' )
+					? wp_json_encode( $structured_payload )
+					: json_encode( $structured_payload );
+				if ( false !== $encoded && null !== $encoded ) {
+					$redacted['content'][ $i ]['text'] = $encoded;
+				}
+				continue;
+			}
+
+			// Single-channel text response: try JSON → redact → re-encode.
+			$text = $part['text'];
+			if ( ! is_string( $text ) || '' === $text ) {
+				continue;
+			}
+			$decoded = json_decode( $text, true );
+			if ( ! is_array( $decoded ) ) {
+				// Plain text — keyword-based redaction has nothing to match.
+				continue;
+			}
+			try {
+				$redacted_decoded = $redactor->redact( $decoded );
+			} catch ( RedactionLimitExceeded $e ) {
+				// Best-effort path: a limit hit here shouldn't tear down the
+				// whole response, but the original (potentially leaky) text
+				// MUST NOT pass through. Replace with a safe marker.
+				$redacted['content'][ $i ]['text'] = '[redacted:limit_exceeded]';
+				continue;
+			}
+			$encoded = function_exists( 'wp_json_encode' )
+				? wp_json_encode( $redacted_decoded )
+				: json_encode( $redacted_decoded );
+			if ( false !== $encoded && null !== $encoded ) {
+				$redacted['content'][ $i ]['text'] = $encoded;
+			}
 		}
 
 		return $redacted;

--- a/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
+++ b/tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php
@@ -488,4 +488,293 @@ class ResponseRedactionGateTest extends TestCase {
 		$this->assertSame( '[redacted:bucket_1]', $out['data']['session_token'] );
 		$this->assertSame( '[redacted:bucket_1]', $out['data']['api_key'] );
 	}
+
+	// ── Text-channel leak fix (Launch Gate v0.1.1) ──────────────────────────
+	//
+	// `tools/call` ships responses on two parallel channels: the typed
+	// `structuredContent` tree, and a JSON-encoded snapshot at
+	// `content[i].text`. The gate's recursive redactor mutates the typed
+	// tree but keyword-based redaction can't match anything in a serialised
+	// string, so the text channel previously leaked raw values even when
+	// the typed channel was correctly redacted.
+
+	/**
+	 * Build the response shape ToolsHandler::call_tool() emits for a non-image
+	 * ability — content[0].text is wp_json_encode($result) and structuredContent
+	 * is the same $result, captured BEFORE the gate runs.
+	 *
+	 * @param array $result_payload What the ability returned.
+	 * @return array
+	 */
+	private function tools_call_response( array $result_payload ): array {
+		return array(
+			'content'           => array(
+				array(
+					'type' => 'text',
+					'text' => json_encode( $result_payload ),
+				),
+			),
+			'structuredContent' => $result_payload,
+		);
+	}
+
+	public function test_text_channel_dual_channel_text_regenerates_from_redacted_structured(): void {
+		$payload = array(
+			'users' => array(
+				array(
+					'id'            => 5,
+					'email'         => 'jacob@willow.se',
+					'session_token' => 'st_live_secret',
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$this->tools_call_response( $payload ),
+			'tools/call',
+			array( 'name' => 'users-list', 'arguments' => array() ),
+			1
+		);
+
+		// structuredContent redacted as before.
+		$this->assertSame( '[redacted:bucket_3]', $out['structuredContent']['users'][0]['email'] );
+		$this->assertSame( '[redacted:bucket_1]', $out['structuredContent']['users'][0]['session_token'] );
+
+		// content[0].text must be regenerated from the redacted structuredContent —
+		// no raw email or secret may remain in the serialised string.
+		$text = $out['content'][0]['text'];
+		$this->assertIsString( $text );
+		$this->assertStringNotContainsString( 'jacob@willow.se', $text );
+		$this->assertStringNotContainsString( 'st_live_secret', $text );
+		$this->assertStringContainsString( '[redacted:bucket_3]', $text );
+		$this->assertStringContainsString( '[redacted:bucket_1]', $text );
+
+		// And the regenerated text must round-trip back to the redacted tree.
+		$decoded = json_decode( $text, true );
+		$this->assertSame( $out['structuredContent'], $decoded );
+	}
+
+	public function test_text_channel_via_execute_ability_meta_tool_dash_form(): void {
+		// The end-to-end scenario GPT 5.5 hit: AI calls fluent-cart/list-customers
+		// through mcp-adapter-execute-ability. Inner result wraps in
+		// {success, data:...}; ToolsHandler builds dual-channel; gate must
+		// redact both channels.
+		$this->register_ability( 'fluent-cart/list-customers' );
+
+		$inner_payload = array(
+			'success' => true,
+			'data'    => array(
+				'customers' => array(
+					array( 'id' => 5, 'email' => 'jacob@willow.se' ),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$this->tools_call_response( $inner_payload ),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter-execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['structuredContent']['data']['customers'][0]['email'] );
+		$this->assertStringNotContainsString( 'jacob@willow.se', $out['content'][0]['text'] );
+	}
+
+	public function test_text_channel_exemption_passes_email_through_both_channels(): void {
+		// When an ability is exempt, BOTH channels must show the unredacted value —
+		// otherwise the user sees inconsistent data depending on which channel
+		// the client surfaces.
+		$this->register_ability( 'fluent-cart/list-customers' );
+		Repo::add_exemption( Repo::BUCKET_CONTACT, 'fluent-cart/list-customers' );
+
+		$payload = array(
+			'data' => array( 'email' => 'jacob@willow.se', 'session_token' => 'st_live_secret' ),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$this->tools_call_response( $payload ),
+			'tools/call',
+			array(
+				'name'      => 'mcp-adapter-execute-ability',
+				'arguments' => array(
+					'ability_name' => 'fluent-cart/list-customers',
+					'parameters'   => array(),
+				),
+			),
+			1
+		);
+
+		// Bucket 3 exempt — email passes on both channels.
+		$this->assertSame( 'jacob@willow.se', $out['structuredContent']['data']['email'] );
+		$this->assertStringContainsString( 'jacob@willow.se', $out['content'][0]['text'] );
+		// Bucket 1 still redacts on both.
+		$this->assertSame( '[redacted:bucket_1]', $out['structuredContent']['data']['session_token'] );
+		$this->assertStringNotContainsString( 'st_live_secret', $out['content'][0]['text'] );
+	}
+
+	public function test_text_channel_image_response_untouched(): void {
+		// ToolsHandler emits image responses without structuredContent and
+		// without content[0].text. The reconciler must not invent a text
+		// field or otherwise mutate the image path.
+		$image_response = array(
+			'content' => array(
+				array(
+					'type'     => 'image',
+					'data'     => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=',
+					'mimeType' => 'image/png',
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$image_response,
+			'tools/call',
+			array( 'name' => 'screenshot/capture', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( 'image', $out['content'][0]['type'] );
+		$this->assertSame( $image_response['content'][0]['data'], $out['content'][0]['data'] );
+		$this->assertSame( 'image/png', $out['content'][0]['mimeType'] );
+		$this->assertArrayNotHasKey( 'text', $out['content'][0] );
+		$this->assertArrayNotHasKey( 'structuredContent', $out );
+	}
+
+	public function test_text_channel_text_only_response_decoded_redacted_re_encoded(): void {
+		// Single-channel text response (no structuredContent). The reconciler
+		// best-effort decodes the JSON, runs redaction, re-encodes. PII must
+		// not leak in the text.
+		$payload = array( 'email' => 'jacob@willow.se', 'name' => 'Jacob' );
+
+		$response = array(
+			'content' => array(
+				array(
+					'type' => 'text',
+					'text' => json_encode( $payload ),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'users-list', 'arguments' => array() ),
+			1
+		);
+
+		$text = $out['content'][0]['text'];
+		$this->assertStringNotContainsString( 'jacob@willow.se', $text );
+		$this->assertStringContainsString( '[redacted:bucket_3]', $text );
+		// Non-PII fields preserved.
+		$this->assertStringContainsString( 'Jacob', $text );
+	}
+
+	public function test_text_channel_plain_string_text_left_alone(): void {
+		// content[0].text that is a plain non-JSON string has no field-name
+		// surface for keyword redaction. Reconciler must leave it intact —
+		// rewriting plain text would be a behaviour change the brief forbids.
+		$response = array(
+			'content' => array(
+				array(
+					'type' => 'text',
+					'text' => 'Hello world. No PII here.',
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'docs/get', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( 'Hello world. No PII here.', $out['content'][0]['text'] );
+	}
+
+	public function test_text_channel_multiple_text_parts_all_regenerate(): void {
+		// Defensive: the adapter writes only content[0] today, but the
+		// reconciler must regenerate every text part if a future handler
+		// emits several from the same structured payload.
+		$payload  = array( 'email' => 'jacob@willow.se' );
+		$response = array(
+			'content'           => array(
+				array( 'type' => 'text', 'text' => json_encode( $payload ) ),
+				array( 'type' => 'text', 'text' => json_encode( $payload ) ),
+			),
+			'structuredContent' => $payload,
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'users-list', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertStringNotContainsString( 'jacob@willow.se', $out['content'][0]['text'] );
+		$this->assertStringNotContainsString( 'jacob@willow.se', $out['content'][1]['text'] );
+		$this->assertSame( $out['content'][0]['text'], $out['content'][1]['text'] );
+	}
+
+	public function test_text_channel_non_tools_call_unchanged(): void {
+		// `initialize` and other non-tool methods don't have content/structuredContent.
+		// The reconciler must be a no-op for them.
+		$response = array(
+			'protocolVersion' => '2025-06-18',
+			'capabilities'    => array( 'tools' => array() ),
+		);
+
+		$out = ResponseRedactionGate::apply( $response, 'initialize', array(), 1 );
+
+		$this->assertSame( $response, $out );
+	}
+
+	public function test_text_channel_response_without_content_unchanged(): void {
+		// Defensive: tools/call result without a `content` key (theoretical /
+		// future shape) passes through unchanged.
+		$response = array( 'data' => array( 'email' => 'jacob@willow.se' ) );
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'whatever', 'arguments' => array() ),
+			1
+		);
+
+		// structuredContent path doesn't apply, but the typed tree is still
+		// redacted by the main pass.
+		$this->assertSame( '[redacted:bucket_3]', $out['data']['email'] );
+		$this->assertArrayNotHasKey( 'content', $out );
+	}
+
+	public function test_text_channel_metadata_preserved_through_reconciliation(): void {
+		// Internal _metadata bookkeeping must survive the reconciler — it's
+		// extracted in apply() before redaction and re-attached after.
+		$payload = array( 'email' => 'jacob@willow.se' );
+		$response = array(
+			'content'           => array(
+				array( 'type' => 'text', 'text' => json_encode( $payload ) ),
+			),
+			'structuredContent' => $payload,
+			'_metadata'         => array( 'component_type' => 'tool', 'tool_name' => 'users/list' ),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'users-list', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( array( 'component_type' => 'tool', 'tool_name' => 'users/list' ), $out['_metadata'] );
+		$this->assertStringNotContainsString( 'jacob@willow.se', $out['content'][0]['text'] );
+	}
 }


### PR DESCRIPTION
**Held PR — Launch Gate v0.1.1 alpha-blocker.** Do not merge until live re-test confirms.

## Summary

`tools/call` responses leaked raw PII via `content[0].text` even when `structuredContent` was correctly redacted. Found by GPT 5.5 testing through the live MCP bridge against `users/list` (and reproducible against any ability returning Bucket 3 fields).

**Symptom**

```json
{
  "content": [{
    "type": "text",
    "text": "{\"users\":[{\"id\":5,\"email\":\"jacob@willow.se\"}]}"   // ← raw
  }],
  "structuredContent": {
    "users": [{"id": 5, "email": "[redacted:bucket_3]"}]               // ← redacted
  }
}
```

## Root cause

In [`src/Handlers/Tools/ToolsHandler.php:201-202`](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/blob/main/src/Handlers/Tools/ToolsHandler.php#L201-L202):

```php
$response['content'][0]['text'] = wp_json_encode( $result );
$response['structuredContent']  = $result;
```

Both channels are stamped from the same `$result` array BEFORE `ResponseRedactionGate::apply()` runs. The gate's recursive redactor mutates `structuredContent` in place but cannot match field names inside the already-serialised JSON string in `content[0].text` — keyword-based redaction has no surface against a flat string.

## Fix

Lives in the gate (per the constraint "do NOT change `ToolsHandler`'s response shape"). After the redaction pass and the internal-bookkeeping restore, `reconcile_tool_channels()` runs:

1. **`structuredContent` present** → regenerate `content[i].text` for every text part by re-encoding the now-redacted typed tree. Canonical path: `tools/call` responses always emit both channels for non-image abilities, so the typed channel is the single source of truth.
2. **`content[i].text` present without `structuredContent`** → best-effort JSON-decode → redact via the same redactor → re-encode. Non-JSON strings are left intact (keyword redaction has no surface in free-form text).
3. **Image parts** (`type === 'image'`) → skipped (no `text` field, no `structuredContent`).
4. **No `content` key** → pass through unchanged. `initialize` and other non-tools/call methods unaffected.

Defensive details:
- Iterates every text part rather than just `[0]` (future-proof against multi-part text handlers).
- `RedactionLimitExceeded` in the single-channel fallback replaces leaky text with `[redacted:limit_exceeded]` rather than tearing down the response.
- Reuses the per-call redactor for the fallback path so counts aggregate.

## Tests

10 new in [`ResponseRedactionGateTest`](tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php), all in the `test_text_channel_*` namespace:

- `test_text_channel_dual_channel_text_regenerates_from_redacted_structured` — **the bug guard.**
- `test_text_channel_via_execute_ability_meta_tool_dash_form` — the exact GPT 5.5 scenario through the dash-form meta-tool.
- `test_text_channel_exemption_passes_email_through_both_channels` — channel symmetry under exemption.
- `test_text_channel_image_response_untouched` — image path unchanged.
- `test_text_channel_text_only_response_decoded_redacted_re_encoded` — single-channel JSON.
- `test_text_channel_plain_string_text_left_alone` — plain text preserved.
- `test_text_channel_multiple_text_parts_all_regenerate` — defensive multi-part.
- `test_text_channel_non_tools_call_unchanged` — `initialize` no-op.
- `test_text_channel_response_without_content_unchanged` — defensive content-less case.
- `test_text_channel_metadata_preserved_through_reconciliation` — `_metadata` survival.

**Full suite: 476 passing, 1577 assertions** (was 466). No regressions.

## Test plan

- [x] Unit tests cover dual-channel, single-channel, image, plain text, multi-part, non-tools/call, metadata
- [x] No change to `ToolsHandler` response shape
- [x] Non-tools/call paths verified unchanged
- [ ] Live re-test against `users/list` and `mcp-adapter-execute-ability` → `fluent-cart/list-customers` after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)