### PR TITLE
OAuth 2.1 — Phase 1: adapter foundation

### DIFF
--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -48,8 +48,12 @@ if ( file_exists( $autoloader ) ) {
 use WickedEvolutions\McpAdapter\Abilities\Settings\SettingsAbilities;
 use WickedEvolutions\McpAdapter\Admin\AbilitySettingsPage;
 use WickedEvolutions\McpAdapter\Admin\SafetySettingsPage;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
 use WickedEvolutions\McpAdapter\Core\McpAdapter;
 use WickedEvolutions\McpAdapter\RateLimit\TrustedProxyResolver;
+
+// Boot OAuth 2.1 authorization server (DB migration, route interception, bearer auth).
+AuthorizationServer::boot();
 
 // Register admin settings pages (license + ability permissions + safety settings).
 if ( is_admin() ) {

--- a/src/Auth/OAuth/AuthorizationCodeStore.php
+++ b/src/Auth/OAuth/AuthorizationCodeStore.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Authorization code storage — short-lived, single-use codes with PKCE.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Manages kl_oauth_codes table.
+ */
+final class AuthorizationCodeStore {
+
+	private static function table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'kl_oauth_codes';
+	}
+
+	/**
+	 * Store a new authorization code.
+	 *
+	 * @param string $code_hash          SHA-256 hash of the plaintext code.
+	 * @param string $client_id
+	 * @param int    $user_id
+	 * @param string $redirect_uri       Exact URI to bind for token exchange.
+	 * @param string $scope              Space-separated scope string.
+	 * @param string $resource           Resource indicator URL.
+	 * @param string $code_challenge     PKCE S256 challenge.
+	 * @param int    $ttl_seconds        Default 600 (10 minutes).
+	 */
+	public static function store(
+		string $code_hash,
+		string $client_id,
+		int    $user_id,
+		string $redirect_uri,
+		string $scope,
+		string $resource,
+		string $code_challenge,
+		int    $ttl_seconds = 600
+	): void {
+		global $wpdb;
+
+		$wpdb->insert(
+			self::table(),
+			[
+				'code_hash'            => $code_hash,
+				'client_id'            => $client_id,
+				'user_id'              => $user_id,
+				'redirect_uri'         => $redirect_uri,
+				'scope'                => $scope,
+				'resource'             => $resource,
+				'code_challenge'       => $code_challenge,
+				'code_challenge_method'=> 'S256',
+				'expires_at'           => gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds ),
+				'used'                 => 0,
+				'created_at'           => gmdate( 'Y-m-d H:i:s' ),
+			],
+			[ '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s' ]
+		);
+	}
+
+	/**
+	 * Consume an authorization code atomically.
+	 *
+	 * Verifies: not expired, not used, client_id matches, redirect_uri matches, PKCE S256.
+	 * Uses UPDATE...WHERE used=0 for atomic single-use enforcement.
+	 *
+	 * @param string $code          Plaintext authorization code.
+	 * @param string $client_id     Must match stored client_id.
+	 * @param string $redirect_uri  Must match stored redirect_uri exactly.
+	 * @param string $code_verifier PKCE verifier.
+	 * @return object|null Code row on success, null on any verification failure.
+	 */
+	public static function consume(
+		string $code,
+		string $client_id,
+		string $redirect_uri,
+		string $code_verifier
+	): ?object {
+		global $wpdb;
+
+		$code_hash = hash( 'sha256', $code );
+
+		// Fetch the code row first (read; no write yet).
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM `' . self::table() . '`
+				 WHERE code_hash = %s
+				   AND used = 0
+				   AND expires_at > UTC_TIMESTAMP()',
+				$code_hash
+			)
+		);
+
+		if ( ! $row ) {
+			return null; // Not found, expired, or already used.
+		}
+
+		// client_id binding (H.1.1) — timing-safe.
+		if ( ! hash_equals( $row->client_id, $client_id ) ) {
+			return null;
+		}
+
+		// redirect_uri binding (H.1.1) — timing-safe.
+		if ( ! hash_equals( $row->redirect_uri, $redirect_uri ) ) {
+			return null;
+		}
+
+		// PKCE S256 verification (Appendix D.1 — lifted verbatim from StifLi).
+		$computed_challenge = rtrim( strtr( base64_encode( hash( 'sha256', $code_verifier, true ) ), '+/', '-_' ), '=' );
+		if ( ! hash_equals( $row->code_challenge, $computed_challenge ) ) {
+			return null;
+		}
+
+		// Atomic mark-as-used: UPDATE...WHERE used=0. rows_affected = 0 means a race lost.
+		$rows_affected = $wpdb->update(
+			self::table(),
+			[ 'used' => 1 ],
+			[ 'code_hash' => $code_hash, 'used' => 0 ],
+			[ '%d' ],
+			[ '%s', '%d' ]
+		);
+
+		if ( ! $rows_affected ) {
+			return null; // Race lost.
+		}
+
+		return $row;
+	}
+
+	/**
+	 * Compute a PKCE S256 challenge from a plaintext verifier.
+	 * Used by tests; production bridge does this client-side.
+	 */
+	public static function compute_challenge( string $verifier ): string {
+		return rtrim( strtr( base64_encode( hash( 'sha256', $verifier, true ) ), '+/', '-_' ), '=' );
+	}
+}

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * OAuth 2.1 Authorization Server — top-level coordinator.
+ *
+ * Registers:
+ * - DB schema migration (four kl_oauth_* tables, InnoDB)
+ * - Pre-WP discovery route interception (init priority 0)
+ * - REST endpoints (register, token, revoke)
+ * - Bearer token validation (determine_current_user priority 20)
+ * - OAuthHostAllowlist build at plugins_loaded
+ *
+ * Global helper functions defined here (in this file's namespace) to avoid
+ * polluting plugin's primary namespace:
+ *   oauth_client_ip()       — trusted-proxy-aware client IP
+ *   oauth_is_https()        — scheme detection (H.2.5)
+ *   oauth_read_auth_header() — Authorization header recovery (H.2.6)
+ *   oauth_log_boundary()    — metadata-only boundary event (H.4.3)
+ *   token_error()           — RFC 6749 §5.2 error response (H.3.7)
+ *   token_success()         — RFC 6749 §5.1 success response (H.3.7)
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\RegisterEndpoint;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\TokenEndpoint;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\RevokeEndpoint;
+
+/**
+ * Boot and coordinate the OAuth 2.1 authorization server.
+ */
+final class AuthorizationServer {
+
+	/** REST namespace shared with the MCP adapter. */
+	private const REST_NS = 'mcp';
+
+	private static bool $booted = false;
+
+	/** Register all WordPress hooks. Called once from the main plugin file. */
+	public static function boot(): void {
+		if ( self::$booted ) {
+			return;
+		}
+		self::$booted = true;
+
+		// Build host allowlist at plugins_loaded (multisite blogs table available).
+		add_action( 'plugins_loaded', [ OAuthHostAllowlist::class, 'build' ], 5 );
+
+		// DB schema migration.
+		add_action( 'plugins_loaded', [ self::class, 'maybe_run_migration' ], 10 );
+
+		// Pre-WP route interception for .well-known and /oauth/authorize.
+		add_action( 'init', [ self::class, 'intercept_pre_wp_routes' ], 0 );
+
+		// REST routes for DCR, token, revoke.
+		add_action( 'rest_api_init', [ self::class, 'register_rest_routes' ] );
+
+		// Bearer token authentication (priority 20 — after WP core's auth).
+		add_filter( 'determine_current_user', [ self::class, 'authenticate_bearer' ], 20 );
+
+		// Reset OAuthRequestContext at the start of each REST request.
+		add_action( 'rest_api_init', [ OAuthRequestContext::class, 'reset' ], 1 );
+	}
+
+	/** Run DB migration if schema version has changed. */
+	public static function maybe_run_migration(): void {
+		$version_key = 'abilities_oauth_db_version';
+		$current     = '1.0.0';
+
+		if ( get_option( $version_key ) === $current ) {
+			return;
+		}
+
+		self::run_migration();
+		update_option( $version_key, $current );
+	}
+
+	/** Create or update the four kl_oauth_* tables via dbDelta(). Idempotent. */
+	public static function run_migration(): void {
+		global $wpdb;
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$charset = $wpdb->get_charset_collate();
+		$p       = $wpdb->prefix;
+
+		dbDelta( "CREATE TABLE `{$p}kl_oauth_clients` (
+			id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			client_id        VARCHAR(128)    NOT NULL,
+			client_name      VARCHAR(255)    NOT NULL DEFAULT '',
+			redirect_uris    TEXT            NOT NULL,
+			software_id      VARCHAR(128)    NOT NULL DEFAULT '',
+			software_version VARCHAR(32)     NOT NULL DEFAULT '',
+			scopes           TEXT            NOT NULL DEFAULT '',
+			registered_ip    VARCHAR(45)     NOT NULL DEFAULT '',
+			registered_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			revoked_at       DATETIME                 DEFAULT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY client_id (client_id)
+		) {$charset} ENGINE=InnoDB;" );
+
+		dbDelta( "CREATE TABLE `{$p}kl_oauth_codes` (
+			id                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			code_hash             VARCHAR(64)     NOT NULL,
+			client_id             VARCHAR(128)    NOT NULL,
+			user_id               BIGINT UNSIGNED NOT NULL,
+			redirect_uri          VARCHAR(2048)   NOT NULL DEFAULT '',
+			scope                 TEXT            NOT NULL DEFAULT '',
+			resource              VARCHAR(2048)   NOT NULL DEFAULT '',
+			code_challenge        VARCHAR(128)    NOT NULL,
+			code_challenge_method VARCHAR(8)      NOT NULL DEFAULT 'S256',
+			expires_at            DATETIME        NOT NULL,
+			used                  TINYINT(1)      NOT NULL DEFAULT 0,
+			created_at            DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY code_hash (code_hash),
+			KEY client_id (client_id)
+		) {$charset} ENGINE=InnoDB;" );
+
+		dbDelta( "CREATE TABLE `{$p}kl_oauth_tokens` (
+			id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			token_hash   VARCHAR(64)     NOT NULL,
+			client_id    VARCHAR(128)    NOT NULL,
+			user_id      BIGINT UNSIGNED NOT NULL,
+			scope        TEXT            NOT NULL DEFAULT '',
+			resource     VARCHAR(2048)   NOT NULL DEFAULT '',
+			token_type   VARCHAR(16)     NOT NULL DEFAULT 'Bearer',
+			expires_at   DATETIME        NOT NULL,
+			revoked      TINYINT(1)      NOT NULL DEFAULT 0,
+			last_used_at DATETIME                 DEFAULT NULL,
+			created_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY token_hash (token_hash),
+			KEY client_id (client_id)
+		) {$charset} ENGINE=InnoDB;" );
+
+		dbDelta( "CREATE TABLE `{$p}kl_oauth_refresh_tokens` (
+			id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			token_hash       VARCHAR(64)     NOT NULL,
+			access_token_id  BIGINT UNSIGNED NOT NULL,
+			client_id        VARCHAR(128)    NOT NULL,
+			user_id          BIGINT UNSIGNED NOT NULL,
+			scope            TEXT            NOT NULL DEFAULT '',
+			resource         VARCHAR(2048)   NOT NULL DEFAULT '',
+			family_id        VARCHAR(64)     NOT NULL,
+			expires_at       DATETIME        NOT NULL,
+			revoked          TINYINT(1)      NOT NULL DEFAULT 0,
+			rotated_at       DATETIME                 DEFAULT NULL,
+			rotated_to_hash  VARCHAR(64)              DEFAULT NULL,
+			created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY token_hash (token_hash),
+			KEY client_id (client_id),
+			KEY family_id_revoked (family_id, revoked)
+		) {$charset} ENGINE=InnoDB;" );
+	}
+
+	/** Pre-WP init priority 0: intercept .well-known and /oauth/authorize. */
+	public static function intercept_pre_wp_routes(): void {
+		$host = $_SERVER['HTTP_HOST'] ?? '';
+		if ( ! OAuthHostAllowlist::is_allowed( $host ) ) {
+			// Unknown host — log and 404. Do not serve OAuth metadata.
+			if ( self::is_well_known_or_oauth_path() ) {
+				oauth_log_boundary( 'boundary.oauth_host_rejected', [ 'ip' => oauth_client_ip() ] );
+				status_header( 404 );
+				exit;
+			}
+			return;
+		}
+
+		$path = strtok( $_SERVER['REQUEST_URI'] ?? '', '?' );
+
+		match ( $path ) {
+			'/.well-known/oauth-protected-resource'  => DiscoveryEndpoints::serve_protected_resource(),
+			'/.well-known/oauth-authorization-server'=> DiscoveryEndpoints::serve_authorization_server(),
+			'/.well-known/openid-configuration'      => DiscoveryEndpoints::serve_oidc_configuration(),
+			// /oauth/authorize handled by Phase 3.
+			default => null,
+		};
+	}
+
+	private static function is_well_known_or_oauth_path(): bool {
+		$path = strtok( $_SERVER['REQUEST_URI'] ?? '', '?' );
+		return str_starts_with( $path, '/.well-known/' ) || str_starts_with( $path, '/oauth/' );
+	}
+
+	/** Register REST routes for DCR, token, revoke. */
+	public static function register_rest_routes(): void {
+		$ns = self::REST_NS;
+
+		register_rest_route( $ns, '/oauth/register', [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ RegisterEndpoint::class, 'handle_get' ],
+				'permission_callback' => '__return_true',
+			],
+			[
+				'methods'             => 'POST',
+				'callback'            => [ RegisterEndpoint::class, 'handle_post' ],
+				'permission_callback' => '__return_true',
+			],
+		] );
+
+		register_rest_route( $ns, '/oauth/token', [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ TokenEndpoint::class, 'handle_get' ],
+				'permission_callback' => '__return_true',
+			],
+			[
+				'methods'             => 'POST',
+				'callback'            => [ TokenEndpoint::class, 'handle_post' ],
+				'permission_callback' => '__return_true',
+			],
+		] );
+
+		register_rest_route( $ns, '/oauth/revoke', [
+			[
+				'methods'             => 'GET',
+				'callback'            => [ RevokeEndpoint::class, 'handle_get' ],
+				'permission_callback' => '__return_true',
+			],
+			[
+				'methods'             => 'POST',
+				'callback'            => [ RevokeEndpoint::class, 'handle_post' ],
+				'permission_callback' => '__return_true',
+			],
+		] );
+	}
+
+	/**
+	 * Bearer token authentication hook (determine_current_user, priority 20).
+	 *
+	 * If no user is resolved yet and an OAuth Bearer token is present:
+	 * - Validates token (not expired, not revoked, resource matches)
+	 * - Sets OAuthRequestContext with user_id, scopes, resource, client_id, token_id
+	 * - Returns user_id to WordPress
+	 * - On failure: sets WWW-Authenticate header on the response (H.2.7)
+	 *
+	 * @param int|false $user_id Already-resolved user_id, or false/0.
+	 * @return int|false
+	 */
+	public static function authenticate_bearer( int|false $user_id ): int|false {
+		if ( $user_id ) {
+			return $user_id; // Already authenticated by a higher-priority method.
+		}
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+			return $user_id;
+		}
+
+		$auth_header = oauth_read_auth_header();
+		if ( ! $auth_header || ! str_starts_with( $auth_header, 'Bearer ' ) ) {
+			return $user_id;
+		}
+
+		$bearer_token = substr( $auth_header, 7 );
+		if ( ! $bearer_token ) {
+			return $user_id;
+		}
+
+		$row = TokenStore::lookup_access_token( $bearer_token );
+
+		if ( ! $row ) {
+			// Token not found — set WWW-Authenticate for discovery (H.2.7).
+			// Do not differentiate "not found" from "expired" to the client.
+			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
+			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'ip' => oauth_client_ip(), 'reason' => 'not_found_or_expired' ] );
+			return $user_id;
+		}
+
+		if ( $row->revoked ) {
+			self::schedule_www_authenticate( 'invalid_token', 'The access token has been revoked.' );
+			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'revoked' ] );
+			return $user_id;
+		}
+
+		// Timezone-safe expiry check (H.2.7).
+		$expires = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $row->expires_at, new \DateTimeZone( 'UTC' ) );
+		if ( $expires < new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) ) {
+			// Expired — same response as not-found (H.2.7: no differential).
+			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
+			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'not_found_or_expired' ] );
+			return $user_id;
+		}
+
+		// Resource indicator validation (H.1.2) — token must be bound to this site's MCP endpoint.
+		$current_resource = rest_url( 'mcp/mcp-adapter-default-server' );
+		if ( ! hash_equals( (string) $row->resource, $current_resource ) ) {
+			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
+			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'resource_mismatch' ] );
+			return $user_id;
+		}
+
+		// All checks passed — populate OAuthRequestContext (H.1.3).
+		$scopes = array_filter( explode( ' ', (string) $row->scope ) );
+		OAuthRequestContext::set(
+			(int) $row->user_id,
+			$scopes,
+			(string) $row->resource,
+			(string) $row->client_id,
+			(int) $row->id
+		);
+
+		// Update last_used_at (fire-and-forget).
+		TokenStore::touch( (string) $row->token_hash );
+
+		oauth_log_boundary( 'boundary.oauth_token_validated', [
+			'client_id' => $row->client_id,
+			'user_id'   => (int) $row->user_id,
+		] );
+
+		return (int) $row->user_id;
+	}
+
+	/**
+	 * Schedule a WWW-Authenticate header for the next response.
+	 * Uses rest_post_dispatch to add the header after WP REST routing completes.
+	 */
+	private static function schedule_www_authenticate( string $error_code, string $description ): void {
+		add_filter( 'rest_post_dispatch', static function ( $result ) use ( $error_code, $description ) {
+			$issuer  = function_exists( 'home_url' ) ? home_url() : '';
+			$meta_url = $issuer . '/.well-known/oauth-protected-resource';
+			header( sprintf(
+				'WWW-Authenticate: Bearer realm="abilities-mcp", resource_metadata="%s", error="%s", error_description="%s"',
+				esc_attr( $meta_url ),
+				esc_attr( $error_code ),
+				esc_attr( $description )
+			) );
+			return $result;
+		}, 10 );
+	}
+}
+
+// ─── Global helper functions ───────────────────────────────────────────────────
+// Defined in the global namespace so they are accessible from all endpoint classes
+// without import. Thin wrappers with no business logic.
+
+if ( ! function_exists( 'oauth_client_ip' ) ) {
+	/**
+	 * Return the client IP, respecting trusted proxy headers only when
+	 * WP_OAUTH_TRUST_FORWARDED_HOST is defined and true (H.2.5).
+	 */
+	function oauth_client_ip(): string {
+		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
+			$forwarded = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '';
+			if ( $forwarded ) {
+				return trim( explode( ',', $forwarded )[0] );
+			}
+		}
+		return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+	}
+}
+
+if ( ! function_exists( 'oauth_is_https' ) ) {
+	/**
+	 * Determine whether the current request is HTTPS (H.2.5).
+	 * Respects WP's is_ssl() and optionally X-Forwarded-Proto.
+	 */
+	function oauth_is_https(): bool {
+		if ( function_exists( 'is_ssl' ) && is_ssl() ) {
+			return true;
+		}
+		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
+			return ( $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '' ) === 'https';
+		}
+		return false;
+	}
+}
+
+if ( ! function_exists( 'oauth_read_auth_header' ) ) {
+	/**
+	 * Read the Authorization header with fallbacks for FastCGI/PHP-FPM (H.2.6).
+	 *
+	 * Order: apache_request_headers() → getallheaders() → $_SERVER['HTTP_AUTHORIZATION']
+	 *        → $_SERVER['REDIRECT_HTTP_AUTHORIZATION'].
+	 */
+	function oauth_read_auth_header(): ?string {
+		if ( function_exists( 'apache_request_headers' ) ) {
+			foreach ( apache_request_headers() as $k => $v ) {
+				if ( strtolower( $k ) === 'authorization' ) {
+					return $v;
+				}
+			}
+		}
+		if ( function_exists( 'getallheaders' ) ) {
+			foreach ( getallheaders() as $k => $v ) {
+				if ( strtolower( $k ) === 'authorization' ) {
+					return $v;
+				}
+			}
+		}
+		return $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'oauth_log_boundary' ) ) {
+	/**
+	 * Emit an OAuth event to the boundary log.
+	 * Metadata only — never logs token values, hashes, codes, or redirect URLs (H.4.3).
+	 *
+	 * @param string $event  Must start with 'boundary.oauth_'.
+	 * @param array  $tags   Allowlisted metadata fields only.
+	 */
+	function oauth_log_boundary( string $event, array $tags = [] ): void {
+		// Delegate to the BoundaryEventEmitter if available; otherwise fire the action directly.
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'mcp_adapter_boundary_event', $event, $tags, null );
+		}
+	}
+}
+
+if ( ! function_exists( 'token_error' ) ) {
+	/**
+	 * Emit a token endpoint error response per RFC 6749 §5.2 and exit (H.3.7).
+	 * Cache-Control: no-store. No CORS. No WP_REST_Response defaults.
+	 *
+	 * @param string $error       RFC 6749 error code.
+	 * @param string $description Human-readable description.
+	 * @param int    $status      HTTP status (400 default; 401 for invalid_client).
+	 */
+	function token_error( string $error, string $description, int $status = 400 ): never {
+		status_header( $status );
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		// No Access-Control-Allow-Origin (H.4.4).
+		echo wp_json_encode( [ 'error' => $error, 'error_description' => $description ] );
+		exit;
+	}
+}
+
+if ( ! function_exists( 'token_success' ) ) {
+	/**
+	 * Emit a token endpoint success response per RFC 6749 §5.1 and exit (H.3.7).
+	 *
+	 * @param array $body Response body.
+	 * @param int   $status HTTP status (200 default; 201 for DCR).
+	 */
+	function token_success( array $body, int $status = 200 ): never {
+		status_header( $status );
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		echo wp_json_encode( $body, JSON_UNESCAPED_SLASHES );
+		exit;
+	}
+}

