### PR TITLE
infra: drop PHP 8.0+8.1 + retarget project automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1
         with:
-          project-url: https://github.com/orgs/Wicked-Evolutions/projects/3
+          project-url: https://github.com/orgs/Wicked-Evolutions/projects/4
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3']
+        php-version: ['8.2', '8.3']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3']
 
     steps:
       - uses: actions/checkout@v4

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -10,7 +10,7 @@
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Requires at least: 6.9
- * Requires PHP: 8.0
+ * Requires PHP: 8.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -10,7 +10,7 @@
  * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Requires at least: 6.9
- * Requires PHP: 8.1
+ * Requires PHP: 8.2
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "require-dev": {
         "yoast/phpunit-polyfills": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "require-dev": {
         "yoast/phpunit-polyfills": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b262993cb110237d3fee6ff16c397e6d",
+    "content-hash": "86e8f125ae994f164ece979a92fe9e76",
     "packages": [],
     "packages-dev": [
         {
@@ -1874,7 +1874,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b94df10c835a390b3eaa4174e7e96ee0",
+    "content-hash": "b262993cb110237d3fee6ff16c397e6d",
     "packages": [],
     "packages-dev": [
         {
@@ -1874,7 +1874,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary

- Drop PHP 8.0 and PHP 8.1 from the test matrix and the plugin's declared floor. Both are EOL (8.0 since November 2023, 8.1 since December 2025) and both rows had latent breakage that's been masked by the matrix never being green:
  - **8.0** — `doctrine/instantiator 2.0.0` (locked dev dep) requires PHP 8.1+.
  - **8.1** — Phase 1's `RateLimiter::check_dcr()` declares a `true|int` return type, which is PHP 8.2+ syntax (literal `true` types landed in 8.2). The `true|int` return is deliberate code; the right fix is scoping supported PHP versions to non-EOL releases, not widening the type.
- Retarget the project-automation workflow at the correct GitHub Project. This repo belongs on **project #4 (Abilities MCP Roadmap)**, not #3 (Abilities For Ai Roadmap).

## What changes

| File | Change |
|---|---|
| `composer.json` | `php` requirement: `>=8.0` → `>=8.2` |
| `composer.lock` | Regenerated. Diff is content-hash + platform pin only across both bumps — **no package versions move** |
| `abilities-mcp-adapter.php` | Plugin header `Requires PHP: 8.0` → `8.2` |
| `.github/workflows/test.yml` | Matrix: drop `'8.0'` and `'8.1'`; keep `'8.2'`, `'8.3'` |
| `.github/workflows/add-to-project.yml` | `project-url`: `…/projects/3` → `…/projects/4` |

Five files, no others.

## Caveat

The `add-to-project` job will continue to fail at runtime until `secrets.ADD_TO_PROJECT_PAT` is refreshed. That refresh is a separate manual step and is **out of scope here** — this PR only fixes the URL.

## Test plan

- [x] Local: each `composer update` produces lock diff = `content-hash` + `platform.php` only.
- [x] Local: `vendor/bin/phpunit tests/` — 525 / 525 green on PHP 8.5.
- [ ] CI: Tests workflow green on `8.2`, `8.3` matrix rows.
- [ ] CI: `add-to-project` will still fail (PAT-not-refreshed); ignore until Jacob handles it.

## Coordination note

After this lands, Phase 2 PR #34 will need a rebase before merge — sprint plan working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)