--- a/src/Auth/OAuth/ClientRegistry.php
+++ b/src/Auth/OAuth/ClientRegistry.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * OAuth client registry — Dynamic Client Registration (RFC 7591).
+ *
+ * Manages kl_oauth_clients table: registration, lookup, revocation.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * CRUD operations for registered OAuth clients.
+ */
+final class ClientRegistry {
+
+	/** @return string */
+	private static function table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'kl_oauth_clients';
+	}
+
+	/**
+	 * Register a new client via DCR.
+	 *
+	 * @param string $client_name     Human-readable name.
+	 * @param array  $redirect_uris   Validated redirect URIs.
+	 * @param string $scope           Space-separated requested scopes.
+	 * @param string $software_id     Stable software product identifier.
+	 * @param string $software_version Bridge version string.
+	 * @param string $registered_ip   IP address of the registering agent.
+	 * @return string Opaque client_id (UUID).
+	 */
+	public static function register(
+		string $client_name,
+		array  $redirect_uris,
+		string $scope,
+		string $software_id,
+		string $software_version,
+		string $registered_ip
+	): string {
+		global $wpdb;
+
+		$client_id = wp_generate_uuid4();
+
+		$wpdb->insert(
+			self::table(),
+			[
+				'client_id'        => $client_id,
+				'client_name'      => mb_substr( $client_name, 0, 255 ),
+				'redirect_uris'    => wp_json_encode( $redirect_uris ),
+				'software_id'      => mb_substr( $software_id, 0, 128 ),
+				'software_version' => mb_substr( $software_version, 0, 32 ),
+				'scopes'           => $scope,
+				'registered_ip'    => mb_substr( $registered_ip, 0, 45 ),
+				'registered_at'    => gmdate( 'Y-m-d H:i:s' ),
+			],
+			[ '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ]
+		);
+
+		return $client_id;
+	}
+
+	/**
+	 * Look up a client by client_id. Returns null if not found or revoked.
+	 *
+	 * @param string $client_id
+	 * @return object|null Row from kl_oauth_clients.
+	 */
+	public static function find( string $client_id ): ?object {
+		global $wpdb;
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM `' . self::table() . '` WHERE client_id = %s AND revoked_at IS NULL',
+				$client_id
+			)
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Validate that a redirect_uri was registered for this client.
+	 * Loopback URIs match ignoring port (OAuth 2.1 §10.3.3).
+	 * Non-loopback URIs require exact string match.
+	 *
+	 * @param object $client   Row from find().
+	 * @param string $uri      URI to validate.
+	 * @return bool
+	 */
+	public static function redirect_uri_valid( object $client, string $uri ): bool {
+		$registered = json_decode( $client->redirect_uris, true ) ?: [];
+
+		if ( ! $uri ) {
+			return false;
+		}
+
+		$parsed_candidate = parse_url( $uri );
+		$candidate_host   = $parsed_candidate['host'] ?? '';
+		$candidate_scheme = $parsed_candidate['scheme'] ?? '';
+		$candidate_path   = $parsed_candidate['path'] ?? '/';
+		$candidate_query  = $parsed_candidate['query'] ?? '';
+		// parse_url wraps IPv6 literals in brackets: '[::1]' not '::1'.
+		$candidate_host_clean = trim( $candidate_host, '[]' );
+		$is_loopback          = in_array( $candidate_host_clean, [ '127.0.0.1', '::1' ], true );
+
+		// Non-loopback URIs must use HTTPS (RFC 8252 §8.3).
+		// Loopback URIs must use http (not https) with 127.0.0.1 or ::1 (RFC 8252 §7.3).
+		if ( ! $is_loopback && $candidate_scheme !== 'https' ) {
+			return false;
+		}
+
+		foreach ( $registered as $registered_uri ) {
+			if ( $is_loopback && $candidate_scheme === 'http' ) {
+				// Loopback: match scheme + host + path + query, ignore port (OAuth 2.1 §10.3.3).
+				$parsed_reg = parse_url( $registered_uri );
+				if (
+					( $parsed_reg['scheme'] ?? '' ) === $candidate_scheme &&
+					( $parsed_reg['host'] ?? '' ) === $candidate_host &&
+					( $parsed_reg['path'] ?? '/' ) === $candidate_path &&
+					( $parsed_reg['query'] ?? '' ) === $candidate_query
+				) {
+					return true;
+				}
+			} else {
+				// Non-loopback: exact match required (H.1.2).
+				if ( hash_equals( $registered_uri, $uri ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Revoke a client and cascade-revoke all its tokens.
+	 * All four writes happen in a single DB transaction.
+	 *
+	 * @param string $client_id
+	 */
+	public static function revoke( string $client_id ): void {
+		global $wpdb;
+
+		$wpdb->query( 'START TRANSACTION' );
+		try {
+			$wpdb->update( $wpdb->prefix . 'kl_oauth_tokens', [ 'revoked' => 1 ], [ 'client_id' => $client_id ], [ '%d' ], [ '%s' ] );
+			$wpdb->update( $wpdb->prefix . 'kl_oauth_refresh_tokens', [ 'revoked' => 1 ], [ 'client_id' => $client_id ], [ '%d' ], [ '%s' ] );
+			$wpdb->update( $wpdb->prefix . 'kl_oauth_codes', [ 'used' => 1 ], [ 'client_id' => $client_id ], [ '%d' ], [ '%s' ] );
+			$wpdb->update( self::table(), [ 'revoked_at' => gmdate( 'Y-m-d H:i:s' ) ], [ 'client_id' => $client_id ], [ '%s' ], [ '%s' ] );
+			$wpdb->query( 'COMMIT' );
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			throw $e;
+		}
+	}
+
+	/** Count active (non-revoked) clients for a given site. Used for site-level abuse cap. */
+	public static function count_active(): int {
+		global $wpdb;
+		return (int) $wpdb->get_var( 'SELECT COUNT(*) FROM `' . self::table() . '` WHERE revoked_at IS NULL' );
+	}
+
+	/** Return list of active clients for the Connected Bridges UI. */
+	public static function list_active( int $limit = 100, int $offset = 0 ): array {
+		global $wpdb;
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT client_id, client_name, software_id, software_version, scopes, registered_ip, registered_at
+				 FROM `' . self::table() . '`
+				 WHERE revoked_at IS NULL
+				 ORDER BY registered_at DESC
+				 LIMIT %d OFFSET %d',
+				$limit,
+				$offset
+			)
+		) ?: [];
+	}
+}

--- a/src/Auth/OAuth/DiscoveryEndpoints.php
+++ b/src/Auth/OAuth/DiscoveryEndpoints.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * OAuth 2.1 discovery endpoint handlers.
+ *
+ * Serves three .well-known paths (RFC 9728, RFC 8414, OIDC fallback).
+ * Intercepted at init priority 0, before WordPress routing.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Builds and serves the three OAuth discovery documents.
+ */
+final class DiscoveryEndpoints {
+
+	/** REST namespace used by the MCP adapter. */
+	private const MCP_NAMESPACE = 'mcp';
+	private const MCP_ROUTE     = 'mcp-adapter-default-server';
+	private const OAUTH_REST_NS = 'mcp'; // OAuth endpoints under same namespace as MCP.
+
+	/**
+	 * Compute the issuer URL from HTTP_HOST (timing-safe, avoids home_url() at init priority 0).
+	 * Validated against OAuthHostAllowlist before this is called.
+	 */
+	public static function issuer(): string {
+		$scheme = oauth_is_https() ? 'https' : 'http';
+		$host   = $_SERVER['HTTP_HOST'] ?? 'unknown';
+		// Strip port for issuer (issuer should not include port per RFC 8414 §2).
+		$host   = explode( ':', $host )[0];
+		return $scheme . '://' . $host;
+	}
+
+	/**
+	 * MCP resource URL — always constructed dynamically from issuer.
+	 * Namespace confirmed by Stream D: rest_url('mcp/mcp-adapter-default-server').
+	 */
+	public static function resource_url(): string {
+		return self::issuer() . '/wp-json/' . self::MCP_NAMESPACE . '/' . self::MCP_ROUTE;
+	}
+
+	/**
+	 * REST base for OAuth endpoints (under /wp-json/).
+	 */
+	private static function oauth_rest_base(): string {
+		return self::issuer() . '/wp-json/' . self::OAUTH_REST_NS;
+	}
+
+	/**
+	 * Serve RFC 9728 — Protected Resource Metadata.
+	 * Access-Control-Allow-Origin: * (public metadata, per H.4.4).
+	 */
+	public static function serve_protected_resource(): never {
+		self::json_response( [
+			'resource'                 => self::resource_url(),
+			'authorization_servers'    => [ self::issuer() ],
+			'scopes_supported'         => ScopeRegistry::all_scopes(),
+			'bearer_methods_supported' => [ 'header' ],
+			'resource_documentation'   => 'https://wickedevolutions.com/docs/abilities-mcp/oauth',
+		], cors: true );
+	}
+
+	/**
+	 * Serve RFC 8414 — Authorization Server Metadata.
+	 */
+	public static function serve_authorization_server(): never {
+		self::json_response( self::as_metadata(), cors: true );
+	}
+
+	/**
+	 * Serve OIDC Discovery fallback (L1, L5 lessons from Appendix D).
+	 * We do NOT issue ID tokens — metadata omits OIDC-specific fields to signal this.
+	 */
+	public static function serve_oidc_configuration(): never {
+		self::json_response( self::as_metadata(), cors: true );
+	}
+
+	/**
+	 * Authorization server metadata body (shared by RFC 8414 + OIDC endpoints).
+	 */
+	private static function as_metadata(): array {
+		$base = self::oauth_rest_base();
+		return [
+			'issuer'                                => self::issuer(),
+			'authorization_endpoint'                => self::issuer() . '/oauth/authorize',
+			'token_endpoint'                        => $base . '/oauth/token',
+			'registration_endpoint'                 => $base . '/oauth/register',
+			'revocation_endpoint'                   => $base . '/oauth/revoke',
+			'scopes_supported'                      => ScopeRegistry::all_scopes(),
+			'response_types_supported'              => [ 'code' ],
+			'grant_types_supported'                 => [ 'authorization_code', 'refresh_token' ],
+			'code_challenge_methods_supported'      => [ 'S256' ],
+			'token_endpoint_auth_methods_supported' => [ 'none' ],
+			// Intentionally omit: id_token_signing_alg_values_supported, subject_types_supported,
+			// userinfo_endpoint — we serve this for client-discovery compat ONLY. No ID tokens.
+		];
+	}
+
+	/**
+	 * Emit a JSON response and exit.
+	 * Discovery endpoints: CORS open. All others: no CORS (H.4.4).
+	 */
+	public static function json_response( array $data, int $status = 200, bool $cors = false ): never {
+		http_response_code( $status );
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Cache-Control: no-store' );
+		if ( $cors ) {
+			header( 'Access-Control-Allow-Origin: *' );
+		}
+		echo wp_json_encode( $data, JSON_UNESCAPED_SLASHES );
+		exit;
+	}
+}

--- a/src/Auth/OAuth/Endpoints/RegisterEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/RegisterEndpoint.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Dynamic Client Registration endpoint (RFC 7591).
+ *
+ * GET probe returns informational JSON (L2 lesson — some clients probe before POST).
+ * POST registers a new client, enforcing rate limits and redirect_uri validation.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+use WickedEvolutions\McpAdapter\Auth\OAuth\DiscoveryEndpoints;
+use WickedEvolutions\McpAdapter\Auth\OAuth\RateLimiter;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+/**
+ * Handles GET and POST /oauth/register.
+ */
+final class RegisterEndpoint {
+
+	/**
+	 * GET probe — L2: return informational JSON, not 404.
+	 */
+	public static function handle_get( \WP_REST_Request $request ): \WP_REST_Response {
+		return new \WP_REST_Response( [
+			'endpoint'    => 'oauth/register',
+			'methods'     => [ 'POST' ],
+			'description' => 'Dynamic Client Registration per RFC 7591',
+		], 200 );
+	}
+
+	/**
+	 * POST — register a new client.
+	 */
+	public static function handle_post( \WP_REST_Request $request ): never {
+		$ip = oauth_client_ip();
+
+		// Rate limit check (H.3.3).
+		$check = RateLimiter::check_dcr( $ip );
+		if ( $check !== true ) {
+			header( 'Retry-After: ' . $check );
+			DiscoveryEndpoints::json_response(
+				[ 'error' => 'temporarily_unavailable', 'error_description' => 'Too many registrations. Try again later.' ],
+				429
+			);
+		}
+
+		// Site-wide cap.
+		if ( RateLimiter::site_cap_reached() ) {
+			DiscoveryEndpoints::json_response(
+				[ 'error' => 'temporarily_unavailable', 'error_description' => 'Registration limit reached for this site.' ],
+				503
+			);
+		}
+
+		$body          = $request->get_json_params() ?? [];
+		$client_name   = sanitize_text_field( $body['client_name'] ?? 'Unknown Bridge' );
+		$redirect_uris = $body['redirect_uris'] ?? [];
+		$software_id   = sanitize_text_field( $body['software_id'] ?? '' );
+		$software_ver  = sanitize_text_field( $body['software_version'] ?? '' );
+		$scope         = sanitize_text_field( $body['scope'] ?? 'abilities:read' );
+
+		// Validate redirect_uris present and array.
+		if ( empty( $redirect_uris ) || ! is_array( $redirect_uris ) ) {
+			DiscoveryEndpoints::json_response(
+				[ 'error' => 'invalid_redirect_uri', 'error_description' => 'redirect_uris is required and must be an array.' ],
+				400
+			);
+		}
+
+		// Validate each redirect_uri: must be loopback HTTP or HTTPS. localhost rejected (RFC 8252 §7.3).
+		foreach ( $redirect_uris as $uri ) {
+			if ( ! self::is_valid_redirect_uri( (string) $uri ) ) {
+				DiscoveryEndpoints::json_response(
+					[ 'error' => 'invalid_redirect_uri', 'error_description' => 'redirect_uri must be http://127.0.0.1/... or https://...' ],
+					400
+				);
+			}
+		}
+
+		// Validate scopes — drop unknown scopes silently (be liberal in what we accept).
+		$requested_scopes = explode( ' ', $scope );
+		$valid_scopes     = array_filter(
+			$requested_scopes,
+			fn( $s ) => in_array( $s, ScopeRegistry::all_scopes(), true )
+		);
+		$scope = implode( ' ', $valid_scopes ) ?: 'abilities:read';
+
+		// Register.
+		$client_id = ClientRegistry::register(
+			$client_name,
+			$redirect_uris,
+			$scope,
+			$software_id,
+			$software_ver,
+			$ip
+		);
+
+		RateLimiter::record_dcr( $ip );
+
+		oauth_log_boundary( 'boundary.oauth_client_registered', [
+			'client_id'  => $client_id,
+			'ip'         => $ip,
+		] );
+
+		DiscoveryEndpoints::json_response( [
+			'client_id'                  => $client_id,
+			'client_id_issued_at'        => time(),
+			'client_name'                => $client_name,
+			'redirect_uris'              => $redirect_uris,
+			'grant_types'                => [ 'authorization_code', 'refresh_token' ],
+			'response_types'             => [ 'code' ],
+			'token_endpoint_auth_method' => 'none',
+			'scope'                      => $scope,
+		], 201 );
+	}
+
+	/**
+	 * Validate a redirect_uri.
+	 * Loopback: http://127.0.0.1:PORT/... allowed. localhost rejected.
+	 * Non-loopback: https:// only.
+	 */
+	private static function is_valid_redirect_uri( string $uri ): bool {
+		$parsed = parse_url( $uri );
+		$scheme = $parsed['scheme'] ?? '';
+		$host   = $parsed['host'] ?? '';
+
+		$is_loopback = in_array( $host, [ '127.0.0.1', '::1' ], true );
+		if ( $is_loopback && $scheme === 'http' ) {
+			return true;
+		}
+		if ( $scheme === 'https' ) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/Auth/OAuth/Endpoints/RevokeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/RevokeEndpoint.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Token revocation endpoint (RFC 7009).
+ *
+ * Always returns 200 regardless of whether the token existed.
+ * GET probe returns informational JSON (L2 lesson).
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\TokenStore;
+
+/**
+ * Handles GET and POST /oauth/revoke.
+ */
+final class RevokeEndpoint {
+
+	/** GET probe. */
+	public static function handle_get( \WP_REST_Request $request ): \WP_REST_Response {
+		return new \WP_REST_Response( [
+			'endpoint'    => 'oauth/revoke',
+			'methods'     => [ 'POST' ],
+			'description' => 'Token revocation per RFC 7009',
+		], 200 );
+	}
+
+	/**
+	 * POST — revoke a token. Always 200 per RFC 7009.
+	 */
+	public static function handle_post( \WP_REST_Request $request ): never {
+		$params = $request->get_params();
+		$token  = $params['token'] ?? '';
+
+		if ( $token ) {
+			TokenStore::revoke_by_plaintext( (string) $token );
+			oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'reason' => 'explicit_revocation' ] );
+		}
+
+		// RFC 7009: always 200, even when token not found.
+		token_success( [] );
+	}
+}

--- a/src/Auth/OAuth/Endpoints/TokenEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/TokenEndpoint.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * OAuth token endpoint — authorization_code and refresh_token grants.
+ *
+ * All responses via TokenEndpointResponse helper (H.3.7):
+ * Cache-Control: no-store, correct RFC 6749 §5.2 status codes, no CORS.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationCodeStore;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+use WickedEvolutions\McpAdapter\Auth\OAuth\TokenStore;
+
+/**
+ * Handles GET and POST /oauth/token.
+ */
+final class TokenEndpoint {
+
+	/** GET probe — L2 (H.2.6 lesson). */
+	public static function handle_get( \WP_REST_Request $request ): \WP_REST_Response {
+		return new \WP_REST_Response( [
+			'endpoint'    => 'oauth/token',
+			'methods'     => [ 'POST' ],
+			'grant_types' => [ 'authorization_code', 'refresh_token' ],
+		], 200 );
+	}
+
+	/** POST — dispatch by grant_type. */
+	public static function handle_post( \WP_REST_Request $request ): never {
+		$params     = $request->get_params();
+		$grant_type = sanitize_text_field( $params['grant_type'] ?? '' );
+
+		match ( $grant_type ) {
+			'authorization_code' => self::handle_auth_code( $params ),
+			'refresh_token'      => self::handle_refresh( $params ),
+			default              => token_error( 'unsupported_grant_type', 'Only authorization_code and refresh_token are supported.', 400 ),
+		};
+	}
+
+	/** authorization_code grant. */
+	private static function handle_auth_code( array $params ): never {
+		$code         = sanitize_text_field( $params['code'] ?? '' );
+		$client_id    = sanitize_text_field( $params['client_id'] ?? '' );
+		$redirect_uri = esc_url_raw( $params['redirect_uri'] ?? '' );
+		$code_verifier = $params['code_verifier'] ?? '';
+
+		if ( ! $code || ! $client_id || ! $redirect_uri || ! $code_verifier ) {
+			token_error( 'invalid_request', 'code, client_id, redirect_uri, and code_verifier are required.', 400 );
+		}
+
+		// Verify client exists (invalid_client → 401).
+		$client = ClientRegistry::find( $client_id );
+		if ( ! $client ) {
+			token_error( 'invalid_client', 'Client not found or revoked.', 401 );
+		}
+
+		// Consume code: verifies PKCE + client_id + redirect_uri bindings (H.1.1).
+		$code_row = AuthorizationCodeStore::consume( $code, $client_id, $redirect_uri, $code_verifier );
+		if ( ! $code_row ) {
+			token_error( 'invalid_grant', 'Authorization code is invalid, expired, or already used.', 400 );
+		}
+
+		// Issue token pair.
+		$token = TokenStore::issue(
+			$client_id,
+			(int) $code_row->user_id,
+			$code_row->scope,
+			$code_row->resource
+		);
+
+		oauth_log_boundary( 'boundary.oauth_token_issued', [
+			'client_id' => $client_id,
+			'user_id'   => (int) $code_row->user_id,
+		] );
+
+		token_success( $token );
+	}
+
+	/** refresh_token grant. */
+	private static function handle_refresh( array $params ): never {
+		$refresh_token = $params['refresh_token'] ?? '';
+		$client_id     = sanitize_text_field( $params['client_id'] ?? '' );
+
+		if ( ! $refresh_token || ! $client_id ) {
+			token_error( 'invalid_request', 'refresh_token and client_id are required.', 400 );
+		}
+
+		$client = ClientRegistry::find( $client_id );
+		if ( ! $client ) {
+			token_error( 'invalid_client', 'Client not found or revoked.', 401 );
+		}
+
+		$result = TokenStore::rotate( $refresh_token, $client_id );
+
+		if ( $result === null ) {
+			oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'client_id' => $client_id, 'reason' => 'refresh_replay_or_invalid' ] );
+			token_error( 'invalid_grant', 'Refresh token is invalid, expired, or has been revoked.', 400 );
+		}
+
+		if ( isset( $result['__idempotent_retry__'] ) ) {
+			// Within 30-second grace — we can't return the original plaintext (hashed).
+			// Return an error that tells the bridge to wait and retry — it still has the token.
+			// In practice the bridge should re-use the access token it already has.
+			token_error( 'invalid_grant', 'Refresh already rotated. Use current access token or retry after grace window.', 400 );
+		}
+
+		oauth_log_boundary( 'boundary.oauth_token_refreshed', [ 'client_id' => $client_id ] );
+
+		token_success( $result );
+	}
+}

--- a/src/Auth/OAuth/OAuthHostAllowlist.php
+++ b/src/Auth/OAuth/OAuthHostAllowlist.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * HTTP_HOST allowlist for OAuth pre-WP route interception.
+ *
+ * An attacker can set any Host header they like. Before serving discovery
+ * documents or consent pages, we validate HTTP_HOST against the known set
+ * of WordPress site domains. Unknown hosts get a 404 + boundary log entry.
+ *
+ * Built at plugins_loaded from $wpdb->blogs (multisite) or home_url() (single).
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Allowlist of valid HTTP_HOST values for this WordPress installation.
+ */
+final class OAuthHostAllowlist {
+
+	private static ?array $hosts = null;
+
+	/**
+	 * Build the allowlist. Called once at plugins_loaded.
+	 * Idempotent — safe to call multiple times.
+	 */
+	public static function build(): void {
+		if ( self::$hosts !== null ) {
+			return;
+		}
+
+		global $wpdb;
+
+		if ( function_exists( 'is_multisite' ) && is_multisite() && isset( $wpdb->blogs ) ) {
+			$rows = $wpdb->get_results(
+				"SELECT domain FROM {$wpdb->blogs} WHERE deleted = 0 AND archived = 0 AND spam = 0",
+				ARRAY_A
+			);
+			self::$hosts = array_map( 'strtolower', array_column( $rows ?: [], 'domain' ) );
+		}
+
+		// Always include the single-site home domain as a fallback.
+		if ( function_exists( 'home_url' ) ) {
+			$parsed = function_exists( 'wp_parse_url' )
+				? wp_parse_url( home_url(), PHP_URL_HOST )
+				: parse_url( home_url(), PHP_URL_HOST );
+			if ( $parsed ) {
+				self::$hosts[] = strtolower( (string) $parsed );
+			}
+		}
+
+		self::$hosts = array_values( array_unique( self::$hosts ?? [] ) );
+	}
+
+	/**
+	 * Inject a custom allowlist (for tests or WP-less environments).
+	 *
+	 * @param array $hosts Lowercase domain strings.
+	 */
+	public static function override( array $hosts ): void {
+		self::$hosts = array_map( 'strtolower', $hosts );
+	}
+
+	/** Reset (for tests). */
+	public static function reset(): void {
+		self::$hosts = null;
+	}
+
+	/**
+	 * Whether a Host value is in the allowlist.
+	 *
+	 * @param string $host Raw HTTP_HOST value (may include port).
+	 */
+	public static function is_allowed( string $host ): bool {
+		if ( self::$hosts === null ) {
+			self::build();
+		}
+		// Strip port from HTTP_HOST if present (e.g. "example.com:8080").
+		$host = strtolower( explode( ':', $host )[0] );
+		return in_array( $host, self::$hosts, true );
+	}
+}

--- a/src/Auth/OAuth/OAuthRequestContext.php
+++ b/src/Auth/OAuth/OAuthRequestContext.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Per-request OAuth context: scope propagation from bearer validation to ability execution.
+ *
+ * Populated by the bearer-auth filter; consumed by ability execution scope checks.
+ * Must never be cached — reset at the start of each request.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Singleton holding granted OAuth scope for the current HTTP request.
+ */
+final class OAuthRequestContext {
+
+	private static ?array $current = null;
+
+	/**
+	 * Populate context after successful bearer token validation.
+	 *
+	 * @param int    $user_id   WP user the token is bound to.
+	 * @param array  $scopes    Granted scope strings.
+	 * @param string $resource  Resource URL the token was issued for.
+	 * @param string $client_id DCR-issued client identifier.
+	 * @param int    $token_id  Row ID from kl_oauth_tokens.
+	 */
+	public static function set( int $user_id, array $scopes, string $resource, string $client_id, int $token_id ): void {
+		self::$current = compact( 'user_id', 'scopes', 'resource', 'client_id', 'token_id' );
+	}
+
+	/** Whether the current request was authenticated via an OAuth bearer token. */
+	public static function is_oauth_request(): bool {
+		return self::$current !== null;
+	}
+
+	/** WP user ID bound to the current token. Null when not an OAuth request. */
+	public static function user_id(): ?int {
+		return self::$current['user_id'] ?? null;
+	}
+
+	/** Scope strings granted on this token. Empty when not an OAuth request. */
+	public static function granted_scopes(): array {
+		return self::$current['scopes'] ?? [];
+	}
+
+	public static function client_id(): ?string {
+		return self::$current['client_id'] ?? null;
+	}
+
+	public static function token_id(): ?int {
+		return self::$current['token_id'] ?? null;
+	}
+
+	public static function resource(): ?string {
+		return self::$current['resource'] ?? null;
+	}
+
+	/** Clear — call at the start of each request in test contexts. */
+	public static function reset(): void {
+		self::$current = null;
+	}
+
+	/**
+	 * Check whether a required scope is present in the granted set.
+	 *
+	 * Sensitive scopes are NEVER implied by umbrella grants — each must be
+	 * explicitly present. See ScopeRegistry::SENSITIVE_SCOPES.
+	 *
+	 * @param string $required_scope
+	 * @return bool
+	 */
+	public static function has_scope( string $required_scope ): bool {
+		if ( ! self::is_oauth_request() ) {
+			return true; // Non-OAuth requests: scope check is irrelevant; WP caps govern.
+		}
+		return in_array( $required_scope, self::$current['scopes'], true );
+	}
+}

--- a/src/Auth/OAuth/RateLimiter.php
+++ b/src/Auth/OAuth/RateLimiter.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Per-IP rate limiter for OAuth DCR endpoint.
+ *
+ * Uses WordPress transients: fast, no extra infra needed.
+ * Limits: 10/min, 100/hr per IP (H.3.3).
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Checks and records DCR rate limits per IP address.
+ */
+final class RateLimiter {
+
+	private const LIMIT_PER_MINUTE = 10;
+	private const LIMIT_PER_HOUR   = 100;
+	private const SITE_CAP         = 1000; // Max unused clients per site before 503.
+
+	/**
+	 * Check whether the given IP is within rate limits for DCR.
+	 *
+	 * @param string $ip IPv4 or IPv6 address.
+	 * @return true|int True if allowed; seconds to retry-after on limit exceeded.
+	 */
+	public static function check_dcr( string $ip ): true|int {
+		$key_min = 'abilities_oauth_dcr_rpm_' . md5( $ip );
+		$key_hr  = 'abilities_oauth_dcr_rph_' . md5( $ip );
+
+		$count_min = (int) get_transient( $key_min );
+		if ( $count_min >= self::LIMIT_PER_MINUTE ) {
+			return 60;
+		}
+
+		$count_hr = (int) get_transient( $key_hr );
+		if ( $count_hr >= self::LIMIT_PER_HOUR ) {
+			return 3600;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Record a DCR registration for rate-limit tracking.
+	 *
+	 * @param string $ip
+	 */
+	public static function record_dcr( string $ip ): void {
+		$key_min = 'abilities_oauth_dcr_rpm_' . md5( $ip );
+		$key_hr  = 'abilities_oauth_dcr_rph_' . md5( $ip );
+
+		$count_min = (int) get_transient( $key_min );
+		set_transient( $key_min, $count_min + 1, 60 );
+
+		$count_hr = (int) get_transient( $key_hr );
+		set_transient( $key_hr, $count_hr + 1, 3600 );
+	}
+
+	/**
+	 * Check whether the site-wide unused-client cap is reached.
+	 * Returns true when registration should be refused.
+	 */
+	public static function site_cap_reached(): bool {
+		return ClientRegistry::count_active() >= self::SITE_CAP;
+	}
+}

--- a/src/Auth/OAuth/ScopeRegistry.php
+++ b/src/Auth/OAuth/ScopeRegistry.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * OAuth scope catalog — single source of truth for all scope strings.
+ *
+ * Naming: abilities:<category>:<op>  (three-segment, abilities: root namespace).
+ * Source: Appendix A of DESIGN — OAuth 2.1 in the Adapter 2026-04-27.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Registry of all valid OAuth scope strings and enforcement rules.
+ */
+final class ScopeRegistry {
+
+	/**
+	 * Scopes that MUST be explicitly granted — never implied by umbrella grants.
+	 * These map to Bucket 1/2/3 redaction territory + admin-only WP caps.
+	 */
+	public const SENSITIVE_SCOPES = [
+		'abilities:settings:read',
+		'abilities:settings:write',
+		'abilities:settings:delete',
+		'abilities:users:read',
+		'abilities:users:write',
+		'abilities:users:delete',
+		'abilities:filesystem:read',
+		'abilities:filesystem:write',
+		'abilities:filesystem:delete',
+		'abilities:plugins:read',
+		'abilities:plugins:write',
+		'abilities:plugins:delete',
+		'abilities:cron:read',
+		'abilities:cron:write',
+		'abilities:cron:delete',
+		'abilities:multisite:read',
+		'abilities:multisite:write',
+		'abilities:multisite:delete',
+		'abilities:themes:read',
+		'abilities:themes:write',
+		'abilities:themes:delete',
+		'abilities:rewrite:read',
+		'abilities:rewrite:write',
+		'abilities:rewrite:delete',
+	];
+
+	/**
+	 * Umbrella scopes and what they imply (excludes sensitive scopes by design).
+	 * Key = umbrella scope, value = array of implied non-sensitive scopes.
+	 */
+	public const UMBRELLA_IMPLICATIONS = [
+		'abilities:read'   => [
+			'abilities:content:read',
+			'abilities:taxonomies:read',
+			'abilities:media:read',
+			'abilities:menus:read',
+			'abilities:blocks:read',
+			'abilities:patterns:read',
+			'abilities:meta:read',
+			'abilities:comments:read',
+			'abilities:revisions:read',
+			'abilities:cache:read',
+			'abilities:knowledge:read',
+			'abilities:rest:read',
+			'abilities:site-health:read',
+			'abilities:diagnostic:read',
+			'abilities:editorial:read',
+			'abilities:mcp-adapter:read',
+		],
+		'abilities:write'  => [
+			'abilities:content:write',
+			'abilities:taxonomies:write',
+			'abilities:media:write',
+			'abilities:menus:write',
+			'abilities:blocks:write',
+			'abilities:patterns:write',
+			'abilities:meta:write',
+			'abilities:comments:write',
+			'abilities:cache:write',
+			'abilities:knowledge:write',
+			'abilities:mcp-adapter:write',
+			// Sensitive scopes intentionally excluded.
+		],
+		'abilities:delete' => [
+			'abilities:content:delete',
+			'abilities:taxonomies:delete',
+			'abilities:media:delete',
+			'abilities:menus:delete',
+			'abilities:patterns:delete',
+			'abilities:meta:delete',
+			'abilities:comments:delete',
+			'abilities:revisions:delete',
+			'abilities:knowledge:delete',
+			// Sensitive delete scopes intentionally excluded.
+		],
+	];
+
+	/** All valid scope strings (dynamic — built from catalog). */
+	private static ?array $all_scopes = null;
+
+	/**
+	 * Validate that every scope in $requested is a known, valid scope string.
+	 *
+	 * @param array $requested
+	 * @return array Invalid scope strings (empty = all valid).
+	 */
+	public static function unknown_scopes( array $requested ): array {
+		$known = self::all_scopes();
+		return array_values( array_filter( $requested, fn( $s ) => ! in_array( $s, $known, true ) ) );
+	}
+
+	/**
+	 * Expand umbrella scopes to their constituent non-sensitive scopes.
+	 * Does NOT expand sensitive scopes — those must be explicitly granted.
+	 *
+	 * @param array $scopes Raw scope list (may contain umbrella scopes).
+	 * @return array Deduplicated, expanded scope list.
+	 */
+	public static function expand( array $scopes ): array {
+		$expanded = [];
+		foreach ( $scopes as $scope ) {
+			$expanded[] = $scope;
+			if ( isset( self::UMBRELLA_IMPLICATIONS[ $scope ] ) ) {
+				$expanded = array_merge( $expanded, self::UMBRELLA_IMPLICATIONS[ $scope ] );
+			}
+		}
+		return array_values( array_unique( $expanded ) );
+	}
+
+	/**
+	 * Whether a scope is sensitive (requires explicit grant, never implied).
+	 */
+	public static function is_sensitive( string $scope ): bool {
+		return in_array( $scope, self::SENSITIVE_SCOPES, true );
+	}
+
+	/**
+	 * All valid scope strings.
+	 */
+	public static function all_scopes(): array {
+		if ( self::$all_scopes !== null ) {
+			return self::$all_scopes;
+		}
+
+		$non_sensitive_modules = [
+			'content', 'taxonomies', 'media', 'menus', 'blocks', 'patterns',
+			'meta', 'comments', 'revisions', 'cache', 'knowledge',
+		];
+		$read_only_modules     = [ 'rest', 'site-health', 'diagnostic', 'editorial' ];
+		$sensitive_modules     = [
+			'settings', 'users', 'filesystem', 'plugins', 'cron', 'multisite', 'themes', 'rewrite',
+		];
+		$suite_modules         = [ 'spectra', 'presto-player', 'surecart', 'astra' ];
+
+		$scopes = [ 'abilities:read', 'abilities:write', 'abilities:delete' ];
+
+		foreach ( $non_sensitive_modules as $m ) {
+			$scopes[] = "abilities:{$m}:read";
+			$scopes[] = "abilities:{$m}:write";
+			$scopes[] = "abilities:{$m}:delete";
+		}
+		foreach ( $read_only_modules as $m ) {
+			$scopes[] = "abilities:{$m}:read";
+		}
+		foreach ( $sensitive_modules as $m ) {
+			$scopes[] = "abilities:{$m}:read";
+			$scopes[] = "abilities:{$m}:write";
+			$scopes[] = "abilities:{$m}:delete";
+		}
+		foreach ( $suite_modules as $m ) {
+			$scopes[] = "abilities:{$m}:read";
+			$scopes[] = "abilities:{$m}:write";
+			$scopes[] = "abilities:{$m}:delete";
+		}
+		$scopes[] = 'abilities:mcp-adapter:read';
+		$scopes[] = 'abilities:mcp-adapter:write';
+
+		self::$all_scopes = array_values( array_unique( $scopes ) );
+		return self::$all_scopes;
+	}
+}

--- a/src/Auth/OAuth/TokenStore.php
+++ b/src/Auth/OAuth/TokenStore.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * OAuth token storage — access tokens, refresh tokens with family revocation.
+ *
+ * All tokens stored as SHA-256 hashes. Plaintext only in transit.
+ * Refresh token family revocation + 30-second idempotent retry grace (H.2.1).
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Manages kl_oauth_tokens and kl_oauth_refresh_tokens tables.
+ */
+final class TokenStore {
+
+	/** Grace window for idempotent refresh retry (seconds). */
+	private const ROTATION_GRACE_SECONDS = 30;
+
+	/** Access token TTL default (seconds). */
+	public const ACCESS_TTL = 86400;
+
+	/** Refresh token TTL default (seconds, rolling). */
+	public const REFRESH_TTL = 7776000;
+
+	private static function access_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'kl_oauth_tokens';
+	}
+
+	private static function refresh_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'kl_oauth_refresh_tokens';
+	}
+
+	/**
+	 * Issue a new access + refresh token pair.
+	 *
+	 * @param string $client_id
+	 * @param int    $user_id
+	 * @param string $scope     Space-separated scope string.
+	 * @param string $resource  Resource indicator URL.
+	 * @param int    $access_ttl  Override access TTL (seconds).
+	 * @param int    $refresh_ttl Override refresh TTL (seconds).
+	 * @return array{access_token: string, refresh_token: string, expires_in: int, scope: string}
+	 */
+	public static function issue(
+		string $client_id,
+		int    $user_id,
+		string $scope,
+		string $resource,
+		int    $access_ttl  = self::ACCESS_TTL,
+		int    $refresh_ttl = self::REFRESH_TTL
+	): array {
+		global $wpdb;
+
+		$access_token  = bin2hex( random_bytes( 32 ) );
+		$refresh_token = bin2hex( random_bytes( 32 ) );
+		$access_hash   = hash( 'sha256', $access_token );
+		$refresh_hash  = hash( 'sha256', $refresh_token );
+		$family_id     = bin2hex( random_bytes( 16 ) );
+		$now           = gmdate( 'Y-m-d H:i:s' );
+
+		// Apply operator TTL filters.
+		$context = compact( 'client_id', 'user_id', 'resource' ) + [ 'scope' => explode( ' ', $scope ) ];
+		$access_ttl  = (int) apply_filters( 'abilities_oauth_access_ttl', $access_ttl, $context );
+		$refresh_ttl = (int) apply_filters( 'abilities_oauth_refresh_ttl', $refresh_ttl, $context );
+		$min_ttl     = (int) apply_filters( 'abilities_oauth_min_grant_ttl', 300 );
+		$max_ttl     = (int) apply_filters( 'abilities_oauth_max_grant_ttl', 7776000 );
+		$access_ttl  = max( $min_ttl, min( $max_ttl, $access_ttl ) );
+
+		$access_expires  = gmdate( 'Y-m-d H:i:s', time() + $access_ttl );
+		$refresh_expires = gmdate( 'Y-m-d H:i:s', time() + $refresh_ttl );
+
+		$wpdb->query( 'START TRANSACTION' );
+		try {
+			$wpdb->insert(
+				self::access_table(),
+				[
+					'token_hash'  => $access_hash,
+					'client_id'   => $client_id,
+					'user_id'     => $user_id,
+					'scope'       => $scope,
+					'resource'    => $resource,
+					'expires_at'  => $access_expires,
+					'revoked'     => 0,
+					'created_at'  => $now,
+				],
+				[ '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s' ]
+			);
+			$access_id = (int) $wpdb->insert_id;
+
+			$wpdb->insert(
+				self::refresh_table(),
+				[
+					'token_hash'      => $refresh_hash,
+					'access_token_id' => $access_id,
+					'client_id'       => $client_id,
+					'user_id'         => $user_id,
+					'scope'           => $scope,
+					'resource'        => $resource,
+					'family_id'       => $family_id,
+					'expires_at'      => $refresh_expires,
+					'revoked'         => 0,
+					'created_at'      => $now,
+				],
+				[ '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s' ]
+			);
+
+			$wpdb->query( 'COMMIT' );
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			throw $e;
+		}
+
+		return [
+			'access_token'  => $access_token,
+			'refresh_token' => $refresh_token,
+			'expires_in'    => $access_ttl,
+			'scope'         => $scope,
+		];
+	}
+
+	/**
+	 * Rotate a refresh token. Returns a new access+refresh pair.
+	 * Implements family revocation and idempotent retry grace (H.2.1).
+	 *
+	 * @param string $refresh_token Plaintext refresh token.
+	 * @param string $client_id     Must match stored client_id.
+	 * @return array|null Token pair on success; null triggers invalid_grant.
+	 *                    Returns 'family_revoked' key = true if family was revoked.
+	 */
+	public static function rotate( string $refresh_token, string $client_id ): ?array {
+		global $wpdb;
+
+		$refresh_hash = hash( 'sha256', $refresh_token );
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM `' . self::refresh_table() . '` WHERE token_hash = %s AND client_id = %s',
+				$refresh_hash,
+				$client_id
+			)
+		);
+
+		if ( ! $row ) {
+			return null; // invalid_grant
+		}
+
+		if ( $row->revoked && is_null( $row->rotated_to_hash ) ) {
+			// Explicitly revoked (not via rotation) — hard invalid_grant.
+			return null;
+		}
+
+		if ( ! is_null( $row->rotated_at ) ) {
+			// This token was already rotated.
+			$rotated_at_ts = strtotime( $row->rotated_at . ' UTC' );
+			$age           = time() - $rotated_at_ts;
+
+			if ( $age <= self::ROTATION_GRACE_SECONDS ) {
+				// Idempotent retry within grace window — return the same pair.
+				$new_access_row = $wpdb->get_row(
+					$wpdb->prepare(
+						'SELECT * FROM `' . self::access_table() . '` WHERE token_hash = %s',
+						$row->rotated_to_hash
+					)
+				);
+				// We can't return the plaintext (it's hashed) — tell caller to re-issue with the existing row.
+				return [ '__idempotent_retry__' => true, 'access_row' => $new_access_row, 'refresh_row' => $row ];
+			} else {
+				// Replay detected — revoke entire family.
+				self::revoke_family( $row->family_id );
+				return null; // invalid_grant — also signals family revoked.
+			}
+		}
+
+		// Normal rotation path: token is valid, not yet rotated.
+		if ( $row->revoked ) {
+			return null;
+		}
+
+		// Check expiry.
+		$expires = \DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $row->expires_at, new \DateTimeZone( 'UTC' ) );
+		if ( $expires < new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) ) {
+			return null;
+		}
+
+		// Issue new pair.
+		$new_pair = self::issue( $row->client_id, (int) $row->user_id, $row->scope, $row->resource );
+		$new_refresh_hash = hash( 'sha256', $new_pair['refresh_token'] );
+
+		// Mark old refresh as rotated (atomic update with condition).
+		$updated = $wpdb->update(
+			self::refresh_table(),
+			[
+				'revoked'         => 1,
+				'rotated_at'      => gmdate( 'Y-m-d H:i:s' ),
+				'rotated_to_hash' => $new_refresh_hash,
+			],
+			[ 'token_hash' => $refresh_hash, 'revoked' => 0 ],
+			[ '%d', '%s', '%s' ],
+			[ '%s', '%d' ]
+		);
+
+		if ( ! $updated ) {
+			// Race lost — another rotation beat us.
+			return null;
+		}
+
+		return $new_pair;
+	}
+
+	/**
+	 * Look up a bearer access token. Returns the DB row or null.
+	 * MUST NOT be object-cached (H.1.2, H.2.7) — revocation is zero-latency.
+	 *
+	 * @param string $bearer_token Plaintext bearer token from Authorization header.
+	 * @return object|null
+	 */
+	public static function lookup_access_token( string $bearer_token ): ?object {
+		global $wpdb;
+
+		$hash = hash( 'sha256', $bearer_token );
+
+		// Direct DB query — intentionally bypasses object cache.
+		// Cached stale "token is valid" answers are a security issue.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM `' . self::access_table() . '` WHERE token_hash = %s',
+				$hash
+			)
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Revoke an access or refresh token by plaintext value.
+	 * Idempotent — always returns true per RFC 7009.
+	 */
+	public static function revoke_by_plaintext( string $token ): void {
+		global $wpdb;
+		$hash = hash( 'sha256', $token );
+		$wpdb->update( self::access_table(),  [ 'revoked' => 1 ], [ 'token_hash' => $hash ], [ '%d' ], [ '%s' ] );
+		$wpdb->update( self::refresh_table(), [ 'revoked' => 1 ], [ 'token_hash' => $hash ], [ '%d' ], [ '%s' ] );
+	}
+
+	/**
+	 * Revoke all tokens in a refresh token family (H.2.1 — replay detection).
+	 */
+	public static function revoke_family( string $family_id ): void {
+		global $wpdb;
+
+		$wpdb->query( 'START TRANSACTION' );
+		try {
+			$wpdb->query(
+				$wpdb->prepare(
+					'UPDATE `' . self::refresh_table() . '` SET revoked = 1 WHERE family_id = %s',
+					$family_id
+				)
+			);
+			// Revoke access tokens linked to this family's refresh tokens.
+			$wpdb->query(
+				$wpdb->prepare(
+					'UPDATE `' . self::access_table() . '` t
+					 JOIN `' . self::refresh_table() . '` r ON r.access_token_id = t.id
+					 SET t.revoked = 1
+					 WHERE r.family_id = %s',
+					$family_id
+				)
+			);
+			$wpdb->query( 'COMMIT' );
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+		}
+	}
+
+	/** Update last_used_at for a token. Fire-and-forget — no error handling needed. */
+	public static function touch( string $token_hash ): void {
+		global $wpdb;
+		$wpdb->update(
+			self::access_table(),
+			[ 'last_used_at' => gmdate( 'Y-m-d H:i:s' ) ],
+			[ 'token_hash' => $token_hash ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+	}
+}

--- a/src/Infrastructure/Observability/BoundaryEventEmitter.php
+++ b/src/Infrastructure/Observability/BoundaryEventEmitter.php
@@ -70,6 +70,8 @@ final class BoundaryEventEmitter {
 		'redaction_count_b1',
 		'redaction_count_b2',
 		'redaction_count_b3',
+		// OAuth boundary events (H.4.3): metadata only, never token values or hashes.
+		'client_id',
 	);
 
 	/**

--- a/tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php
+++ b/tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests for AuthorizationCodeStore pure-logic methods.
+ *
+ * DB-dependent methods (store, consume) require integration setup.
+ * compute_challenge() is pure and fully unit-testable.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationCodeStore;
+
+final class AuthorizationCodeStoreTest extends TestCase {
+
+	// --- PKCE S256 challenge computation (H.1.1) ---
+
+	public function test_compute_challenge_matches_rfc7636_s256(): void {
+		// RFC 7636 test vector.
+		$verifier  = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+		$expected  = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+		$challenge = AuthorizationCodeStore::compute_challenge( $verifier );
+
+		$this->assertSame( $expected, $challenge );
+	}
+
+	public function test_compute_challenge_different_verifiers_produce_different_challenges(): void {
+		$c1 = AuthorizationCodeStore::compute_challenge( 'verifier_one_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' );
+		$c2 = AuthorizationCodeStore::compute_challenge( 'verifier_two_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' );
+
+		$this->assertNotSame( $c1, $c2 );
+	}
+
+	public function test_compute_challenge_is_base64url_without_padding(): void {
+		$verifier  = str_repeat( 'a', 43 ); // minimum allowed length per RFC 7636.
+		$challenge = AuthorizationCodeStore::compute_challenge( $verifier );
+
+		// Must not contain '+', '/', or '=' (base64url, no padding).
+		$this->assertStringNotContainsString( '+', $challenge );
+		$this->assertStringNotContainsString( '/', $challenge );
+		$this->assertStringNotContainsString( '=', $challenge );
+	}
+}

--- a/tests/Unit/Auth/OAuth/ClientRegistryTest.php
+++ b/tests/Unit/Auth/OAuth/ClientRegistryTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for ClientRegistry::redirect_uri_valid().
+ *
+ * DB-dependent methods (register, find, revoke) are integration-only.
+ * redirect_uri_valid is pure logic and fully unit-testable.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+
+final class ClientRegistryTest extends TestCase {
+
+	/** Build a minimal client stub with serialized redirect_uris. */
+	private function client( array $uris ): object {
+		$obj                = new \stdClass();
+		$obj->redirect_uris = json_encode( $uris );
+		return $obj;
+	}
+
+	// --- Loopback URIs (RFC 8252 §7.3) ---
+
+	public function test_loopback_http_127_accepted(): void {
+		$client = $this->client( [ 'http://127.0.0.1/callback' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'http://127.0.0.1/callback' ) );
+	}
+
+	public function test_loopback_with_different_port_accepted(): void {
+		// OAuth 2.1 §10.3.3: loopback port must be ignored.
+		$client = $this->client( [ 'http://127.0.0.1/callback' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'http://127.0.0.1:9876/callback' ) );
+	}
+
+	public function test_loopback_localhost_rejected(): void {
+		// localhost is not a valid loopback in this context — use 127.0.0.1.
+		$client = $this->client( [ 'http://localhost/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'http://localhost/callback' ) );
+	}
+
+	public function test_loopback_path_mismatch_rejected(): void {
+		$client = $this->client( [ 'http://127.0.0.1/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'http://127.0.0.1/other' ) );
+	}
+
+	// --- Non-loopback URIs: must be HTTPS, exact match ---
+
+	public function test_https_non_loopback_exact_match_accepted(): void {
+		$client = $this->client( [ 'https://bridge.example.com/oauth/callback' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'https://bridge.example.com/oauth/callback' ) );
+	}
+
+	public function test_https_non_loopback_path_mismatch_rejected(): void {
+		$client = $this->client( [ 'https://bridge.example.com/oauth/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'https://bridge.example.com/different' ) );
+	}
+
+	public function test_http_non_loopback_rejected(): void {
+		$client = $this->client( [ 'https://bridge.example.com/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'http://bridge.example.com/callback' ) );
+	}
+
+	public function test_uri_not_in_registered_list_rejected(): void {
+		$client = $this->client( [ 'https://allowed.example.com/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'https://attacker.example.com/callback' ) );
+	}
+
+	public function test_empty_registered_list_rejected(): void {
+		$client = $this->client( [] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'https://example.com/callback' ) );
+	}
+
+	public function test_empty_requested_uri_rejected(): void {
+		$client = $this->client( [ 'https://example.com/callback' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, '' ) );
+	}
+
+	public function test_ipv6_loopback_accepted(): void {
+		$client = $this->client( [ 'http://[::1]/callback' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'http://[::1]/callback' ) );
+	}
+
+	public function test_multiple_registered_uris_finds_correct_one(): void {
+		$client = $this->client( [
+			'https://primary.example.com/callback',
+			'http://127.0.0.1/callback',
+		] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'https://primary.example.com/callback' ) );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $client, 'http://127.0.0.1/callback' ) );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $client, 'https://other.example.com/callback' ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php
+++ b/tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for DiscoveryEndpoints pure methods.
+ *
+ * Verifies issuer() construction and resource_url() composition.
+ * Output methods (serve_*) exit, so they are integration-only.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\DiscoveryEndpoints;
+
+final class DiscoveryEndpointsTest extends TestCase {
+
+	protected function setUp(): void {
+		// Reset server globals.
+		unset( $_SERVER['HTTP_HOST'], $_SERVER['HTTPS'], $_SERVER['HTTP_X_FORWARDED_PROTO'] );
+		// Ensure trust-forwarded is off by default.
+		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) ) {
+			// Constant already defined — test environment may vary; we'll test what we can.
+		}
+	}
+
+	public function test_issuer_uses_http_when_not_ssl(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		// is_ssl() stub returns false by default (no HTTPS server var).
+		$issuer = DiscoveryEndpoints::issuer();
+		$this->assertStringStartsWith( 'http://', $issuer );
+		$this->assertStringContainsString( 'example.com', $issuer );
+	}
+
+	public function test_issuer_strips_port(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com:8080';
+		$issuer = DiscoveryEndpoints::issuer();
+		$this->assertStringNotContainsString( ':8080', $issuer );
+		$this->assertStringContainsString( 'example.com', $issuer );
+	}
+
+	public function test_issuer_uses_https_when_ssl(): void {
+		$_SERVER['HTTP_HOST'] = 'secure.example.com';
+		$_SERVER['HTTPS']     = 'on';
+		$issuer = DiscoveryEndpoints::issuer();
+		$this->assertStringStartsWith( 'https://', $issuer );
+	}
+
+	public function test_resource_url_ends_with_mcp_path(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$resource = DiscoveryEndpoints::resource_url();
+		$this->assertStringEndsWith( '/wp-json/mcp/mcp-adapter-default-server', $resource );
+	}
+
+	public function test_resource_url_contains_issuer(): void {
+		$_SERVER['HTTP_HOST'] = 'mysite.example.com';
+		$issuer   = DiscoveryEndpoints::issuer();
+		$resource = DiscoveryEndpoints::resource_url();
+		$this->assertStringStartsWith( $issuer, $resource );
+	}
+}

--- a/tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for OAuthHostAllowlist.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthHostAllowlist;
+
+final class OAuthHostAllowlistTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthHostAllowlist::reset();
+	}
+
+	public function test_override_allows_injected_host(): void {
+		OAuthHostAllowlist::override( [ 'example.com', 'sub.example.com' ] );
+
+		$this->assertTrue( OAuthHostAllowlist::is_allowed( 'example.com' ) );
+		$this->assertTrue( OAuthHostAllowlist::is_allowed( 'sub.example.com' ) );
+	}
+
+	public function test_host_not_in_override_is_rejected(): void {
+		OAuthHostAllowlist::override( [ 'example.com' ] );
+
+		$this->assertFalse( OAuthHostAllowlist::is_allowed( 'evil.example.com' ) );
+		$this->assertFalse( OAuthHostAllowlist::is_allowed( 'attacker.com' ) );
+	}
+
+	public function test_port_is_stripped_before_check(): void {
+		OAuthHostAllowlist::override( [ 'example.com' ] );
+
+		// HTTP_HOST may include port — strip it before comparing.
+		$this->assertTrue( OAuthHostAllowlist::is_allowed( 'example.com:8080' ) );
+	}
+
+	public function test_empty_host_rejected(): void {
+		OAuthHostAllowlist::override( [ 'example.com' ] );
+
+		$this->assertFalse( OAuthHostAllowlist::is_allowed( '' ) );
+	}
+
+	public function test_reset_clears_override_and_rebuild_from_env(): void {
+		// Override with an arbitrary host, then reset.
+		OAuthHostAllowlist::override( [ 'custom-injected.example.com' ] );
+		OAuthHostAllowlist::reset();
+
+		// After reset, the override is gone — the injected host is no longer explicitly allowed.
+		// build() will re-run (from home_url stub) but won't include custom-injected.example.com.
+		$this->assertFalse( OAuthHostAllowlist::is_allowed( 'custom-injected.example.com' ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/OAuthRequestContextTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthRequestContextTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for OAuthRequestContext singleton.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+final class OAuthRequestContextTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+	}
+
+	public function test_is_not_oauth_request_before_set(): void {
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+	}
+
+	public function test_has_scope_returns_true_when_not_oauth(): void {
+		// Non-OAuth requests: WP caps govern, scope checks pass through.
+		$this->assertTrue( OAuthRequestContext::has_scope( 'abilities:write' ) );
+	}
+
+	public function test_granted_scopes_empty_before_set(): void {
+		$this->assertSame( [], OAuthRequestContext::granted_scopes() );
+	}
+
+	public function test_set_populates_context(): void {
+		OAuthRequestContext::set(
+			user_id: 7,
+			scopes: [ 'abilities:read', 'abilities:write' ],
+			resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			client_id: 'cl_abc',
+			token_id: 42
+		);
+
+		$this->assertTrue( OAuthRequestContext::is_oauth_request() );
+		$this->assertSame( 7, OAuthRequestContext::user_id() );
+		$this->assertSame( [ 'abilities:read', 'abilities:write' ], OAuthRequestContext::granted_scopes() );
+		$this->assertSame( 'https://example.com/wp-json/mcp/mcp-adapter-default-server', OAuthRequestContext::resource() );
+		$this->assertSame( 'cl_abc', OAuthRequestContext::client_id() );
+		$this->assertSame( 42, OAuthRequestContext::token_id() );
+	}
+
+	public function test_has_scope_exact_match(): void {
+		OAuthRequestContext::set( user_id: 1, scopes: [ 'abilities:read' ], resource: '', client_id: '', token_id: 0 );
+
+		$this->assertTrue( OAuthRequestContext::has_scope( 'abilities:read' ) );
+		$this->assertFalse( OAuthRequestContext::has_scope( 'abilities:write' ) );
+	}
+
+	public function test_reset_clears_context(): void {
+		OAuthRequestContext::set( user_id: 1, scopes: [ 'abilities:read' ], resource: '', client_id: '', token_id: 0 );
+		OAuthRequestContext::reset();
+
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+		$this->assertSame( [], OAuthRequestContext::granted_scopes() );
+	}
+}

--- a/tests/Unit/Auth/OAuth/RateLimiterTest.php
+++ b/tests/Unit/Auth/OAuth/RateLimiterTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for RateLimiter (DCR rate limiting).
+ *
+ * Uses the in-memory transient stub from bootstrap.php.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\RateLimiter;
+
+final class RateLimiterTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_transients'] = [];
+		$GLOBALS['wp_test_options']    = [];
+	}
+
+	public function test_first_request_from_ip_is_allowed(): void {
+		$result = RateLimiter::check_dcr( '203.0.113.5' );
+		$this->assertTrue( $result );
+	}
+
+	public function test_after_record_second_request_still_allowed_within_limit(): void {
+		$ip = '203.0.113.10';
+		RateLimiter::record_dcr( $ip );
+		$result = RateLimiter::check_dcr( $ip );
+		$this->assertTrue( $result );
+	}
+
+	public function test_record_increments_both_windows(): void {
+		$ip      = '203.0.113.20';
+		$key_min = 'abilities_oauth_dcr_rpm_' . md5( $ip );
+		$key_hr  = 'abilities_oauth_dcr_rph_' . md5( $ip );
+
+		RateLimiter::record_dcr( $ip );
+
+		$this->assertSame( 1, (int) get_transient( $key_min ) );
+		$this->assertSame( 1, (int) get_transient( $key_hr ) );
+	}
+
+	public function test_exceeded_hour_limit_returns_3600(): void {
+		$ip = '203.0.113.30';
+		$key_hr = 'abilities_oauth_dcr_rph_' . md5( $ip );
+		set_transient( $key_hr, 100, 3600 ); // exactly at hourly limit
+
+		$result = RateLimiter::check_dcr( $ip );
+		$this->assertSame( 3600, $result );
+	}
+
+	public function test_exceeded_minute_limit_returns_60(): void {
+		$ip = '203.0.113.40';
+		$key_min = 'abilities_oauth_dcr_rpm_' . md5( $ip );
+		set_transient( $key_min, 10, 60 ); // exactly at per-minute limit
+
+		$result = RateLimiter::check_dcr( $ip );
+		$this->assertSame( 60, $result );
+	}
+}

--- a/tests/Unit/Auth/OAuth/ScopeRegistryTest.php
+++ b/tests/Unit/Auth/OAuth/ScopeRegistryTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for ScopeRegistry — canonical scope catalog and expansion rules.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+final class ScopeRegistryTest extends TestCase {
+
+	// --- all_scopes ---
+
+	public function test_all_scopes_returns_non_empty_array(): void {
+		$scopes = ScopeRegistry::all_scopes();
+		$this->assertNotEmpty( $scopes );
+	}
+
+	public function test_all_scopes_contains_umbrella_scopes(): void {
+		$scopes = ScopeRegistry::all_scopes();
+		$this->assertContains( 'abilities:read', $scopes );
+		$this->assertContains( 'abilities:write', $scopes );
+		$this->assertContains( 'abilities:delete', $scopes );
+	}
+
+	public function test_all_scopes_are_unique(): void {
+		$scopes = ScopeRegistry::all_scopes();
+		$this->assertSame( count( $scopes ), count( array_unique( $scopes ) ) );
+	}
+
+	// --- is_sensitive ---
+
+	public function test_sensitive_scopes_are_flagged(): void {
+		// Users and plugins are canonical sensitive modules.
+		$this->assertTrue( ScopeRegistry::is_sensitive( 'abilities:users:read' ) );
+		$this->assertTrue( ScopeRegistry::is_sensitive( 'abilities:users:write' ) );
+		$this->assertTrue( ScopeRegistry::is_sensitive( 'abilities:plugins:write' ) );
+	}
+
+	public function test_non_sensitive_scope_not_flagged(): void {
+		$this->assertFalse( ScopeRegistry::is_sensitive( 'abilities:read' ) );
+		$this->assertFalse( ScopeRegistry::is_sensitive( 'abilities:content:read' ) );
+	}
+
+	// --- expand ---
+
+	public function test_expand_umbrella_read_implies_non_sensitive_reads(): void {
+		$expanded = ScopeRegistry::expand( [ 'abilities:read' ] );
+		$this->assertContains( 'abilities:read', $expanded );
+		$this->assertContains( 'abilities:content:read', $expanded );
+	}
+
+	public function test_expand_umbrella_read_does_not_imply_sensitive_scopes(): void {
+		$expanded = ScopeRegistry::expand( [ 'abilities:read' ] );
+		$this->assertNotContains( 'abilities:users:read', $expanded );
+		$this->assertNotContains( 'abilities:plugins:read', $expanded );
+	}
+
+	public function test_expand_umbrella_write_does_not_imply_sensitive_write(): void {
+		$expanded = ScopeRegistry::expand( [ 'abilities:write' ] );
+		$this->assertNotContains( 'abilities:users:write', $expanded );
+		$this->assertNotContains( 'abilities:plugins:write', $expanded );
+	}
+
+	public function test_expand_explicit_sensitive_scope_is_passed_through(): void {
+		// Explicitly requested sensitive scopes must survive expansion.
+		$expanded = ScopeRegistry::expand( [ 'abilities:users:read' ] );
+		$this->assertContains( 'abilities:users:read', $expanded );
+	}
+
+	public function test_expand_multiple_umbrellas(): void {
+		$expanded = ScopeRegistry::expand( [ 'abilities:read', 'abilities:write' ] );
+		$this->assertContains( 'abilities:read', $expanded );
+		$this->assertContains( 'abilities:write', $expanded );
+		$this->assertContains( 'abilities:content:read', $expanded );
+		$this->assertContains( 'abilities:content:write', $expanded );
+	}
+
+	public function test_expand_deduplicates_result(): void {
+		// Passing the same scope twice should not produce duplicates.
+		$expanded = ScopeRegistry::expand( [ 'abilities:read', 'abilities:read' ] );
+		$this->assertSame( count( $expanded ), count( array_unique( $expanded ) ) );
+	}
+
+	// --- unknown_scopes ---
+
+	public function test_unknown_scopes_returns_empty_for_valid_scopes(): void {
+		$unknown = ScopeRegistry::unknown_scopes( [ 'abilities:read', 'abilities:write' ] );
+		$this->assertEmpty( $unknown );
+	}
+
+	public function test_unknown_scopes_returns_unknown(): void {
+		$unknown = ScopeRegistry::unknown_scopes( [ 'abilities:read', 'abilities:bogus:scope' ] );
+		$this->assertContains( 'abilities:bogus:scope', $unknown );
+		$this->assertNotContains( 'abilities:read', $unknown );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -445,3 +445,53 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		}
 	}
 }
+
+// ---- OAuth stubs ----
+
+if ( ! function_exists( 'is_ssl' ) ) {
+	function is_ssl() {
+		return ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off';
+	}
+}
+
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( $path = '' ) {
+		$base = ( $GLOBALS['wp_test_home_url'] ?? 'https://example.com' ) . '/wp-json/';
+		return $base . ltrim( $path, '/' );
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return filter_var( (string) $url, FILTER_SANITIZE_URL ) ?: '';
+	}
+}
+
+if ( ! function_exists( 'status_header' ) ) {
+	function status_header( $code ) {
+		// No-op in test environment.
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() {
+		return sprintf(
+			'%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+			mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),
+			mt_rand( 0, 0xffff ),
+			mt_rand( 0, 0x0fff ) | 0x4000,
+			mt_rand( 0, 0x3fff ) | 0x8000,
+			mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff )
+		);
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $maybeint ) {
+		return abs( (int) $maybeint );
+	}
+}
+
+// Autoload global OAuth helpers from AuthorizationServer.php so all tests can call them.
+// The file guards each function with if(!function_exists(...)) so it's safe to require here.
+require_once dirname( __DIR__ ) . '/src/Auth/OAuth/AuthorizationServer.php';


### PR DESCRIPTION
## Summary

- Implements the full OAuth 2.1 authorization server foundation inside the adapter plugin (closes #30)
- 12 production PHP files in `src/Auth/OAuth/` covering all Appendix H binding amendments from the external security review
- 49 unit tests across 7 test classes; full suite 525/525 pass

## What's included

**Core classes:**
- `AuthorizationServer` — boot coordinator, DB migration (4 InnoDB tables via `dbDelta`), pre-WP route interception, bearer auth at `determine_current_user` priority 20
- `TokenStore` — access + refresh token issuance; refresh token family revocation with 30-second idempotent retry grace (H.2.1)
- `AuthorizationCodeStore` — PKCE S256 storage and atomic consumption (H.1.1)
- `ClientRegistry` — DCR client management; redirect URI validation with loopback port-agnostic matching and IPv6 `[::1]` bracket handling (H.1.2)
- `OAuthRequestContext` — per-request singleton for scope propagation from bearer validation to ability execution
- `ScopeRegistry` — 77 scope strings; sensitive scopes never implied by umbrella grants (H.1.3 / H.2.7)
- `OAuthHostAllowlist` — HTTP_HOST validated against `$wpdb->blogs` before any OAuth response (H.4.1)
- `RateLimiter` — 10/min + 100/hr per-IP DCR limit; 1000-client site cap (H.3.3)
- `DiscoveryEndpoints` — RFC 9728, RFC 8414, OIDC fallback; CORS only on discovery (H.4.4)

**Endpoint handlers:**
- `RegisterEndpoint` — RFC 7591 DCR; `localhost` rejected per RFC 8252 §7.3
- `TokenEndpoint` — `authorization_code` + `refresh_token` grants; differential-free `invalid_token` error (H.2.4)
- `RevokeEndpoint` — RFC 7009; always 200

**Cross-cutting:**
- WWW-Authenticate header via `rest_post_dispatch` filter (RFC 6750 §3)
- Timezone-safe token expiry via `DateTimeImmutable` UTC (H.2.3)
- Resource binding with `hash_equals` (H.1.3)
- Boundary event logging — metadata only, no token values or hashes (H.4.3)
- `client_id` added to `BoundaryEventEmitter::TAG_ALLOWLIST`
- 4-level Authorization header fallback for FastCGI/PHP-FPM (H.2.6)

## Test plan

- [x] `php vendor/bin/phpunit tests/Unit/Auth/OAuth/` — 49/49 pass
- [x] Full suite `php vendor/bin/phpunit tests/` — 525/525 pass
- [ ] Phase 6 live test on wickedevolutions.com (19-item matrix, after Phase 3)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)