### PR TITLE
OAuth 2.1 — Phase 3: consent screen + Connected Bridges

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -265,3 +265,44 @@
 	font-weight: 600;
 	color: #1d2327;
 }
+
+/* --- Connected Bridges table (Phase 3) --- */
+.wp-mcp-bridges-table { max-width: 1200px; }
+
+.wp-mcp-bridges-table th.wp-mcp-adapter-col-action { width: 90px; }
+
+.wp-mcp-bridges-scope-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-size: 12px;
+	line-height: 1.6;
+}
+
+.wp-mcp-bridges-scope-list li {
+	margin: 0;
+}
+
+.wp-mcp-bridges-scope-list code {
+	font-size: 11px;
+	background: #f6f7f7;
+	padding: 1px 6px;
+	border-radius: 2px;
+}
+
+.wp-mcp-bridges-warning {
+	color: #dba617;
+	margin-left: 6px;
+	font-size: 14px;
+	cursor: help;
+}
+
+/* --- Recent OAuth activity audit slice (Phase 3) --- */
+.wp-mcp-bridges-audit { max-width: 1200px; font-size: 12px; }
+
+.wp-mcp-bridges-audit code {
+	font-size: 11px;
+	background: #f6f7f7;
+	padding: 1px 6px;
+	border-radius: 2px;
+}

--- a/assets/consent.css
+++ b/assets/consent.css
@@ -1,0 +1,256 @@
+/*
+ * Abilities MCP Adapter — consent screen stylesheet.
+ *
+ * Loaded ONLY by the public /oauth/authorize page (the consent screen).
+ * Mirrors the design language of the Abilities for AI plugin admin UI
+ * (the Phase 2 admin.css primitives) but is self-contained so the consent
+ * page can render without any WP admin context.
+ *
+ * No JavaScript on the consent page. All sensitive interactions are pure
+ * server-rendered HTML form submission, per Appendix H.4.5.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ */
+
+* { box-sizing: border-box; }
+
+.wp-mcp-consent-body {
+	margin: 0;
+	padding: 32px 16px;
+	background: #f0f0f1;
+	color: #1d2327;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.wp-mcp-consent-shell {
+	max-width: 640px;
+	margin: 0 auto;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 6px;
+	padding: 32px;
+	box-shadow: 0 1px 3px rgba( 0, 0, 0, .08 );
+}
+
+.wp-mcp-consent-shell--error {
+	border-color: #d63638;
+}
+
+.wp-mcp-consent-header {
+	margin-bottom: 24px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.wp-mcp-consent-h1 {
+	font-size: 22px;
+	font-weight: 600;
+	margin: 0 0 6px;
+	color: #1d2327;
+}
+
+.wp-mcp-consent-h2 {
+	font-size: 15px;
+	font-weight: 600;
+	margin: 24px 0 12px;
+	color: #1d2327;
+}
+
+.wp-mcp-consent-site {
+	margin: 0;
+	font-size: 13px;
+	color: #50575e;
+}
+
+.wp-mcp-consent-site-url {
+	display: block;
+	color: #646970;
+	font-family: monospace;
+	font-size: 12px;
+	margin-top: 2px;
+}
+
+.wp-mcp-consent-notice {
+	padding: 12px 16px;
+	border-left: 4px solid #2271b1;
+	background: #f0f6fc;
+	margin: 0 0 20px;
+	font-size: 13px;
+}
+
+.wp-mcp-consent-notice--reauth {
+	border-left-color: #dba617;
+	background: #fcf9e8;
+}
+
+.wp-mcp-consent-notice--incremental {
+	border-left-color: #2271b1;
+	background: #f0f6fc;
+}
+
+.wp-mcp-consent-form { margin: 0; }
+
+.wp-mcp-consent-identity {
+	margin: 0 0 16px;
+}
+
+.wp-mcp-consent-user {
+	margin: 0 0 12px;
+	font-size: 14px;
+}
+
+.wp-mcp-consent-user-login {
+	color: #646970;
+	font-size: 13px;
+	margin-left: 4px;
+}
+
+.wp-mcp-consent-label {
+	display: block;
+	font-weight: 600;
+	font-size: 13px;
+	margin-top: 12px;
+}
+
+.wp-mcp-consent-select {
+	margin-top: 4px;
+	padding: 6px 10px;
+	font-size: 14px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	min-width: 200px;
+}
+
+.wp-mcp-consent-hint {
+	margin: 4px 0 0;
+	font-size: 12px;
+	color: #646970;
+}
+
+.wp-mcp-consent-scopes { margin: 0 0 24px; }
+
+.wp-mcp-consent-group {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 12px 16px;
+	margin: 0 0 12px;
+}
+
+.wp-mcp-consent-group--sensitive {
+	border-color: #d63638;
+	background: #fcf0f1;
+}
+
+.wp-mcp-consent-legend {
+	font-weight: 600;
+	font-size: 13px;
+	padding: 0 6px;
+	color: #1d2327;
+}
+
+.wp-mcp-consent-lock {
+	margin-left: 4px;
+}
+
+.wp-mcp-consent-scope {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 6px 0;
+	font-size: 13px;
+	flex-wrap: wrap;
+}
+
+.wp-mcp-consent-scope input[type="checkbox"] {
+	margin: 0;
+}
+
+.wp-mcp-consent-scope-name {
+	font-family: monospace;
+	font-size: 12px;
+	background: #f6f7f7;
+	padding: 1px 6px;
+	border-radius: 2px;
+	color: #1d2327;
+}
+
+.wp-mcp-consent-scope--sensitive .wp-mcp-consent-scope-name {
+	background: #fcf0f1;
+	color: #d63638;
+}
+
+.wp-mcp-consent-badge {
+	display: inline-block;
+	font-size: 11px;
+	padding: 1px 8px;
+	border-radius: 10px;
+	background: #f6f7f7;
+	color: #50575e;
+}
+
+.wp-mcp-consent-badge--granted {
+	background: #edfaef;
+	color: #00a32a;
+}
+
+.wp-mcp-consent-badge--sensitive {
+	background: #fcf0f1;
+	color: #d63638;
+	font-weight: 600;
+}
+
+.wp-mcp-consent-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+	margin: 24px 0 0;
+	padding-top: 16px;
+	border-top: 1px solid #dcdcde;
+}
+
+.wp-mcp-consent-button {
+	font-size: 14px;
+	padding: 8px 18px;
+	border-radius: 4px;
+	border: 1px solid #2271b1;
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.wp-mcp-consent-button--primary {
+	background: #2271b1;
+	color: #fff;
+}
+
+.wp-mcp-consent-button--primary:hover {
+	background: #135e96;
+	border-color: #135e96;
+}
+
+.wp-mcp-consent-button--secondary {
+	background: #fff;
+	color: #2271b1;
+}
+
+.wp-mcp-consent-button--secondary:hover {
+	background: #f6f7f7;
+}
+
+.wp-mcp-consent-footer {
+	margin-top: 16px;
+}
+
+.wp-mcp-consent-footer-text {
+	margin: 0;
+	font-size: 12px;
+	color: #646970;
+}
+
+.wp-mcp-consent-error {
+	color: #d63638;
+	font-size: 14px;
+	margin: 0 0 12px;
+}

--- a/src/Admin/AdapterAdminPage.php
+++ b/src/Admin/AdapterAdminPage.php
@@ -138,6 +138,11 @@ final class AdapterAdminPage {
 		if ( isset( $_POST['mcp_safety_action'] ) ) {
 			SafetyTab::handle_save();
 		}
+
+		// Connected Bridges tab: revoke action.
+		if ( isset( $_POST[ ConnectedBridgesTab::ACTION_FIELD ] ) ) {
+			ConnectedBridgesTab::handle_action();
+		}
 	}
 
 	/**

--- a/src/Admin/Bridges/AuthHeaderProbe.php
+++ b/src/Admin/Bridges/AuthHeaderProbe.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Populate the H.2.6 Authorization-header diagnostic from a rolling counter
+ * of recent MCP requests.
+ *
+ * The Phase 2 placeholder shipped an extension hook
+ * (`mcp_adapter_bridges_authorization_header_status`) but no data source.
+ * Phase 3 provides a minimal data source that doesn't require new tables:
+ *   - On every MCP REST request, the bearer auth path notes whether the
+ *     Authorization header was present.
+ *   - The probe accumulates a small rolling counter (last 100 requests).
+ *   - The diagnostic filter returns the operator-facing status from this
+ *     counter.
+ *
+ * Hosting setup docs link is the same one the design doc references for
+ * the operator setup guide.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Admin\Bridges;
+
+use WickedEvolutions\McpAdapter\Admin\Tabs\ConnectedBridgesTab;
+
+/**
+ * Rolling Authorization-header presence counter + diagnostic resolver.
+ */
+final class AuthHeaderProbe {
+
+	/** WP option storing the rolling counter. */
+	public const OPTION = 'abilities_oauth_auth_header_probe';
+
+	/** Window size — last N MCP requests considered. */
+	public const WINDOW_SIZE = 100;
+
+	/** Hosting docs link surfaced to the operator. */
+	public const DOCS_URL = 'https://wickedevolutions.com/docs/abilities-mcp/oauth#authorization-header';
+
+	/** Register hook + filter. Idempotent. */
+	public static function register(): void {
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( ConnectedBridgesTab::DIAGNOSTIC_FILTER, array( self::class, 'resolve_status' ) );
+		}
+	}
+
+	/**
+	 * Record one observation.
+	 *
+	 * @param bool $header_present Whether the request's Authorization header was readable.
+	 */
+	public static function record( bool $header_present ): void {
+		$state = self::read_state();
+
+		$state['observations'][] = $header_present ? 1 : 0;
+		if ( count( $state['observations'] ) > self::WINDOW_SIZE ) {
+			$state['observations'] = array_slice( $state['observations'], -self::WINDOW_SIZE );
+		}
+		$state['last_seen_unix'] = time();
+
+		update_option( self::OPTION, $state, false );
+	}
+
+	/**
+	 * Filter callback returning the diagnostic shape Phase 2 expects.
+	 *
+	 * Returning `null` lets the placeholder fall back to its own "unknown"
+	 * default. Returning an array with `state` set to ok/warn/unknown
+	 * overrides the default.
+	 *
+	 * @param mixed $existing Previously-filtered value.
+	 * @return mixed
+	 */
+	public static function resolve_status( $existing = null ) {
+		$state = self::read_state();
+		$obs   = $state['observations'];
+
+		if ( empty( $obs ) ) {
+			// No requests yet — let the placeholder's "unknown" copy stand.
+			return $existing;
+		}
+
+		$present = array_sum( $obs );
+		$total   = count( $obs );
+		$missing = $total - $present;
+
+		if ( 0 === $present ) {
+			return array(
+				'state'    => 'warn',
+				'message'  => sprintf(
+					/* translators: 1: count of recent requests */
+					__( 'No Authorization header detected on the last %1$d MCP request(s). Your hosting may be stripping it before PHP sees it.', 'mcp-adapter' ),
+					$total
+				),
+				'docs_url' => self::DOCS_URL,
+			);
+		}
+
+		if ( $missing > 0 ) {
+			return array(
+				'state'    => 'warn',
+				'message'  => sprintf(
+					/* translators: 1: present count, 2: total count */
+					__( 'Authorization header detected on %1$d of the last %2$d MCP requests. Missing on the rest — your hosting may be stripping it intermittently.', 'mcp-adapter' ),
+					$present,
+					$total
+				),
+				'docs_url' => self::DOCS_URL,
+			);
+		}
+
+		return array(
+			'state'    => 'ok',
+			'message'  => sprintf(
+				/* translators: 1: count of recent requests */
+				__( 'Authorization header detected on the last %1$d MCP request(s).', 'mcp-adapter' ),
+				$total
+			),
+			'docs_url' => '',
+		);
+	}
+
+	/**
+	 * @return array{observations:int[], last_seen_unix:int}
+	 */
+	private static function read_state(): array {
+		$raw = get_option( self::OPTION, array() );
+		$obs = is_array( $raw['observations'] ?? null ) ? $raw['observations'] : array();
+		$obs = array_values( array_map( static fn( $v ) => (int) $v ? 1 : 0, $obs ) );
+		return array(
+			'observations'   => $obs,
+			'last_seen_unix' => (int) ( $raw['last_seen_unix'] ?? 0 ),
+		);
+	}
+
+	/** For tests. */
+	public static function clear(): void {
+		delete_option( self::OPTION );
+	}
+}

--- a/src/Admin/Bridges/BoundaryAuditBuffer.php
+++ b/src/Admin/Bridges/BoundaryAuditBuffer.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Capture OAuth boundary events in a bounded ring buffer for the
+ * Connected Bridges audit slice.
+ *
+ * The MCP adapter's boundary log is fire-and-forget — Phase 1 never shipped a
+ * persistent storage backend. To render a useful "recent OAuth activity" view
+ * without changing the boundary contract, this class subscribes to the
+ * `mcp_adapter_boundary_event` action and stores OAuth events in a small
+ * WP option (last 25 events). Bounded size keeps option payload < 4 KB.
+ *
+ * Tags are already sanitized by {@see BoundaryEventEmitter::sanitize()} —
+ * we never see token values, scope strings, or hashes.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Admin\Bridges;
+
+/**
+ * Subscribe + read the OAuth audit slice.
+ */
+final class BoundaryAuditBuffer {
+
+	/** WP option name. */
+	public const OPTION = 'abilities_oauth_audit_buffer';
+
+	/** Maximum entries retained (FIFO). */
+	public const MAX_ENTRIES = 25;
+
+	/** OAuth events we record. */
+	private const RECORDED_EVENTS = array(
+		'boundary.oauth_token_issued',
+		'boundary.oauth_token_refreshed',
+		'boundary.oauth_token_revoked',
+		'boundary.oauth_authorization_granted',
+		'boundary.oauth_authorization_auto_approved',
+		'boundary.oauth_authorization_denied',
+		'boundary.oauth_authorize_error',
+		'boundary.oauth_invalid_token',
+	);
+
+	/** Register the action listener. Idempotent. */
+	public static function register(): void {
+		if ( function_exists( 'add_action' ) ) {
+			add_action( 'mcp_adapter_boundary_event', array( self::class, 'capture' ), 100, 3 );
+		}
+	}
+
+	/**
+	 * Action callback. Filters to OAuth events, then appends to the ring buffer.
+	 *
+	 * @param string     $event       Boundary event name.
+	 * @param array      $tags        Already-sanitized tags.
+	 * @param float|null $duration_ms Unused.
+	 */
+	public static function capture( string $event, array $tags = array(), ?float $duration_ms = null ): void {
+		if ( ! in_array( $event, self::RECORDED_EVENTS, true ) ) {
+			return;
+		}
+
+		$buffer = self::read();
+
+		$buffer[] = array(
+			'time'       => time(),
+			'event'      => $event,
+			'client_id'  => isset( $tags['client_id'] ) && is_string( $tags['client_id'] ) ? $tags['client_id'] : '',
+			'user_id'    => isset( $tags['user_id'] ) && is_numeric( $tags['user_id'] ) ? (int) $tags['user_id'] : 0,
+			'reason'     => isset( $tags['reason'] ) && is_string( $tags['reason'] ) ? $tags['reason'] : '',
+			'error_code' => isset( $tags['error_code'] ) && is_string( $tags['error_code'] ) ? $tags['error_code'] : '',
+		);
+
+		// Trim to MAX_ENTRIES — keep the most recent N.
+		if ( count( $buffer ) > self::MAX_ENTRIES ) {
+			$buffer = array_slice( $buffer, -self::MAX_ENTRIES );
+		}
+
+		update_option( self::OPTION, $buffer, false );
+	}
+
+	/**
+	 * Read the audit buffer, newest first.
+	 *
+	 * @return array<int, array{time:int,event:string,client_id:string,user_id:int,reason:string,error_code:string}>
+	 */
+	public static function read(): array {
+		$raw = get_option( self::OPTION, array() );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		// Defensive — keep only entries with the expected keys.
+		$out = array();
+		foreach ( $raw as $entry ) {
+			if ( ! is_array( $entry ) || ! isset( $entry['event'] ) ) {
+				continue;
+			}
+			$out[] = array(
+				'time'       => (int) ( $entry['time'] ?? 0 ),
+				'event'      => (string) $entry['event'],
+				'client_id'  => (string) ( $entry['client_id'] ?? '' ),
+				'user_id'    => (int) ( $entry['user_id'] ?? 0 ),
+				'reason'     => (string) ( $entry['reason'] ?? '' ),
+				'error_code' => (string) ( $entry['error_code'] ?? '' ),
+			);
+		}
+		return $out;
+	}
+
+	/** For tests. */
+	public static function clear(): void {
+		delete_option( self::OPTION );
+	}
+}

--- a/src/Admin/Bridges/BridgeRowProjector.php
+++ b/src/Admin/Bridges/BridgeRowProjector.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Project a Connected Bridges table row from raw OAuth data.
+ *
+ * Pure logic — given a client row + the most-recent token row + the last
+ * interactive consent timestamp, returns a flat array of display values.
+ * Tested without any DB.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Admin\Bridges;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PolicyStore;
+
+/**
+ * Build the display-ready shape of one bridge row.
+ */
+final class BridgeRowProjector {
+
+	/** Number of days before the silent-cap to start showing the warning icon (per H.2.4). */
+	public const SILENT_WARNING_DAYS_BEFORE_CAP = 30;
+
+	/**
+	 * Project a single row.
+	 *
+	 * @param object   $client                 Row from kl_oauth_clients (client_id, client_name, scopes, registered_at, ...)
+	 * @param ?object  $latest_token           Most recent active token row, or null when none.
+	 * @param ?int     $last_interactive_unix  UNIX timestamp of last interactive consent.
+	 * @param int      $now_unix               Injected for testability.
+	 * @param int      $silent_cap_days        From {@see PolicyStore::consent_max_silent_days()}.
+	 * @return array{
+	 *   client_id:string,
+	 *   client_name:string,
+	 *   software:string,
+	 *   user_id:int,
+	 *   scopes:string[],
+	 *   last_used_at:?string,
+	 *   expires_at:?string,
+	 *   last_consent_days:?int,
+	 *   show_silent_warning:bool,
+	 *   registered_at:string
+	 * }
+	 */
+	public static function project(
+		object  $client,
+		?object $latest_token,
+		?int    $last_interactive_unix,
+		int     $now_unix,
+		int     $silent_cap_days
+	): array {
+		$client_id   = (string) ( $client->client_id ?? '' );
+		$client_name = (string) ( $client->client_name ?? '' );
+		$software_id = (string) ( $client->software_id ?? '' );
+		$software_v  = (string) ( $client->software_version ?? '' );
+		$software    = trim( $software_id . ( '' !== $software_v ? ' ' . $software_v : '' ) );
+
+		$scope_str = (string) ( $latest_token->scope ?? $client->scopes ?? '' );
+		$scopes    = '' === $scope_str ? array() : array_values( array_filter( explode( ' ', $scope_str ) ) );
+
+		$user_id = (int) ( $latest_token->user_id ?? 0 );
+
+		$last_used = isset( $latest_token->last_used_at ) && '' !== (string) $latest_token->last_used_at
+			? (string) $latest_token->last_used_at
+			: null;
+
+		$expires = isset( $latest_token->expires_at ) && '' !== (string) $latest_token->expires_at
+			? (string) $latest_token->expires_at
+			: null;
+
+		$days_since = null;
+		if ( null !== $last_interactive_unix ) {
+			$delta      = max( 0, $now_unix - $last_interactive_unix );
+			$days_since = (int) floor( $delta / 86400 );
+		}
+
+		$show_warning = false;
+		if ( null !== $days_since ) {
+			$threshold    = max( 0, $silent_cap_days - self::SILENT_WARNING_DAYS_BEFORE_CAP );
+			$show_warning = $days_since >= $threshold;
+		}
+
+		return array(
+			'client_id'           => $client_id,
+			'client_name'         => $client_name,
+			'software'            => $software,
+			'user_id'             => $user_id,
+			'scopes'              => $scopes,
+			'last_used_at'        => $last_used,
+			'expires_at'          => $expires,
+			'last_consent_days'   => $days_since,
+			'show_silent_warning' => $show_warning,
+			'registered_at'       => (string) ( $client->registered_at ?? '' ),
+		);
+	}
+}

--- a/src/Admin/Tabs/ConnectedBridgesTab.php
+++ b/src/Admin/Tabs/ConnectedBridgesTab.php
@@ -1,28 +1,19 @@
 <?php
 /**
- * Connected Bridges tab — Phase 2 placeholder shell.
+ * Connected Bridges admin tab — Phase 3.
  *
- * The full bridge listing (registered clients, authorized user, scopes, last
- * used, expires, revoke action) is Phase 3 work. This file ships only the
- * empty tab shell so the operator sees the navigation entry, plus the
- * Authorization-header diagnostic hook reserved by the OAuth design doc
- * (Appendix H.2.6 — "Connected Bridges diagnostic tab").
+ * Lists OAuth-registered bridges, their authorized user, granted scopes,
+ * last use / expiry, and last interactive consent age (Appendix H.2.4).
+ * Shows the H.2.6 Authorization-header diagnostic. Renders a recent OAuth
+ * audit slice so the operator can verify activity at a glance.
  *
- * Diagnostic data source — extension hook:
+ * Revoke uses {@see ClientRegistry::revoke()} which already does the
+ * cascade-revoke transaction Phase 1 shipped — propagation is zero-delay
+ * because token lookups (per H.1.2 / H.2.7) bypass the object cache.
  *
- *   apply_filters( 'mcp_adapter_bridges_authorization_header_status', null );
- *
- * Returning shape — null OR an associative array:
- *   [
- *     'state'   => 'ok' | 'warn' | 'unknown', // required
- *     'message' => string,                    // operator-facing line
- *     'docs_url'=> string,                    // optional link target
- *   ]
- *
- * Phase 1's AuthorizationServer is free to implement this filter once the
- * /oauth/echo-headers debug endpoint exists. Until that ships, the tab
- * renders the "unknown" fallback. No Phase 3 functionality is embedded
- * here — just the seam.
+ * The diagnostic seam (`mcp_adapter_bridges_authorization_header_status`)
+ * shipped in Phase 2 is preserved unchanged — Phase 3 just provides a
+ * data source via {@see AuthHeaderProbe}.
  *
  * Copyright (C) 2026 Wicked Evolutions
  * License: GPL-2.0-or-later
@@ -34,29 +25,224 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Admin\Tabs;
 
+use function WickedEvolutions\McpAdapter\Auth\OAuth\oauth_log_boundary;
+use WickedEvolutions\McpAdapter\Admin\AdapterAdminPage;
+use WickedEvolutions\McpAdapter\Admin\Bridges\BoundaryAuditBuffer;
+use WickedEvolutions\McpAdapter\Admin\Bridges\BridgeRowProjector;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\LastConsentLookup;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PolicyStore;
+
 /**
- * Placeholder Connected Bridges tab + reserved diagnostic seam.
+ * Renders the Connected Bridges tab and handles its form actions.
  */
 final class ConnectedBridgesTab {
 
 	/** Filter hook reserved for the H.2.6 Authorization-header diagnostic. */
 	public const DIAGNOSTIC_FILTER = 'mcp_adapter_bridges_authorization_header_status';
 
+	/** POST field marking a bridges-tab action submission. */
+	public const ACTION_FIELD = 'mcp_bridges_action';
+
+	/** Nonce action / field. */
+	public const NONCE_ACTION = 'mcp_bridges_action';
+	public const NONCE_FIELD  = 'mcp_bridges_nonce';
+
+	/** Action values. */
+	public const ACTION_REVOKE = 'revoke';
+
 	/**
-	 * Render the placeholder body.
+	 * Render the tab body.
 	 */
 	public static function render(): void {
+		// Operator may have just performed a revoke — surface the result.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only flash query arg
+		$flash = isset( $_GET['mcp_bridges_flash'] ) ? sanitize_key( wp_unslash( (string) $_GET['mcp_bridges_flash'] ) ) : '';
+		if ( '' !== $flash ) {
+			self::render_flash( $flash );
+		}
+
+		$clients = ClientRegistry::list_active( 100, 0 );
+
+		if ( empty( $clients ) ) {
+			?>
+			<p><?php esc_html_e( 'No bridges have completed the OAuth authorization flow yet.', 'mcp-adapter' ); ?></p>
+
+			<div class="wp-mcp-adapter-empty-state">
+				<p class="wp-mcp-adapter-empty-state-title"><?php esc_html_e( 'No bridges yet', 'mcp-adapter' ); ?></p>
+				<p>
+					<?php esc_html_e( 'When a bridge completes the OAuth authorization flow, it will appear here with the user it acts on behalf of, the scopes it requested, and a revoke action.', 'mcp-adapter' ); ?>
+				</p>
+			</div>
+			<?php
+		} else {
+			self::render_table( $clients );
+		}
+
+		self::render_audit_slice();
+		self::render_authorization_header_diagnostic();
+	}
+
+	/**
+	 * Render the bridges table.
+	 *
+	 * @param object[] $clients
+	 */
+	private static function render_table( array $clients ): void {
+		$silent_cap = PolicyStore::consent_max_silent_days();
+		$now        = time();
+		$revoke_url = AdapterAdminPage::tab_url( AdapterAdminPage::TAB_BRIDGES );
 		?>
-		<p><?php esc_html_e( 'Bridges that have authorized themselves against this site via OAuth 2.1 will be listed here. The full Connected Bridges UI ships in the next release.', 'mcp-adapter' ); ?></p>
+		<h2><?php esc_html_e( 'Authorized bridges', 'mcp-adapter' ); ?></h2>
+		<table class="widefat striped wp-mcp-adapter-table wp-mcp-bridges-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Bridge', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'User', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Scopes', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Last used', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Expires', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Last consent', 'mcp-adapter' ); ?></th>
+					<th class="wp-mcp-adapter-col-action"><?php esc_html_e( 'Action', 'mcp-adapter' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+			<?php foreach ( $clients as $client ) :
+				$latest_token = self::latest_token_for( (string) $client->client_id );
+				$last_consent = LastConsentLookup::timestamp_for( (string) $client->client_id, (int) ( $latest_token->user_id ?? 0 ) );
+				$row          = BridgeRowProjector::project( $client, $latest_token, $last_consent, $now, $silent_cap );
+				$user_login   = self::user_login( $row['user_id'] );
+				?>
+				<tr>
+					<td>
+						<strong><?php echo esc_html( '' !== $row['client_name'] ? $row['client_name'] : __( 'Unnamed bridge', 'mcp-adapter' ) ); ?></strong>
+						<?php if ( '' !== $row['software'] ) : ?>
+							<br><span class="wp-mcp-adapter-hint"><?php echo esc_html( $row['software'] ); ?></span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ( $row['user_id'] > 0 ) : ?>
+							<?php echo esc_html( '' !== $user_login ? $user_login : '#' . $row['user_id'] ); ?>
+						<?php else : ?>
+							<span class="wp-mcp-adapter-hint"><?php esc_html_e( 'No active token', 'mcp-adapter' ); ?></span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<?php if ( ! empty( $row['scopes'] ) ) : ?>
+							<ul class="wp-mcp-bridges-scope-list">
+								<?php foreach ( $row['scopes'] as $scope ) : ?>
+									<li><code><?php echo esc_html( $scope ); ?></code></li>
+								<?php endforeach; ?>
+							</ul>
+						<?php else : ?>
+							<span class="wp-mcp-adapter-hint">&mdash;</span>
+						<?php endif; ?>
+					</td>
+					<td><?php echo esc_html( self::format_datetime( $row['last_used_at'] ) ); ?></td>
+					<td><?php echo esc_html( self::format_datetime( $row['expires_at'] ) ); ?></td>
+					<td>
+						<?php if ( null === $row['last_consent_days'] ) : ?>
+							<span class="wp-mcp-adapter-hint"><?php esc_html_e( 'Never', 'mcp-adapter' ); ?></span>
+						<?php else : ?>
+							<?php
+							echo esc_html( sprintf(
+								/* translators: %d = number of days */
+								_n( '%d day ago', '%d days ago', (int) $row['last_consent_days'], 'mcp-adapter' ),
+								(int) $row['last_consent_days']
+							) );
+							?>
+							<?php if ( $row['show_silent_warning'] ) : ?>
+								<span class="wp-mcp-bridges-warning" title="<?php esc_attr_e( 'Within 30 days of the silent-consent cap. Bridge will require re-confirmation soon.', 'mcp-adapter' ); ?>">&#9888;</span>
+							<?php endif; ?>
+						<?php endif; ?>
+					</td>
+					<td>
+						<form method="post" action="<?php echo esc_url( $revoke_url ); ?>" class="wp-mcp-adapter-row-form">
+							<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD ); ?>
+							<input type="hidden" name="<?php echo esc_attr( self::ACTION_FIELD ); ?>" value="<?php echo esc_attr( self::ACTION_REVOKE ); ?>">
+							<input type="hidden" name="client_id" value="<?php echo esc_attr( $row['client_id'] ); ?>">
+							<button type="submit" class="button button-secondary wp-mcp-adapter-row-button"
+							        onclick="return confirm('<?php echo esc_js( __( 'Revoke this bridge? All its tokens will be invalidated immediately.', 'mcp-adapter' ) ); ?>');">
+								<?php esc_html_e( 'Revoke', 'mcp-adapter' ); ?>
+							</button>
+						</form>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+		</table>
+		<p class="wp-mcp-adapter-hint wp-mcp-adapter-hint--spaced">
+			<?php
+			echo esc_html( sprintf(
+				/* translators: %d = days */
+				__( 'Bridges that have not interactively re-consented within %d days will be required to show the full consent screen on next authorize.', 'mcp-adapter' ),
+				$silent_cap
+			) );
+			?>
+		</p>
+		<?php
+	}
 
-		<div class="wp-mcp-adapter-empty-state">
-			<p class="wp-mcp-adapter-empty-state-title"><?php esc_html_e( 'No bridges yet', 'mcp-adapter' ); ?></p>
-			<p>
-				<?php esc_html_e( 'When an MCP bridge completes the OAuth authorization flow, it will appear here with the user it acts on behalf of, the scopes it requested, and a revoke action.', 'mcp-adapter' ); ?>
-			</p>
-		</div>
-
-		<?php self::render_authorization_header_diagnostic(); ?>
+	/** Render recent OAuth audit slice. */
+	private static function render_audit_slice(): void {
+		$entries = BoundaryAuditBuffer::read();
+		?>
+		<h2 class="wp-mcp-adapter-section-spaced"><?php esc_html_e( 'Recent OAuth activity', 'mcp-adapter' ); ?></h2>
+		<?php if ( empty( $entries ) ) : ?>
+			<p class="wp-mcp-adapter-hint"><?php esc_html_e( 'No OAuth events recorded yet.', 'mcp-adapter' ); ?></p>
+			<?php return; ?>
+		<?php endif; ?>
+		<table class="widefat striped wp-mcp-adapter-table wp-mcp-bridges-audit">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'When', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Event', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Bridge', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'User', 'mcp-adapter' ); ?></th>
+					<th><?php esc_html_e( 'Detail', 'mcp-adapter' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+			<?php foreach ( array_reverse( $entries ) as $entry ) : ?>
+				<tr>
+					<td><?php echo esc_html( self::format_datetime( gmdate( 'Y-m-d H:i:s', $entry['time'] ) ) ); ?></td>
+					<td><code><?php echo esc_html( $entry['event'] ); ?></code></td>
+					<td>
+						<?php
+						echo '' !== $entry['client_id']
+							? '<code>' . esc_html( substr( $entry['client_id'], 0, 8 ) ) . '…</code>'
+							: '<span class="wp-mcp-adapter-hint">&mdash;</span>';
+						?>
+					</td>
+					<td>
+						<?php
+						echo $entry['user_id'] > 0
+							? '#' . esc_html( (string) $entry['user_id'] )
+							: '<span class="wp-mcp-adapter-hint">&mdash;</span>';
+						?>
+					</td>
+					<td>
+						<?php if ( '' !== $entry['error_code'] ) : ?>
+							<code><?php echo esc_html( $entry['error_code'] ); ?></code>
+						<?php elseif ( '' !== $entry['reason'] ) : ?>
+							<?php echo esc_html( $entry['reason'] ); ?>
+						<?php else : ?>
+							<span class="wp-mcp-adapter-hint">&mdash;</span>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+		</table>
+		<p class="wp-mcp-adapter-hint">
+			<?php
+			echo esc_html( sprintf(
+				/* translators: %d = number of entries */
+				_n( 'Last %d OAuth event.', 'Last %d OAuth events.', count( $entries ), 'mcp-adapter' ),
+				count( $entries )
+			) );
+			?>
+		</p>
 		<?php
 	}
 
@@ -64,8 +250,9 @@ final class ConnectedBridgesTab {
 	 * Render the Authorization-header diagnostic card.
 	 *
 	 * Per H.2.6 the Connected Bridges tab must reserve a hook for this
-	 * diagnostic. The card is shipped now; the data source is delivered
-	 * by Phase 3 (or any later phase that hooks the filter).
+	 * diagnostic. Phase 2 shipped the seam; Phase 3 ships a data source via
+	 * {@see AuthHeaderProbe}, but the seam still works for any third-party
+	 * listener that wants to override the value.
 	 */
 	private static function render_authorization_header_diagnostic(): void {
 		$status = self::resolve_status();
@@ -83,7 +270,7 @@ final class ConnectedBridgesTab {
 		$state_label = $state_labels[ $status['state'] ] ?? $state_labels['unknown'];
 
 		?>
-		<h2><?php esc_html_e( 'Authorization header diagnostic', 'mcp-adapter' ); ?></h2>
+		<h2 class="wp-mcp-adapter-section-spaced"><?php esc_html_e( 'Authorization header diagnostic', 'mcp-adapter' ); ?></h2>
 		<div class="wp-mcp-adapter-card">
 			<div class="wp-mcp-adapter-status">
 				<span class="wp-mcp-adapter-status-dot <?php echo esc_attr( $dot_class ); ?>"></span>
@@ -102,6 +289,93 @@ final class ConnectedBridgesTab {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * POST handler — revoke a bridge.
+	 */
+	public static function handle_action(): void {
+		$capability = function_exists( 'is_network_admin' ) && is_network_admin() ? 'manage_network_options' : 'manage_options';
+		if ( ! current_user_can( $capability ) ) {
+			return;
+		}
+
+		$action = isset( $_POST[ self::ACTION_FIELD ] ) ? sanitize_key( wp_unslash( (string) $_POST[ self::ACTION_FIELD ] ) ) : '';
+		if ( '' === $action ) {
+			return;
+		}
+
+		$nonce = isset( $_POST[ self::NONCE_FIELD ] ) ? sanitize_text_field( wp_unslash( (string) $_POST[ self::NONCE_FIELD ] ) ) : '';
+		if ( ! function_exists( 'wp_verify_nonce' ) || ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			return;
+		}
+
+		if ( self::ACTION_REVOKE !== $action ) {
+			return;
+		}
+
+		$client_id = isset( $_POST['client_id'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['client_id'] ) ) : '';
+		if ( '' === $client_id ) {
+			return;
+		}
+
+		ClientRegistry::revoke( $client_id );
+
+		oauth_log_boundary( 'boundary.oauth_token_revoked', array(
+			'client_id' => $client_id,
+			'user_id'   => (int) get_current_user_id(),
+			'reason'    => 'admin_revoked',
+		) );
+
+		if ( function_exists( 'wp_safe_redirect' ) ) {
+			wp_safe_redirect( AdapterAdminPage::tab_url( AdapterAdminPage::TAB_BRIDGES, array( 'mcp_bridges_flash' => 'revoked' ) ) );
+			exit;
+		}
+	}
+
+	// ─── Helpers ────────────────────────────────────────────────────────────────
+
+	/** Most recent active token row for a client_id. */
+	private static function latest_token_for( string $client_id ): ?object {
+		global $wpdb;
+		if ( ! isset( $wpdb ) ) {
+			return null;
+		}
+		$table = $wpdb->prefix . 'kl_oauth_tokens';
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT user_id, scope, last_used_at, expires_at, revoked
+				 FROM `{$table}` WHERE client_id = %s AND revoked = 0
+				 ORDER BY created_at DESC LIMIT 1",
+				$client_id
+			)
+		);
+		return $row ?: null;
+	}
+
+	/** Resolve a user login by ID; returns empty string when unknown. */
+	private static function user_login( int $user_id ): string {
+		if ( $user_id <= 0 || ! function_exists( 'get_userdata' ) ) {
+			return '';
+		}
+		$user = get_userdata( $user_id );
+		return $user && isset( $user->user_login ) ? (string) $user->user_login : '';
+	}
+
+	/** Format a 'Y-m-d H:i:s' UTC datetime for the operator's local view. */
+	private static function format_datetime( ?string $datetime ): string {
+		if ( null === $datetime || '' === $datetime ) {
+			return '—';
+		}
+		$timestamp = strtotime( $datetime . ' UTC' );
+		if ( ! $timestamp ) {
+			return $datetime;
+		}
+		if ( function_exists( 'wp_date' ) ) {
+			$format = function_exists( 'get_option' ) ? get_option( 'date_format', 'Y-m-d' ) . ' ' . get_option( 'time_format', 'H:i' ) : 'Y-m-d H:i';
+			return (string) wp_date( $format, $timestamp );
+		}
+		return gmdate( 'Y-m-d H:i', $timestamp );
 	}
 
 	/**
@@ -139,5 +413,17 @@ final class ConnectedBridgesTab {
 			'message'  => $message,
 			'docs_url' => $docs_url,
 		);
+	}
+
+	/** Render an inline flash message after a revoke. */
+	private static function render_flash( string $flash ): void {
+		if ( 'revoked' !== $flash ) {
+			return;
+		}
+		?>
+		<div class="notice notice-success">
+			<p><?php esc_html_e( 'Bridge revoked. All its tokens have been invalidated.', 'mcp-adapter' ); ?></p>
+		</div>
+		<?php
 	}
 }

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -28,6 +28,9 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Auth\OAuth;
 
+use WickedEvolutions\McpAdapter\Admin\Bridges\AuthHeaderProbe;
+use WickedEvolutions\McpAdapter\Admin\Bridges\BoundaryAuditBuffer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\AuthorizeEndpoint;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\RegisterEndpoint;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\TokenEndpoint;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\RevokeEndpoint;
@@ -66,6 +69,12 @@ final class AuthorizationServer {
 
 		// Reset OAuthRequestContext at the start of each REST request.
 		add_action( 'rest_api_init', [ OAuthRequestContext::class, 'reset' ], 1 );
+
+		// Phase 3: capture OAuth boundary events for the Connected Bridges audit slice.
+		BoundaryAuditBuffer::register();
+
+		// Phase 3: provide a data source for the H.2.6 Authorization-header diagnostic.
+		AuthHeaderProbe::register();
 	}
 
 	/** Run DB migration if schema version has changed. */
@@ -179,7 +188,7 @@ final class AuthorizationServer {
 			'/.well-known/oauth-protected-resource'  => DiscoveryEndpoints::serve_protected_resource(),
 			'/.well-known/oauth-authorization-server'=> DiscoveryEndpoints::serve_authorization_server(),
 			'/.well-known/openid-configuration'      => DiscoveryEndpoints::serve_oidc_configuration(),
-			// /oauth/authorize handled by Phase 3.
+			'/oauth/authorize'                       => AuthorizeEndpoint::dispatch(),
 			default => null,
 		};
 	}
@@ -254,6 +263,15 @@ final class AuthorizationServer {
 		}
 
 		$auth_header = oauth_read_auth_header();
+
+		// Phase 3 (H.2.6): record header presence/absence for the diagnostic.
+		// Only count requests that actually look like MCP traffic so the rolling
+		// counter reflects bridge calls, not unrelated REST hits.
+		$path = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
+		if ( str_contains( $path, '/wp-json/mcp/' ) || str_contains( $path, '/wp-json/abilities-mcp-adapter/' ) ) {
+			AuthHeaderProbe::record( null !== $auth_header && '' !== $auth_header );
+		}
+
 		if ( ! $auth_header || ! str_starts_with( $auth_header, 'Bearer ' ) ) {
 			return $user_id;
 		}

--- a/src/Auth/OAuth/Consent/AuthorizeRequestValidator.php
+++ b/src/Auth/OAuth/Consent/AuthorizeRequestValidator.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Pure parameter validation for /oauth/authorize.
+ *
+ * Implements Appendix H.3.6's pre-login validation order: client_id and
+ * redirect_uri are checked BEFORE we even consider the operator's login
+ * state. If either is malformed, the response is 400 HTML — never a redirect
+ * that leaks "user is/isn't logged in" state to an unauthenticated attacker.
+ *
+ * Implements Appendix H.3.5 for the `state` parameter: required, ≤256 chars,
+ * round-tripped opaquely.
+ *
+ * Returns a typed result so the endpoint can split error rendering from
+ * happy-path consent decisions.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+/**
+ * Validation outcome for an /oauth/authorize request.
+ *
+ * Two error categories:
+ *   - PRE_REDIRECT_ERROR — client_id or redirect_uri invalid; response MUST be 400 HTML, never redirect (H.3.6).
+ *   - REDIRECTABLE_ERROR — client_id+redirect_uri are good; OAuth-spec error returned via redirect with `error=...` (H.3.5/H.3.6).
+ */
+final class AuthorizeValidationResult {
+
+	public const OK                 = 'ok';
+	public const PRE_REDIRECT_ERROR = 'pre_redirect_error';
+	public const REDIRECTABLE_ERROR = 'redirectable_error';
+
+	public function __construct(
+		public readonly string  $status,
+		public readonly ?object $client,
+		public readonly string  $redirect_uri,
+		public readonly array   $requested_scopes,
+		public readonly string  $code_challenge,
+		public readonly string  $state,
+		public readonly string  $resource,
+		public readonly string  $error_code = '',
+		public readonly string  $error_description = ''
+	) {}
+
+	public function is_ok(): bool {
+		return self::OK === $this->status;
+	}
+
+	public function is_pre_redirect_error(): bool {
+		return self::PRE_REDIRECT_ERROR === $this->status;
+	}
+
+	public function is_redirectable_error(): bool {
+		return self::REDIRECTABLE_ERROR === $this->status;
+	}
+}
+
+/**
+ * Pure validation of the /oauth/authorize query parameters.
+ */
+final class AuthorizeRequestValidator {
+
+	/** Hard ceiling on `state` from Appendix H.3.5. */
+	public const MAX_STATE_LENGTH = 256;
+
+	/**
+	 * Validate per the locked Appendix H.3.6 order.
+	 *
+	 * @param array  $params   Raw $_GET (or POST body) — values are coerced to strings here.
+	 * @param string $resource_indicator The site's expected resource indicator URL.
+	 */
+	public static function validate( array $params, string $resource_indicator ): AuthorizeValidationResult {
+		$client_id      = self::str( $params['client_id'] ?? '' );
+		$redirect_uri   = self::str( $params['redirect_uri'] ?? '' );
+		$response_type  = self::str( $params['response_type'] ?? '' );
+		$scope          = self::str( $params['scope'] ?? '' );
+		$state          = self::str( $params['state'] ?? '' );
+		$code_challenge = self::str( $params['code_challenge'] ?? '' );
+		$code_method    = self::str( $params['code_challenge_method'] ?? '' );
+		$resource       = self::str( $params['resource'] ?? '' );
+
+		// === H.3.6 step 1: client_id absent or malformed → 400 HTML, no redirect ===
+		if ( '' === $client_id ) {
+			return self::pre_redirect_error( 'invalid_request', 'client_id is required.' );
+		}
+
+		// === H.3.6 step 2: client lookup → 400 HTML if not found / revoked ===
+		$client = ClientRegistry::find( $client_id );
+		if ( ! $client ) {
+			return self::pre_redirect_error( 'invalid_client', 'Client not found or revoked.' );
+		}
+
+		// === H.3.6 step 3: redirect_uri validation → 400 HTML if invalid ===
+		if ( '' === $redirect_uri || ! ClientRegistry::redirect_uri_valid( $client, $redirect_uri ) ) {
+			return self::pre_redirect_error( 'invalid_request', 'redirect_uri is not registered for this client.' );
+		}
+
+		// From this point on, errors are redirectable per OAuth 2.1 — `error=...&state=...` to redirect_uri.
+
+		// response_type must be `code`.
+		if ( 'code' !== $response_type ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'unsupported_response_type', 'Only response_type=code is supported.' );
+		}
+
+		// === H.3.6 step 5: PKCE S256 ===
+		if ( '' === $code_challenge ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'invalid_request', 'code_challenge is required.' );
+		}
+		if ( '' !== $code_method && 'S256' !== $code_method ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'invalid_request', 'code_challenge_method must be S256.' );
+		}
+
+		// === H.3.5 / H.3.6 step 6: state required, ≤256 chars ===
+		if ( '' === $state ) {
+			return self::redirectable_error( $client, $redirect_uri, '', 'invalid_request', 'state parameter is required.' );
+		}
+		if ( strlen( $state ) > self::MAX_STATE_LENGTH ) {
+			return self::redirectable_error( $client, $redirect_uri, '', 'invalid_request', 'state parameter exceeds 256 characters.' );
+		}
+
+		// Resource indicator MUST match this site's MCP endpoint when present (H.1.2 already binds tokens; we enforce it up front so the bridge can't claim a different resource).
+		if ( '' !== $resource && ! hash_equals( $resource_indicator, $resource ) ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'invalid_target', 'resource indicator does not match this server.' );
+		}
+		// If absent, fill with the site's own resource indicator — the issued token will be bound to it.
+		if ( '' === $resource ) {
+			$resource = $resource_indicator;
+		}
+
+		// === H.3.6 step 4: scope validation ===
+		// Empty scope is allowed (defaults to no abilities) but we require explicit scope to avoid surprises.
+		$requested_raw = '' === $scope ? array() : array_values( array_filter( explode( ' ', $scope ) ) );
+		if ( empty( $requested_raw ) ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'invalid_scope', 'scope parameter is required.' );
+		}
+		$expanded = ScopeRegistry::expand( $requested_raw );
+		$unknown  = ScopeRegistry::unknown_scopes( $expanded );
+		if ( ! empty( $unknown ) ) {
+			return self::redirectable_error( $client, $redirect_uri, $state, 'invalid_scope', 'Unknown scope(s): ' . implode( ' ', $unknown ) );
+		}
+
+		// All checks passed.
+		return new AuthorizeValidationResult(
+			AuthorizeValidationResult::OK,
+			$client,
+			$redirect_uri,
+			$expanded,
+			$code_challenge,
+			$state,
+			$resource
+		);
+	}
+
+	/** Coerce + sanitize a single scalar param to a string. */
+	private static function str( mixed $value ): string {
+		if ( is_string( $value ) ) {
+			return trim( $value );
+		}
+		if ( is_scalar( $value ) ) {
+			return trim( (string) $value );
+		}
+		return '';
+	}
+
+	private static function pre_redirect_error( string $code, string $description ): AuthorizeValidationResult {
+		return new AuthorizeValidationResult(
+			AuthorizeValidationResult::PRE_REDIRECT_ERROR,
+			null,
+			'',
+			array(),
+			'',
+			'',
+			'',
+			$code,
+			$description
+		);
+	}
+
+	private static function redirectable_error( object $client, string $redirect_uri, string $state, string $code, string $description ): AuthorizeValidationResult {
+		return new AuthorizeValidationResult(
+			AuthorizeValidationResult::REDIRECTABLE_ERROR,
+			$client,
+			$redirect_uri,
+			array(),
+			'',
+			$state,
+			'',
+			$code,
+			$description
+		);
+	}
+}

--- a/src/Auth/OAuth/Consent/ConsentDecision.php
+++ b/src/Auth/OAuth/Consent/ConsentDecision.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Value object describing how the authorize endpoint should route a request.
+ *
+ * Outcomes:
+ *   - AUTO_APPROVE          mint a code immediately, no consent screen
+ *   - RENDER_FULL           show the full consent screen (sensitive scope OR silent-cap exceeded OR no prior grant)
+ *   - RENDER_INCREMENTAL    show the incremental consent screen (only new non-sensitive scopes)
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Immutable consent-routing decision returned by {@see ConsentDecisionEvaluator}.
+ */
+final class ConsentDecision {
+
+	public const AUTO_APPROVE       = 'auto_approve';
+	public const RENDER_FULL        = 'render_full';
+	public const RENDER_INCREMENTAL = 'render_incremental';
+
+	/**
+	 * @param string   $action        One of the ACTION_* constants.
+	 * @param string[] $requested     The requested scope set (validated, deduplicated).
+	 * @param string[] $previously    Scopes the user previously granted to this client.
+	 * @param string[] $newly_added   Scopes in $requested not in $previously.
+	 * @param string[] $sensitive     Scopes in $requested that are sensitive.
+	 * @param string   $reason        Operator-facing rationale ("" when AUTO_APPROVE).
+	 */
+	public function __construct(
+		public readonly string $action,
+		public readonly array  $requested,
+		public readonly array  $previously,
+		public readonly array  $newly_added,
+		public readonly array  $sensitive,
+		public readonly string $reason = ''
+	) {}
+
+	/** True when the authorize endpoint should mint a code without rendering. */
+	public function is_auto_approve(): bool {
+		return self::AUTO_APPROVE === $this->action;
+	}
+
+	/** True when the authorize endpoint should render the full consent screen. */
+	public function is_render_full(): bool {
+		return self::RENDER_FULL === $this->action;
+	}
+
+	/** True when the authorize endpoint should render the incremental consent screen. */
+	public function is_render_incremental(): bool {
+		return self::RENDER_INCREMENTAL === $this->action;
+	}
+}

--- a/src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php
+++ b/src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Decide whether an /oauth/authorize request can auto-approve, must show
+ * the full consent screen, or can show the incremental consent screen.
+ *
+ * Pure logic — all temporal + DB inputs are passed in by the caller (the
+ * authorize endpoint). That keeps the decision unit-testable without DB or
+ * clock fixtures.
+ *
+ * Decision contract (binding sources only):
+ *   - Sub-issue #32: "Auto-approve logic: recognized client_id + unchanged
+ *     non-sensitive scopes + within consent_max_silent_days"
+ *   - Appendix H.2.4: any silence > consent_max_silent_days → FULL consent
+ *   - Appendix H.3.4: sensitive scopes always show consent, even when
+ *     previously granted; any new scope → consent (full if any sensitive,
+ *     incremental if all new are non-sensitive)
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+/**
+ * Pure-function decision engine for the authorize endpoint.
+ */
+final class ConsentDecisionEvaluator {
+
+	/**
+	 * Decide consent routing for a fully-validated authorize request.
+	 *
+	 * @param string[] $requested_scopes        Scopes from the authorize query, deduplicated, all known.
+	 * @param string[] $previously_granted      Most recent active token's scope set; empty array if no prior grant.
+	 * @param int|null $last_interactive_unix   UNIX timestamp of the last interactive consent for this (client, user); null if none.
+	 * @param int      $now_unix                Current UNIX time (injected for testability).
+	 * @param int      $consent_max_silent_days Resolved silent-cap from {@see PolicyStore}.
+	 * @return ConsentDecision
+	 */
+	public static function evaluate(
+		array $requested_scopes,
+		array $previously_granted,
+		?int  $last_interactive_unix,
+		int   $now_unix,
+		int   $consent_max_silent_days
+	): ConsentDecision {
+		$requested  = self::normalize( $requested_scopes );
+		$previously = self::normalize( $previously_granted );
+
+		$sensitive   = array_values( array_filter( $requested, [ ScopeRegistry::class, 'is_sensitive' ] ) );
+		$newly_added = array_values( array_diff( $requested, $previously ) );
+
+		// (1) No prior grant → full consent. The bridge has never authorized for this user.
+		if ( null === $last_interactive_unix ) {
+			return new ConsentDecision(
+				ConsentDecision::RENDER_FULL,
+				$requested,
+				$previously,
+				$newly_added,
+				$sensitive,
+				'first_authorization'
+			);
+		}
+
+		// (2) Silent cap exceeded (Appendix H.2.4) → full consent regardless of scope set.
+		$silent_seconds = $now_unix - $last_interactive_unix;
+		$cap_seconds    = $consent_max_silent_days * 86400;
+		if ( $silent_seconds > $cap_seconds ) {
+			return new ConsentDecision(
+				ConsentDecision::RENDER_FULL,
+				$requested,
+				$previously,
+				$newly_added,
+				$sensitive,
+				'silent_cap_exceeded'
+			);
+		}
+
+		// (3) Any sensitive scope in the request set (Appendix H.3.4) → full consent,
+		//     even if every sensitive scope was previously granted.
+		if ( ! empty( $sensitive ) ) {
+			return new ConsentDecision(
+				ConsentDecision::RENDER_FULL,
+				$requested,
+				$previously,
+				$newly_added,
+				$sensitive,
+				'sensitive_scope_requested'
+			);
+		}
+
+		// (4) Some non-sensitive scopes are new → incremental consent.
+		if ( ! empty( $newly_added ) ) {
+			return new ConsentDecision(
+				ConsentDecision::RENDER_INCREMENTAL,
+				$requested,
+				$previously,
+				$newly_added,
+				$sensitive,
+				'new_non_sensitive_scopes'
+			);
+		}
+
+		// (5) Recognized client + unchanged non-sensitive scopes + within silent cap → auto-approve.
+		return new ConsentDecision(
+			ConsentDecision::AUTO_APPROVE,
+			$requested,
+			$previously,
+			$newly_added,
+			$sensitive
+		);
+	}
+
+	/** Sort + deduplicate to keep set comparisons deterministic. */
+	private static function normalize( array $scopes ): array {
+		$clean = array_values( array_unique( array_filter( $scopes, 'is_string' ) ) );
+		sort( $clean );
+		return $clean;
+	}
+}

--- a/src/Auth/OAuth/Consent/ConsentScreenRenderer.php
+++ b/src/Auth/OAuth/Consent/ConsentScreenRenderer.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * Server-rendered consent screen.
+ *
+ * Plain HTML form — no JavaScript. The form posts to the same /oauth/authorize
+ * URL with the OAuth flow parameters round-tripped as hidden inputs. The
+ * RenderedScopeNonce binds this rendered scope set to the POST submission
+ * (Appendix H.4.5 — browser-extension threat).
+ *
+ * Per Appendix H.3.4:
+ *   - All scopes (previously-granted AND newly-requested) render as toggleable checkboxes.
+ *   - Previously-granted scopes are pre-checked AND show a "Granted YYYY-MM-DD" badge.
+ *   - Sensitive scopes show a lock icon and require explicit re-check (pre-checked but visible).
+ *
+ * Per Appendix H.4.5: role switcher only lists roles the current user already holds.
+ *
+ * No inline style="" attributes — all visuals via class names in assets/consent.css.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+/**
+ * Renders the consent HTML page and exits.
+ */
+final class ConsentScreenRenderer {
+
+	/** Rendered nonce hidden field name. */
+	public const NONCE_FIELD = 'mcp_oauth_consent_nonce';
+
+	/** Submitted scope checkbox name. Multiple values arrive as `mcp_oauth_scope[]`. */
+	public const SCOPE_FIELD = 'mcp_oauth_scope';
+
+	/** Submitted role select name. */
+	public const ROLE_FIELD = 'mcp_oauth_role';
+
+	/** Submitted decision (`authorize` | `deny`). */
+	public const DECISION_FIELD = 'mcp_oauth_decision';
+
+	/** Submitted decision values. */
+	public const DECISION_AUTHORIZE = 'authorize';
+	public const DECISION_DENY      = 'deny';
+
+	/**
+	 * Render the consent page and exit.
+	 *
+	 * @param array $params {
+	 *   @type string   $client_id        OAuth client_id (validated).
+	 *   @type string   $client_name      Operator-facing client name from DCR.
+	 *   @type string   $redirect_uri     Validated redirect_uri.
+	 *   @type string   $scope            Original space-separated scope string (round-trip).
+	 *   @type string   $state            OAuth state (round-trip).
+	 *   @type string   $code_challenge   PKCE challenge (round-trip).
+	 *   @type string   $resource         Resource indicator URL (round-trip).
+	 *   @type int      $user_id          Currently logged-in user.
+	 *   @type string   $user_login       Login name to display.
+	 *   @type string   $user_display     Display name to show.
+	 *   @type string[] $available_roles  Roles the user actually holds (already filtered).
+	 *   @type ConsentDecision $decision  Routing decision (RENDER_FULL or RENDER_INCREMENTAL).
+	 *   @type ?int     $previously_granted_at_unix Timestamp of last interactive consent (null = first).
+	 *   @type string   $action_url       Where the form posts to (full /oauth/authorize URL).
+	 * }
+	 */
+	public static function render( array $params ): never {
+		$html = self::build_html( $params );
+
+		status_header( 200 );
+		header( 'Content-Type: text/html; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		header( 'X-Frame-Options: DENY' );
+		header( "Content-Security-Policy: default-src 'none'; style-src 'self'; form-action 'self'; frame-ancestors 'none'" );
+
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML built by build_html(); all dynamic values escaped at insertion.
+		exit;
+	}
+
+	/**
+	 * Build the consent screen HTML without side effects.
+	 *
+	 * Same parameter contract as {@see render()}. Returns the HTML body so
+	 * tests can assert structure, escape correctness, and nonce embedding
+	 * without the `exit` of the production render path.
+	 */
+	public static function build_html( array $params ): string {
+		$client_id      = (string) ( $params['client_id'] ?? '' );
+		$client_name    = (string) ( $params['client_name'] ?? __( 'Unnamed bridge', 'mcp-adapter' ) );
+		$redirect_uri   = (string) ( $params['redirect_uri'] ?? '' );
+		$scope          = (string) ( $params['scope'] ?? '' );
+		$state          = (string) ( $params['state'] ?? '' );
+		$code_challenge = (string) ( $params['code_challenge'] ?? '' );
+		$resource       = (string) ( $params['resource'] ?? '' );
+		$user_id        = (int) ( $params['user_id'] ?? 0 );
+		$user_login     = (string) ( $params['user_login'] ?? '' );
+		$user_display   = (string) ( $params['user_display'] ?? $user_login );
+		$available_roles = is_array( $params['available_roles'] ?? null ) ? $params['available_roles'] : array();
+		/** @var ConsentDecision $decision */
+		$decision = $params['decision'];
+		$previously_at = $params['previously_granted_at_unix'] ?? null;
+		$action_url    = (string) ( $params['action_url'] ?? '' );
+		$site_name     = function_exists( 'get_bloginfo' ) ? (string) get_bloginfo( 'name' ) : '';
+		$site_url      = function_exists( 'home_url' ) ? (string) home_url() : '';
+
+		$rendered_scopes = $decision->requested;
+		$nonce = RenderedScopeNonce::issue( $rendered_scopes, $user_id, $client_id, $redirect_uri, $state );
+
+		$consent_css_url = self::stylesheet_url();
+		$is_incremental  = $decision->is_render_incremental();
+		$reason          = $decision->reason;
+
+		ob_start();
+		?><!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo esc_html( sprintf( __( 'Authorize %s', 'mcp-adapter' ), $client_name ) ); ?></title>
+<?php if ( $consent_css_url ) : ?>
+<link rel="stylesheet" href="<?php echo esc_url( $consent_css_url ); ?>">
+<?php endif; ?>
+</head>
+<body class="wp-mcp-consent-body">
+<main class="wp-mcp-consent-shell">
+	<header class="wp-mcp-consent-header">
+		<h1 class="wp-mcp-consent-h1"><?php echo esc_html( sprintf( __( 'Authorize %s', 'mcp-adapter' ), $client_name ) ); ?></h1>
+		<p class="wp-mcp-consent-site">
+			<?php echo esc_html( $site_name ); ?>
+			<?php if ( $site_url ) : ?>
+				<span class="wp-mcp-consent-site-url"><?php echo esc_html( $site_url ); ?></span>
+			<?php endif; ?>
+		</p>
+	</header>
+
+	<?php if ( 'silent_cap_exceeded' === $reason ) : ?>
+		<p class="wp-mcp-consent-notice wp-mcp-consent-notice--reauth">
+			<?php esc_html_e( 'You have not reviewed this bridge in a while. Please re-confirm what it can access.', 'mcp-adapter' ); ?>
+		</p>
+	<?php elseif ( $is_incremental ) : ?>
+		<p class="wp-mcp-consent-notice wp-mcp-consent-notice--incremental">
+			<?php esc_html_e( 'This bridge is requesting additional permissions beyond what you previously granted.', 'mcp-adapter' ); ?>
+		</p>
+	<?php endif; ?>
+
+	<form method="post" action="<?php echo esc_url( $action_url ); ?>" class="wp-mcp-consent-form">
+		<input type="hidden" name="client_id"        value="<?php echo esc_attr( $client_id ); ?>">
+		<input type="hidden" name="redirect_uri"     value="<?php echo esc_attr( $redirect_uri ); ?>">
+		<input type="hidden" name="scope"            value="<?php echo esc_attr( $scope ); ?>">
+		<input type="hidden" name="state"            value="<?php echo esc_attr( $state ); ?>">
+		<input type="hidden" name="code_challenge"   value="<?php echo esc_attr( $code_challenge ); ?>">
+		<input type="hidden" name="code_challenge_method" value="S256">
+		<input type="hidden" name="response_type"    value="code">
+		<input type="hidden" name="resource"         value="<?php echo esc_attr( $resource ); ?>">
+		<input type="hidden" name="<?php echo esc_attr( self::NONCE_FIELD ); ?>" value="<?php echo esc_attr( $nonce ); ?>">
+
+		<section class="wp-mcp-consent-identity">
+			<h2 class="wp-mcp-consent-h2"><?php esc_html_e( 'Authorize as', 'mcp-adapter' ); ?></h2>
+			<p class="wp-mcp-consent-user">
+				<strong><?php echo esc_html( $user_display ); ?></strong>
+				<span class="wp-mcp-consent-user-login">(<?php echo esc_html( $user_login ); ?>)</span>
+			</p>
+			<?php if ( count( $available_roles ) > 1 ) : ?>
+				<label class="wp-mcp-consent-label" for="wp-mcp-consent-role">
+					<?php esc_html_e( 'Role to grant:', 'mcp-adapter' ); ?>
+				</label>
+				<select id="wp-mcp-consent-role" name="<?php echo esc_attr( self::ROLE_FIELD ); ?>" class="wp-mcp-consent-select">
+					<?php foreach ( $available_roles as $role ) : ?>
+						<option value="<?php echo esc_attr( $role ); ?>"><?php echo esc_html( $role ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			<?php elseif ( count( $available_roles ) === 1 ) : ?>
+				<input type="hidden" name="<?php echo esc_attr( self::ROLE_FIELD ); ?>" value="<?php echo esc_attr( $available_roles[0] ); ?>">
+				<p class="wp-mcp-consent-hint">
+					<?php
+					echo esc_html( sprintf(
+						/* translators: %s = WordPress role slug */
+						__( 'Role: %s', 'mcp-adapter' ),
+						$available_roles[0]
+					) );
+					?>
+				</p>
+			<?php endif; ?>
+		</section>
+
+		<section class="wp-mcp-consent-scopes">
+			<h2 class="wp-mcp-consent-h2"><?php esc_html_e( 'Permissions requested', 'mcp-adapter' ); ?></h2>
+			<?php self::render_scope_groups( $rendered_scopes, $decision, $previously_at ); ?>
+		</section>
+
+		<section class="wp-mcp-consent-actions">
+			<button type="submit"
+			        name="<?php echo esc_attr( self::DECISION_FIELD ); ?>"
+			        value="<?php echo esc_attr( self::DECISION_DENY ); ?>"
+			        class="wp-mcp-consent-button wp-mcp-consent-button--secondary">
+				<?php esc_html_e( 'Deny', 'mcp-adapter' ); ?>
+			</button>
+			<button type="submit"
+			        name="<?php echo esc_attr( self::DECISION_FIELD ); ?>"
+			        value="<?php echo esc_attr( self::DECISION_AUTHORIZE ); ?>"
+			        class="wp-mcp-consent-button wp-mcp-consent-button--primary">
+				<?php esc_html_e( 'Authorize', 'mcp-adapter' ); ?>
+			</button>
+		</section>
+
+		<footer class="wp-mcp-consent-footer">
+			<p class="wp-mcp-consent-footer-text">
+				<?php esc_html_e( 'You can revoke this authorization at any time from the Connected Bridges tab in WP-Admin.', 'mcp-adapter' ); ?>
+			</p>
+		</footer>
+	</form>
+</main>
+</body>
+</html>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the grouped scope checkbox list.
+	 *
+	 * @param string[]        $rendered_scopes
+	 * @param ConsentDecision $decision
+	 * @param ?int            $previously_granted_at_unix
+	 */
+	private static function render_scope_groups( array $rendered_scopes, ConsentDecision $decision, ?int $previously_granted_at_unix ): void {
+		$groups            = ScopeGrouper::group( $rendered_scopes );
+		$previously        = array_flip( $decision->previously );
+		$granted_date_text = $previously_granted_at_unix
+			? gmdate( 'Y-m-d', $previously_granted_at_unix )
+			: '';
+
+		foreach ( $groups as $module => $scopes ) {
+			$module_label = 'umbrella' === $module
+				? __( 'Umbrella permissions', 'mcp-adapter' )
+				: ucfirst( str_replace( '-', ' ', (string) $module ) );
+			$is_sensitive_group = ScopeGrouper::group_is_sensitive( $scopes );
+			?>
+			<fieldset class="wp-mcp-consent-group <?php echo $is_sensitive_group ? 'wp-mcp-consent-group--sensitive' : ''; ?>">
+				<legend class="wp-mcp-consent-legend">
+					<?php echo esc_html( $module_label ); ?>
+					<?php if ( $is_sensitive_group ) : ?>
+						<span class="wp-mcp-consent-lock" aria-label="<?php esc_attr_e( 'Sensitive permission', 'mcp-adapter' ); ?>">&#x1F512;</span>
+					<?php endif; ?>
+				</legend>
+				<?php foreach ( $scopes as $scope_name ) :
+					$is_sensitive = ScopeRegistry::is_sensitive( $scope_name );
+					$was_granted  = isset( $previously[ $scope_name ] );
+					// All scopes pre-checked, all toggleable. Sensitive scopes always rendered (per H.3.4).
+					?>
+					<label class="wp-mcp-consent-scope <?php echo $is_sensitive ? 'wp-mcp-consent-scope--sensitive' : ''; ?>">
+						<input type="checkbox"
+						       name="<?php echo esc_attr( self::SCOPE_FIELD ); ?>[]"
+						       value="<?php echo esc_attr( $scope_name ); ?>"
+						       checked>
+						<span class="wp-mcp-consent-scope-name"><?php echo esc_html( $scope_name ); ?></span>
+						<?php if ( $was_granted && '' !== $granted_date_text ) : ?>
+							<span class="wp-mcp-consent-badge wp-mcp-consent-badge--granted">
+								<?php
+								echo esc_html( sprintf(
+									/* translators: %s = ISO date YYYY-MM-DD */
+									__( 'Granted %s', 'mcp-adapter' ),
+									$granted_date_text
+								) );
+								?>
+							</span>
+						<?php endif; ?>
+						<?php if ( $is_sensitive ) : ?>
+							<span class="wp-mcp-consent-badge wp-mcp-consent-badge--sensitive">
+								<?php esc_html_e( 'Sensitive', 'mcp-adapter' ); ?>
+							</span>
+						<?php endif; ?>
+					</label>
+				<?php endforeach; ?>
+			</fieldset>
+			<?php
+		}
+	}
+
+	/**
+	 * Resolve the URL of consent.css. Returns empty string if asset machinery is unavailable.
+	 */
+	private static function stylesheet_url(): string {
+		if ( ! function_exists( 'plugins_url' ) || ! defined( 'ABILITIES_MCP_ADAPTER_PATH' ) ) {
+			return '';
+		}
+		$ver = defined( 'ABILITIES_MCP_ADAPTER_VERSION' ) ? '?v=' . rawurlencode( (string) ABILITIES_MCP_ADAPTER_VERSION ) : '';
+		return plugins_url( 'assets/consent.css', ABILITIES_MCP_ADAPTER_PATH . 'abilities-mcp-adapter.php' ) . $ver;
+	}
+
+	/**
+	 * Render an error page for pre-login validation failures (Appendix H.3.6).
+	 * No redirect — pure 400 HTML so the request never leaks into wp-login.
+	 */
+	public static function render_error( string $title, string $detail, int $status = 400 ): never {
+		$html = self::build_error_html( $title, $detail );
+
+		status_header( $status );
+		header( 'Content-Type: text/html; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		header( 'X-Frame-Options: DENY' );
+
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built by build_error_html(), all dynamic values escaped.
+		exit;
+	}
+
+	/**
+	 * Build the error page HTML without side effects. Tested independently.
+	 */
+	public static function build_error_html( string $title, string $detail ): string {
+		$consent_css_url = self::stylesheet_url();
+		ob_start();
+		?><!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo esc_html( $title ); ?></title>
+<?php if ( $consent_css_url ) : ?>
+<link rel="stylesheet" href="<?php echo esc_url( $consent_css_url ); ?>">
+<?php endif; ?>
+</head>
+<body class="wp-mcp-consent-body">
+<main class="wp-mcp-consent-shell wp-mcp-consent-shell--error">
+	<h1 class="wp-mcp-consent-h1"><?php echo esc_html( $title ); ?></h1>
+	<p class="wp-mcp-consent-error"><?php echo esc_html( $detail ); ?></p>
+	<p class="wp-mcp-consent-footer-text">
+		<?php esc_html_e( 'No authorization has been granted. You can safely close this tab.', 'mcp-adapter' ); ?>
+	</p>
+</main>
+</body>
+</html>
+		<?php
+		return (string) ob_get_clean();
+	}
+}

--- a/src/Auth/OAuth/Consent/LastConsentLookup.php
+++ b/src/Auth/OAuth/Consent/LastConsentLookup.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Look up the timestamp of the last interactive consent for a (client_id,
+ * user_id) pair. Drives the Appendix H.2.4 silent-cap check.
+ *
+ * Source of truth: the boundary log (`mcp_adapter_boundary_event` action).
+ * Phase 1's logging contract emits one event per OAuth lifecycle step; we
+ * emit two distinct event names so an interactive grant can be told apart
+ * from an auto-approved one without inventing a new boundary tag:
+ *
+ *   - boundary.oauth_authorization_granted        — interactive consent
+ *   - boundary.oauth_authorization_auto_approved  — silent re-auth
+ *
+ * H.2.4 explicitly requires "the most recent INTERACTIVE consent ... NOT
+ * auto-approve," which is what makes the two-event-name split necessary.
+ *
+ * The actual read path is implementation-detail: most installs don't ship a
+ * persistent boundary log table. Phase 3 records the last-interactive
+ * timestamp directly via a per-(client,user) WP option as a side-effect of
+ * the granted event, keyed so it's compact and bounded by client count.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Read + record the most recent interactive consent timestamp.
+ */
+final class LastConsentLookup {
+
+	/** Option name prefix. Suffix = sha256(client_id|user_id). Bounded by client count. */
+	private const OPTION_PREFIX = 'abilities_oauth_last_consent_';
+
+	/** Compose the per-pair option name. */
+	private static function key( string $client_id, int $user_id ): string {
+		// sha1 keeps the option name well under WP's 191-char index cap and is
+		// sufficient — this is a key, not a security primitive.
+		return self::OPTION_PREFIX . sha1( $client_id . '|' . $user_id );
+	}
+
+	/**
+	 * Most recent interactive-consent UNIX timestamp, or null if none recorded.
+	 */
+	public static function timestamp_for( string $client_id, int $user_id ): ?int {
+		$value = get_option( self::key( $client_id, $user_id ), null );
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		return (int) $value;
+	}
+
+	/**
+	 * Record an interactive consent timestamp.
+	 *
+	 * Only call from the POST handler when the operator clicked Authorize.
+	 * Auto-approve MUST NOT call this — that's what H.2.4 explicitly excludes.
+	 */
+	public static function record( string $client_id, int $user_id, int $now_unix ): void {
+		update_option( self::key( $client_id, $user_id ), $now_unix );
+	}
+
+	/**
+	 * Days elapsed since the last interactive consent, or null if never.
+	 */
+	public static function days_since( string $client_id, int $user_id, int $now_unix ): ?int {
+		$ts = self::timestamp_for( $client_id, $user_id );
+		if ( null === $ts ) {
+			return null;
+		}
+		$delta = $now_unix - $ts;
+		if ( $delta < 0 ) {
+			return 0;
+		}
+		return (int) floor( $delta / 86400 );
+	}
+}

--- a/src/Auth/OAuth/Consent/PolicyStore.php
+++ b/src/Auth/OAuth/Consent/PolicyStore.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Per-site OAuth consent policy storage.
+ *
+ * Phase 3 introduces one policy field: `consent_max_silent_days` (Appendix
+ * H.2.4 — long-lived auto-approve cap). Default 365 days. Operator-overridable
+ * either via WP option (admin UI) or via the `abilities_oauth_consent_max_silent_days`
+ * filter, mirroring the option+filter pattern Phase 1 uses for TTL knobs.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Read consent policy values with sane defaults and filter overrides.
+ */
+final class PolicyStore {
+
+	/** WP option name for the silent-cap override. */
+	public const OPTION_SILENT_DAYS = 'abilities_oauth_consent_max_silent_days';
+
+	/** Default silent cap per Appendix H.2.4. */
+	public const DEFAULT_SILENT_DAYS = 365;
+
+	/** Hard floor — re-prompts more than once a day are operator hostile. */
+	public const MIN_SILENT_DAYS = 1;
+
+	/** Hard ceiling — beyond two years a re-confirmation is mandatory. */
+	public const MAX_SILENT_DAYS = 730;
+
+	/**
+	 * Resolve the silent-cap in days.
+	 *
+	 * Resolution order:
+	 *   1. Filter override (`abilities_oauth_consent_max_silent_days`) — wins if non-empty integer.
+	 *   2. WP option (admin-set).
+	 *   3. {@see DEFAULT_SILENT_DAYS}.
+	 *
+	 * The result is clamped to [MIN_SILENT_DAYS, MAX_SILENT_DAYS].
+	 */
+	public static function consent_max_silent_days(): int {
+		$option = (int) get_option( self::OPTION_SILENT_DAYS, self::DEFAULT_SILENT_DAYS );
+		if ( $option <= 0 ) {
+			$option = self::DEFAULT_SILENT_DAYS;
+		}
+
+		$filtered = (int) apply_filters( self::OPTION_SILENT_DAYS, $option );
+		if ( $filtered <= 0 ) {
+			$filtered = $option;
+		}
+
+		return self::clamp( $filtered );
+	}
+
+	/** Clamp a candidate value to the supported range. */
+	public static function clamp( int $days ): int {
+		if ( $days < self::MIN_SILENT_DAYS ) {
+			return self::MIN_SILENT_DAYS;
+		}
+		if ( $days > self::MAX_SILENT_DAYS ) {
+			return self::MAX_SILENT_DAYS;
+		}
+		return $days;
+	}
+}

--- a/src/Auth/OAuth/Consent/PriorGrantLookup.php
+++ b/src/Auth/OAuth/Consent/PriorGrantLookup.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Find the most recent active token's scope set for a (client_id, user_id)
+ * pair. Used to compute "previously granted" for the consent decision.
+ *
+ * Direct DB query — intentionally bypasses object cache, since stale data
+ * here would cause incorrect auto-approve routing.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Read previously-granted scopes from kl_oauth_tokens.
+ */
+final class PriorGrantLookup {
+
+	/**
+	 * Return the scope set of the most recent non-revoked, non-expired
+	 * access token for this (client_id, user_id), or empty array if none.
+	 *
+	 * Even an expired token counts as "previously granted scopes" for the
+	 * scope-diff classification — what matters is whether the operator has
+	 * ever consented to those scopes for this client. Expiry alone does not
+	 * un-grant. (Revocation does.)
+	 *
+	 * @return string[]
+	 */
+	public static function scopes_for( string $client_id, int $user_id ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'kl_oauth_tokens';
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT scope FROM `{$table}`
+				 WHERE client_id = %s AND user_id = %d AND revoked = 0
+				 ORDER BY created_at DESC
+				 LIMIT 1",
+				$client_id,
+				$user_id
+			)
+		);
+
+		if ( ! $row || ! isset( $row->scope ) || '' === (string) $row->scope ) {
+			return array();
+		}
+		return array_values( array_filter( explode( ' ', (string) $row->scope ) ) );
+	}
+}

--- a/src/Auth/OAuth/Consent/RenderedScopeNonce.php
+++ b/src/Auth/OAuth/Consent/RenderedScopeNonce.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Server-bound nonce that ties the consent POST to the consent GET render
+ * (Appendix H.4.5 — browser-extension threat).
+ *
+ * The consent screen is rendered with a hidden input containing this nonce.
+ * The POST handler MUST verify (a) the nonce was issued by the server, (b)
+ * it has not been used already, (c) the submitted scope set is a subset of
+ * the rendered scope set the nonce was issued for.
+ *
+ * Stored as a transient — short-lived (15 minutes) and single-use. The
+ * server-side store is the only source of truth; a malicious browser
+ * extension can change the visible checkboxes but cannot fabricate an
+ * issued-by-server scope set behind them.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Issue, redeem, and verify nonces binding the consent GET to the consent POST.
+ */
+final class RenderedScopeNonce {
+
+	/** Lifetime of an unused nonce (seconds). 15 minutes matches the operator's expected attention window. */
+	public const TTL_SECONDS = 900;
+
+	/** Transient key prefix. */
+	private const PREFIX = 'mcp_oauth_consent_nonce_';
+
+	/**
+	 * Issue a nonce binding the rendered scope set to the user, client, redirect_uri, and the OAuth `state`.
+	 *
+	 * @param string[] $rendered_scopes The exact scope set rendered to the operator.
+	 * @param int      $user_id         The currently logged-in user.
+	 * @param string   $client_id       The OAuth client_id.
+	 * @param string   $redirect_uri    The validated redirect_uri.
+	 * @param string   $state           The OAuth state parameter.
+	 * @return string The opaque nonce to embed in the consent form.
+	 */
+	public static function issue(
+		array  $rendered_scopes,
+		int    $user_id,
+		string $client_id,
+		string $redirect_uri,
+		string $state
+	): string {
+		$nonce = bin2hex( random_bytes( 16 ) );
+		$payload = array(
+			'rendered_scopes' => array_values( array_unique( array_filter( $rendered_scopes, 'is_string' ) ) ),
+			'user_id'         => $user_id,
+			'client_id'       => $client_id,
+			'redirect_uri'    => $redirect_uri,
+			'state_hash'      => hash( 'sha256', $state ),
+		);
+		set_transient( self::PREFIX . $nonce, $payload, self::TTL_SECONDS );
+		return $nonce;
+	}
+
+	/**
+	 * Look up + atomically delete the nonce.
+	 *
+	 * Returns null if not found, expired, or already redeemed.
+	 *
+	 * @return array{rendered_scopes:string[],user_id:int,client_id:string,redirect_uri:string,state_hash:string}|null
+	 */
+	public static function redeem( string $nonce ): ?array {
+		if ( '' === $nonce ) {
+			return null;
+		}
+		$key     = self::PREFIX . $nonce;
+		$payload = get_transient( $key );
+		if ( ! is_array( $payload ) ) {
+			return null;
+		}
+		// Single-use semantics — delete before returning.
+		delete_transient( $key );
+		return $payload;
+	}
+
+	/**
+	 * Verify that a redemption matches the request and submitted scopes are a subset of rendered.
+	 *
+	 * @param array  $payload          Output of {@see redeem()}.
+	 * @param int    $user_id          Current request user_id.
+	 * @param string $client_id        Current request client_id.
+	 * @param string $redirect_uri     Current request redirect_uri.
+	 * @param string $state            Current request state.
+	 * @param string[] $submitted_scopes Scopes the operator checked on the form.
+	 */
+	public static function submitted_subset_is_valid(
+		array $payload,
+		int $user_id,
+		string $client_id,
+		string $redirect_uri,
+		string $state,
+		array $submitted_scopes
+	): bool {
+		if ( (int) ( $payload['user_id'] ?? 0 ) !== $user_id ) {
+			return false;
+		}
+		if ( ! hash_equals( (string) ( $payload['client_id'] ?? '' ), $client_id ) ) {
+			return false;
+		}
+		if ( ! hash_equals( (string) ( $payload['redirect_uri'] ?? '' ), $redirect_uri ) ) {
+			return false;
+		}
+		if ( ! hash_equals( (string) ( $payload['state_hash'] ?? '' ), hash( 'sha256', $state ) ) ) {
+			return false;
+		}
+		$rendered = is_array( $payload['rendered_scopes'] ?? null ) ? $payload['rendered_scopes'] : array();
+		foreach ( $submitted_scopes as $scope ) {
+			if ( ! in_array( $scope, $rendered, true ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/Auth/OAuth/Consent/RoleSelector.php
+++ b/src/Auth/OAuth/Consent/RoleSelector.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Role switcher constraint logic (Appendix H.4.5).
+ *
+ * The consent screen lets the operator authorize the bridge as one of their
+ * own WordPress roles — but only roles they actually possess. A tampered form
+ * cannot escalate (Editor cannot select Admin even if they edit the DOM):
+ * the POST handler re-checks the submitted role against this same allowlist.
+ *
+ * Pure logic — no WP coupling beyond the WP_User shape. Tests inject a fake
+ * user via the `roles_for_user_id()` injection point.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+/**
+ * Determine which roles a user may authorize a bridge as.
+ */
+final class RoleSelector {
+
+	/**
+	 * Return the role slugs the user with the given ID currently holds.
+	 *
+	 * Falls back to `get_userdata()` if no injected resolver is provided —
+	 * the production path. Tests can inject a callable returning string[].
+	 *
+	 * @param int                   $user_id WP user ID.
+	 * @param callable|null         $resolver Optional `(int $user_id): string[]` for tests.
+	 * @return string[] Role slugs, in WP_User->roles order. Empty array when user not found.
+	 */
+	public static function roles_for_user_id( int $user_id, ?callable $resolver = null ): array {
+		if ( $resolver ) {
+			$roles = $resolver( $user_id );
+			return is_array( $roles ) ? array_values( array_filter( $roles, 'is_string' ) ) : array();
+		}
+
+		if ( ! function_exists( 'get_userdata' ) ) {
+			return array();
+		}
+
+		$user = get_userdata( $user_id );
+		if ( ! $user || empty( $user->roles ) || ! is_array( $user->roles ) ) {
+			return array();
+		}
+		return array_values( array_filter( $user->roles, 'is_string' ) );
+	}
+
+	/**
+	 * Verify that a submitted role is one the user actually holds.
+	 *
+	 * This is the H.4.5 server-side recheck. Even if the consent form was
+	 * tampered to add `admin` to the role select, this method returns false
+	 * for a user whose `roles` array does not contain `admin`.
+	 *
+	 * @param int                   $user_id        WP user ID.
+	 * @param string                $submitted_role Role slug from the POST body.
+	 * @param callable|null         $resolver       Optional injection for tests.
+	 */
+	public static function user_holds_role( int $user_id, string $submitted_role, ?callable $resolver = null ): bool {
+		if ( '' === $submitted_role ) {
+			return false;
+		}
+		return in_array( $submitted_role, self::roles_for_user_id( $user_id, $resolver ), true );
+	}
+}

--- a/src/Auth/OAuth/Consent/ScopeGrouper.php
+++ b/src/Auth/OAuth/Consent/ScopeGrouper.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Group scope strings by module for the consent screen.
+ *
+ * The full scope catalog is owned by {@see ScopeRegistry}; this class
+ * arranges already-known scope strings into the visual buckets the consent
+ * screen renders. Pure logic — no HTML.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Consent;
+
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+/**
+ * Group already-known scope strings by their module segment.
+ */
+final class ScopeGrouper {
+
+	/**
+	 * Group scopes by their middle module segment.
+	 *
+	 * Scope shape is `abilities:<module>:<op>` for module-scoped grants and
+	 * `abilities:<umbrella>` for the three umbrella grants. Umbrella scopes
+	 * group under the synthetic key 'umbrella'.
+	 *
+	 * Output ordering: umbrella first, then modules alphabetically. Within a
+	 * module, scopes preserve the order given (already sorted by callers).
+	 *
+	 * @param string[] $scopes Already-validated scope strings.
+	 * @return array<string, string[]> Module slug → scope strings.
+	 */
+	public static function group( array $scopes ): array {
+		$out = array();
+		foreach ( $scopes as $scope ) {
+			if ( ! is_string( $scope ) ) {
+				continue;
+			}
+			$parts = explode( ':', $scope );
+			// 'abilities:read' → umbrella; 'abilities:content:read' → module 'content'.
+			$module = ( count( $parts ) === 2 ) ? 'umbrella' : ( $parts[1] ?? 'umbrella' );
+			$out[ $module ][] = $scope;
+		}
+
+		// Stable order: umbrella first, then alphabetical modules.
+		uksort(
+			$out,
+			static function ( string $a, string $b ): int {
+				if ( 'umbrella' === $a ) {
+					return -1;
+				}
+				if ( 'umbrella' === $b ) {
+					return 1;
+				}
+				return strcmp( $a, $b );
+			}
+		);
+
+		return $out;
+	}
+
+	/**
+	 * Whether a module group contains any sensitive scope.
+	 *
+	 * Used to render the lock icon next to module headings.
+	 *
+	 * @param string[] $module_scopes
+	 */
+	public static function group_is_sensitive( array $module_scopes ): bool {
+		foreach ( $module_scopes as $scope ) {
+			if ( ScopeRegistry::is_sensitive( (string) $scope ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * /oauth/authorize endpoint — Phase 3.
+ *
+ * Pre-WP route handler intercepted at init priority 0 by AuthorizationServer.
+ * GET handles initial redirect-from-bridge; POST handles consent form submit.
+ *
+ * Locked-spec compliance:
+ *   - Appendix H.3.6: validate client_id + redirect_uri BEFORE the login
+ *     redirect. An attacker hitting /oauth/authorize with a malformed
+ *     client_id gets a 400 HTML error, NOT a redirect to wp-login.
+ *   - Appendix H.3.5: state is required, ≤256 chars, round-tripped opaquely.
+ *   - Appendix H.3.4 + sub-issue scope: sensitive scopes always show
+ *     consent; auto-approve only when (recognized client_id + unchanged
+ *     non-sensitive scopes + within consent_max_silent_days).
+ *   - Appendix H.4.5: scope set re-validated server-side on POST against
+ *     the rendered nonce; role switcher constrained server-side to roles
+ *     the current user actually holds.
+ *
+ * Output rules (all responses):
+ *   - Cache-Control: no-store
+ *   - X-Frame-Options: DENY (consent screen is server-rendered, no JS, no iframes)
+ *   - No CORS — consent is operator-facing, never cross-origin
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints;
+
+use function WickedEvolutions\McpAdapter\Auth\OAuth\oauth_client_ip;
+use function WickedEvolutions\McpAdapter\Auth\OAuth\oauth_log_boundary;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationCodeStore;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\AuthorizeRequestValidator;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\AuthorizeValidationResult;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecision;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecisionEvaluator;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentScreenRenderer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\LastConsentLookup;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PolicyStore;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PriorGrantLookup;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RenderedScopeNonce;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RoleSelector;
+use WickedEvolutions\McpAdapter\Auth\OAuth\DiscoveryEndpoints;
+
+/**
+ * Top-level dispatcher for /oauth/authorize. Pre-WP — exits with `never`.
+ */
+final class AuthorizeEndpoint {
+
+	/** Lifetime of an issued authorization code (seconds). */
+	private const CODE_TTL = 600;
+
+	/** Dispatch by request method. */
+	public static function dispatch(): never {
+		$method = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? 'GET' ) );
+		match ( $method ) {
+			'GET'  => self::handle_get( $_GET ),
+			'POST' => self::handle_post( $_POST ),
+			default => self::reject_method(),
+		};
+	}
+
+	/** Reject any non-GET / non-POST method per OAuth 2.1. */
+	private static function reject_method(): never {
+		status_header( 405 );
+		header( 'Allow: GET, POST' );
+		header( 'Cache-Control: no-store' );
+		exit;
+	}
+
+	// ─── GET /oauth/authorize ────────────────────────────────────────────────────
+
+	/**
+	 * GET handler — validates per H.3.6, then dispatches to login redirect,
+	 * auto-approve, or consent screen.
+	 *
+	 * @param array $params Raw query string.
+	 */
+	public static function handle_get( array $params ): never {
+		$resource_indicator = self::resource_indicator();
+		$validation         = AuthorizeRequestValidator::validate( $params, $resource_indicator );
+
+		if ( $validation->is_pre_redirect_error() ) {
+			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+				'ip'         => oauth_client_ip(),
+				'reason'     => 'pre_redirect_validation_failed',
+				'error_code' => $validation->error_code,
+			) );
+			ConsentScreenRenderer::render_error(
+				__( 'Authorization request invalid', 'mcp-adapter' ),
+				$validation->error_description
+			);
+		}
+
+		if ( $validation->is_redirectable_error() ) {
+			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+				'client_id'  => (string) $validation->client->client_id,
+				'reason'     => 'redirectable_validation_failed',
+				'error_code' => $validation->error_code,
+			) );
+			self::redirect_with_error( $validation->redirect_uri, $validation->error_code, $validation->error_description, $validation->state );
+		}
+
+		// Validation passed. From here, the request can be redirected to wp-login safely
+		// (the redirect_uri itself is now known good — H.3.6 line 7 reached).
+		if ( ! is_user_logged_in() ) {
+			self::redirect_to_login();
+		}
+
+		$user_id = (int) get_current_user_id();
+		$now     = time();
+
+		$prior_scopes      = PriorGrantLookup::scopes_for( (string) $validation->client->client_id, $user_id );
+		$last_interactive  = LastConsentLookup::timestamp_for( (string) $validation->client->client_id, $user_id );
+		$silent_cap_days   = PolicyStore::consent_max_silent_days();
+
+		$decision = ConsentDecisionEvaluator::evaluate(
+			$validation->requested_scopes,
+			$prior_scopes,
+			$last_interactive,
+			$now,
+			$silent_cap_days
+		);
+
+		if ( $decision->is_auto_approve() ) {
+			self::mint_code_and_redirect( $validation, $decision, $user_id, /* interactive */ false );
+		}
+
+		// Render full or incremental consent.
+		self::render_consent( $validation, $decision, $user_id, $last_interactive );
+	}
+
+	/**
+	 * Issue a code, log the appropriate boundary event, and 302 to redirect_uri.
+	 *
+	 * @param bool $interactive True when the operator just clicked Authorize on the consent form.
+	 */
+	private static function mint_code_and_redirect(
+		AuthorizeValidationResult $validation,
+		ConsentDecision $decision,
+		int $user_id,
+		bool $interactive,
+		?array $effective_scopes = null
+	): never {
+		$client_id = (string) $validation->client->client_id;
+		$scopes    = $effective_scopes ?? $decision->requested;
+		$scope_str = implode( ' ', $scopes );
+
+		$plaintext_code = bin2hex( random_bytes( 32 ) );
+		AuthorizationCodeStore::store(
+			hash( 'sha256', $plaintext_code ),
+			$client_id,
+			$user_id,
+			$validation->redirect_uri,
+			$scope_str,
+			$validation->resource,
+			$validation->code_challenge,
+			self::CODE_TTL
+		);
+
+		if ( $interactive ) {
+			LastConsentLookup::record( $client_id, $user_id, time() );
+			oauth_log_boundary( 'boundary.oauth_authorization_granted', array(
+				'client_id' => $client_id,
+				'user_id'   => $user_id,
+			) );
+		} else {
+			oauth_log_boundary( 'boundary.oauth_authorization_auto_approved', array(
+				'client_id' => $client_id,
+				'user_id'   => $user_id,
+			) );
+		}
+
+		self::redirect_with_code( $validation->redirect_uri, $plaintext_code, $validation->state );
+	}
+
+	/** Render full or incremental consent screen. */
+	private static function render_consent(
+		AuthorizeValidationResult $validation,
+		ConsentDecision $decision,
+		int $user_id,
+		?int $last_interactive_unix
+	): never {
+		$client = $validation->client;
+		$user   = function_exists( 'get_userdata' ) ? get_userdata( $user_id ) : null;
+
+		$user_login   = $user && isset( $user->user_login )   ? (string) $user->user_login   : (string) $user_id;
+		$user_display = $user && isset( $user->display_name ) ? (string) $user->display_name : $user_login;
+
+		$available_roles = RoleSelector::roles_for_user_id( $user_id );
+
+		$action_url = self::self_url();
+
+		ConsentScreenRenderer::render( array(
+			'client_id'                  => (string) $client->client_id,
+			'client_name'                => (string) ( $client->client_name ?? '' ),
+			'redirect_uri'               => $validation->redirect_uri,
+			'scope'                      => implode( ' ', $decision->requested ),
+			'state'                      => $validation->state,
+			'code_challenge'             => $validation->code_challenge,
+			'resource'                   => $validation->resource,
+			'user_id'                    => $user_id,
+			'user_login'                 => $user_login,
+			'user_display'               => $user_display,
+			'available_roles'            => $available_roles,
+			'decision'                   => $decision,
+			'previously_granted_at_unix' => $last_interactive_unix,
+			'action_url'                 => $action_url,
+		) );
+	}
+
+	// ─── POST /oauth/authorize ───────────────────────────────────────────────────
+
+	/**
+	 * POST handler — operator submitted the consent form.
+	 *
+	 * Re-validates query parameters from the POST body (defense-in-depth: never
+	 * trust that the GET-validated values survived an attacker-controlled DOM).
+	 * Re-checks scope subset against the server-issued nonce (H.4.5).
+	 * Re-checks role membership against the user's actual roles (H.4.5).
+	 *
+	 * @param array $params Raw $_POST.
+	 */
+	public static function handle_post( array $params ): never {
+		// Operator must be logged in to post the consent form.
+		if ( ! is_user_logged_in() ) {
+			self::redirect_to_login();
+		}
+
+		$resource_indicator = self::resource_indicator();
+		$validation         = AuthorizeRequestValidator::validate( $params, $resource_indicator );
+
+		if ( $validation->is_pre_redirect_error() ) {
+			ConsentScreenRenderer::render_error(
+				__( 'Authorization request invalid', 'mcp-adapter' ),
+				$validation->error_description
+			);
+		}
+		if ( $validation->is_redirectable_error() ) {
+			self::redirect_with_error( $validation->redirect_uri, $validation->error_code, $validation->error_description, $validation->state );
+		}
+
+		$user_id = (int) get_current_user_id();
+		$client  = $validation->client;
+
+		$decision_field = (string) ( $params[ ConsentScreenRenderer::DECISION_FIELD ] ?? '' );
+		if ( ConsentScreenRenderer::DECISION_DENY === $decision_field ) {
+			oauth_log_boundary( 'boundary.oauth_authorization_denied', array(
+				'client_id' => (string) $client->client_id,
+				'user_id'   => $user_id,
+				'reason'    => 'operator_denied',
+			) );
+			self::redirect_with_error( $validation->redirect_uri, 'access_denied', 'The operator declined to grant access.', $validation->state );
+		}
+
+		if ( ConsentScreenRenderer::DECISION_AUTHORIZE !== $decision_field ) {
+			ConsentScreenRenderer::render_error(
+				__( 'Consent form invalid', 'mcp-adapter' ),
+				__( 'No decision was submitted.', 'mcp-adapter' )
+			);
+		}
+
+		// === H.4.5: redeem the rendered-scope nonce. ===
+		$nonce_value = (string) ( $params[ ConsentScreenRenderer::NONCE_FIELD ] ?? '' );
+		$payload     = RenderedScopeNonce::redeem( $nonce_value );
+		if ( null === $payload ) {
+			ConsentScreenRenderer::render_error(
+				__( 'Consent form expired', 'mcp-adapter' ),
+				__( 'Please restart the authorization flow from your bridge.', 'mcp-adapter' )
+			);
+		}
+
+		// === H.4.5: scope set re-validation against the server-issued nonce. ===
+		$submitted_scopes = self::submitted_scopes( $params );
+		if ( ! RenderedScopeNonce::submitted_subset_is_valid(
+			$payload,
+			$user_id,
+			(string) $client->client_id,
+			$validation->redirect_uri,
+			$validation->state,
+			$submitted_scopes
+		) ) {
+			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+				'client_id' => (string) $client->client_id,
+				'user_id'   => $user_id,
+				'reason'    => 'scope_subset_violation',
+			) );
+			ConsentScreenRenderer::render_error(
+				__( 'Consent form tampering detected', 'mcp-adapter' ),
+				__( 'The submitted permissions do not match what was rendered. Please restart the authorization flow.', 'mcp-adapter' )
+			);
+		}
+
+		// === H.4.5: role switcher must be a role the user currently holds. ===
+		$submitted_role  = (string) ( $params[ ConsentScreenRenderer::ROLE_FIELD ] ?? '' );
+		$available_roles = RoleSelector::roles_for_user_id( $user_id );
+		if ( ! empty( $available_roles ) ) {
+			// If the form sent any role, it must be one the user actually holds.
+			if ( '' !== $submitted_role && ! RoleSelector::user_holds_role( $user_id, $submitted_role ) ) {
+				oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+					'client_id' => (string) $client->client_id,
+					'user_id'   => $user_id,
+					'reason'    => 'role_escalation_attempt',
+				) );
+				ConsentScreenRenderer::render_error(
+					__( 'Role selection invalid', 'mcp-adapter' ),
+					__( 'You may only authorize the bridge as a role you already hold.', 'mcp-adapter' )
+				);
+			}
+		}
+
+		// All gates passed. Submitted scope set may be narrower than rendered.
+		// We mint with *the submitted set*, not the originally-requested set.
+		$decision = new ConsentDecision(
+			ConsentDecision::RENDER_FULL,
+			$validation->requested_scopes,
+			$submitted_scopes,
+			array(),
+			array(),
+			''
+		);
+		self::mint_code_and_redirect( $validation, $decision, $user_id, /* interactive */ true, $submitted_scopes );
+	}
+
+	/**
+	 * Extract the submitted scope[] checkbox values, deduplicated, all strings.
+	 *
+	 * @param array $params $_POST
+	 * @return string[]
+	 */
+	private static function submitted_scopes( array $params ): array {
+		$raw = $params[ ConsentScreenRenderer::SCOPE_FIELD ] ?? array();
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $value ) {
+			if ( is_string( $value ) && '' !== $value ) {
+				$out[] = $value;
+			}
+		}
+		return array_values( array_unique( $out ) );
+	}
+
+	// ─── Redirect helpers ────────────────────────────────────────────────────────
+
+	/** Redirect to wp-login.php with `redirect_to` set back to this exact authorize URL (H.3.6 same-origin note). */
+	private static function redirect_to_login(): never {
+		$self = self::self_url() . ( isset( $_SERVER['QUERY_STRING'] ) && '' !== (string) $_SERVER['QUERY_STRING']
+			? '?' . (string) $_SERVER['QUERY_STRING']
+			: '' );
+		$login_url = function_exists( 'wp_login_url' )
+			? wp_login_url( $self )
+			: ( DiscoveryEndpoints::issuer() . '/wp-login.php?redirect_to=' . rawurlencode( $self ) );
+
+		status_header( 302 );
+		header( 'Location: ' . $login_url );
+		header( 'Cache-Control: no-store' );
+		exit;
+	}
+
+	/**
+	 * Redirect with `code` + `state` to a known-good redirect_uri.
+	 * Uses raw header() — wp_redirect adds defaults that don't suit a 302
+	 * back to a loopback bridge.
+	 */
+	private static function redirect_with_code( string $redirect_uri, string $code, string $state ): never {
+		$separator = ( str_contains( $redirect_uri, '?' ) ) ? '&' : '?';
+		$location  = $redirect_uri
+			. $separator . 'code=' . rawurlencode( $code )
+			. '&state=' . rawurlencode( $state );
+
+		status_header( 302 );
+		header( 'Location: ' . $location );
+		header( 'Cache-Control: no-store' );
+		exit;
+	}
+
+	/**
+	 * Redirect with `error=...&error_description=...&state=...` to a known-good redirect_uri.
+	 * Per OAuth 2.1 §10.7, only used when redirect_uri itself has been validated.
+	 */
+	private static function redirect_with_error( string $redirect_uri, string $error_code, string $description, string $state ): never {
+		$separator = ( str_contains( $redirect_uri, '?' ) ) ? '&' : '?';
+		$location  = $redirect_uri
+			. $separator . 'error=' . rawurlencode( $error_code )
+			. '&error_description=' . rawurlencode( $description )
+			. ( '' !== $state ? '&state=' . rawurlencode( $state ) : '' );
+
+		status_header( 302 );
+		header( 'Location: ' . $location );
+		header( 'Cache-Control: no-store' );
+		exit;
+	}
+
+	/** The canonical /oauth/authorize URL on this site, for self-posting + redirect_to. */
+	private static function self_url(): string {
+		return DiscoveryEndpoints::issuer() . '/oauth/authorize';
+	}
+
+	/** This site's resource indicator URL (mirrors AuthorizationServer::authenticate_bearer's binding). */
+	private static function resource_indicator(): string {
+		return function_exists( 'rest_url' )
+			? rest_url( 'mcp/mcp-adapter-default-server' )
+			: DiscoveryEndpoints::resource_url();
+	}
+}

--- a/tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php
+++ b/tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests for AuthHeaderProbe — populates the H.2.6 diagnostic from a rolling counter.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Admin\Bridges\AuthHeaderProbe;
+
+final class AuthHeaderProbeTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options'] = array();
+		AuthHeaderProbe::clear();
+	}
+
+	public function test_returns_existing_when_no_observations_yet(): void {
+		$result = AuthHeaderProbe::resolve_status( null );
+		$this->assertNull( $result, 'No observations means: defer to placeholder default.' );
+	}
+
+	public function test_returns_ok_when_all_recent_requests_had_header(): void {
+		for ( $i = 0; $i < 5; $i++ ) {
+			AuthHeaderProbe::record( true );
+		}
+		$result = AuthHeaderProbe::resolve_status( null );
+		$this->assertSame( 'ok', $result['state'] );
+	}
+
+	public function test_returns_warn_when_no_recent_requests_had_header(): void {
+		for ( $i = 0; $i < 3; $i++ ) {
+			AuthHeaderProbe::record( false );
+		}
+		$result = AuthHeaderProbe::resolve_status( null );
+		$this->assertSame( 'warn', $result['state'] );
+		$this->assertNotEmpty( $result['docs_url'] );
+	}
+
+	public function test_returns_warn_when_some_recent_requests_were_missing_header(): void {
+		AuthHeaderProbe::record( true );
+		AuthHeaderProbe::record( true );
+		AuthHeaderProbe::record( false );
+		$result = AuthHeaderProbe::resolve_status( null );
+		$this->assertSame( 'warn', $result['state'] );
+	}
+
+	public function test_window_is_capped_at_100_observations(): void {
+		// Push 150 observations — only the last 100 should be considered.
+		for ( $i = 0; $i < 150; $i++ ) {
+			AuthHeaderProbe::record( true );
+		}
+		$result = AuthHeaderProbe::resolve_status( null );
+		$this->assertSame( 'ok', $result['state'] );
+		$this->assertStringContainsString( '100', $result['message'] );
+	}
+}

--- a/tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php
+++ b/tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for BoundaryAuditBuffer — captures OAuth boundary events into a
+ * bounded ring buffer for the Connected Bridges audit slice.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Admin\Bridges\BoundaryAuditBuffer;
+
+final class BoundaryAuditBufferTest extends TestCase {
+
+	protected function setUp(): void {
+		BoundaryAuditBuffer::clear();
+	}
+
+	public function test_captures_oauth_events_to_buffer(): void {
+		BoundaryAuditBuffer::capture( 'boundary.oauth_authorization_granted', array( 'client_id' => 'cid', 'user_id' => 7 ) );
+		$entries = BoundaryAuditBuffer::read();
+		$this->assertCount( 1, $entries );
+		$this->assertSame( 'boundary.oauth_authorization_granted', $entries[0]['event'] );
+		$this->assertSame( 'cid', $entries[0]['client_id'] );
+		$this->assertSame( 7, $entries[0]['user_id'] );
+	}
+
+	public function test_ignores_non_oauth_events(): void {
+		BoundaryAuditBuffer::capture( 'boundary.session_created', array( 'client_id' => 'cid' ) );
+		$this->assertEmpty( BoundaryAuditBuffer::read() );
+	}
+
+	public function test_buffer_is_bounded_to_max_entries(): void {
+		for ( $i = 0; $i < BoundaryAuditBuffer::MAX_ENTRIES + 5; $i++ ) {
+			BoundaryAuditBuffer::capture( 'boundary.oauth_token_issued', array( 'client_id' => 'c' . $i ) );
+		}
+		$entries = BoundaryAuditBuffer::read();
+		$this->assertCount( BoundaryAuditBuffer::MAX_ENTRIES, $entries );
+		// Last entry should be the most recent.
+		$this->assertSame( 'c' . ( BoundaryAuditBuffer::MAX_ENTRIES + 4 ), end( $entries )['client_id'] );
+	}
+
+	public function test_records_reason_and_error_code_when_present(): void {
+		BoundaryAuditBuffer::capture( 'boundary.oauth_authorize_error', array(
+			'client_id'  => 'cid',
+			'reason'     => 'redirectable_validation_failed',
+			'error_code' => 'invalid_scope',
+		) );
+		$entries = BoundaryAuditBuffer::read();
+		$this->assertSame( 'redirectable_validation_failed', $entries[0]['reason'] );
+		$this->assertSame( 'invalid_scope', $entries[0]['error_code'] );
+	}
+
+	public function test_handles_missing_optional_fields_gracefully(): void {
+		BoundaryAuditBuffer::capture( 'boundary.oauth_invalid_token', array() );
+		$entries = BoundaryAuditBuffer::read();
+		$this->assertCount( 1, $entries );
+		$this->assertSame( '', $entries[0]['client_id'] );
+		$this->assertSame( 0, $entries[0]['user_id'] );
+		$this->assertSame( '', $entries[0]['reason'] );
+	}
+}

--- a/tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php
+++ b/tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for BridgeRowProjector — pure projection of a Connected Bridges row.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Admin\Bridges;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Admin\Bridges\BridgeRowProjector;
+
+final class BridgeRowProjectorTest extends TestCase {
+
+	private const NOW = 1_700_000_000;
+	private const DAY = 86400;
+
+	public function test_projects_basic_row(): void {
+		$client = (object) array(
+			'client_id'        => 'cid-1',
+			'client_name'      => 'My Bridge',
+			'software_id'      => 'com.example.bridge',
+			'software_version' => '1.2.3',
+			'scopes'           => 'abilities:read',
+			'registered_at'    => '2026-01-01 00:00:00',
+		);
+		$token = (object) array(
+			'user_id'      => 7,
+			'scope'        => 'abilities:content:read abilities:content:write',
+			'last_used_at' => '2026-04-25 08:00:00',
+			'expires_at'   => '2026-05-25 08:00:00',
+		);
+
+		$row = BridgeRowProjector::project( $client, $token, self::NOW - ( 100 * self::DAY ), self::NOW, 365 );
+
+		$this->assertSame( 'cid-1', $row['client_id'] );
+		$this->assertSame( 'My Bridge', $row['client_name'] );
+		$this->assertSame( 'com.example.bridge 1.2.3', $row['software'] );
+		$this->assertSame( 7, $row['user_id'] );
+		$this->assertSame( array( 'abilities:content:read', 'abilities:content:write' ), $row['scopes'] );
+		$this->assertSame( '2026-04-25 08:00:00', $row['last_used_at'] );
+		$this->assertSame( 100, $row['last_consent_days'] );
+		$this->assertFalse( $row['show_silent_warning'] );
+	}
+
+	public function test_silent_warning_triggers_at_threshold_minus_30_days(): void {
+		$client = (object) array( 'client_id' => 'cid-1', 'client_name' => 'X' );
+		$token  = (object) array( 'user_id' => 1, 'scope' => 'abilities:read', 'last_used_at' => '', 'expires_at' => '' );
+
+		// Cap = 365, threshold = 335. At 334 days, no warning. At 335, warning.
+		$row_below = BridgeRowProjector::project( $client, $token, self::NOW - ( 334 * self::DAY ), self::NOW, 365 );
+		$row_at    = BridgeRowProjector::project( $client, $token, self::NOW - ( 335 * self::DAY ), self::NOW, 365 );
+
+		$this->assertFalse( $row_below['show_silent_warning'] );
+		$this->assertTrue(  $row_at['show_silent_warning'] );
+	}
+
+	public function test_silent_warning_false_when_no_last_consent(): void {
+		$client = (object) array( 'client_id' => 'cid-1', 'client_name' => 'X' );
+		$token  = (object) array( 'user_id' => 1, 'scope' => '', 'last_used_at' => null, 'expires_at' => null );
+
+		$row = BridgeRowProjector::project( $client, $token, null, self::NOW, 365 );
+		$this->assertNull( $row['last_consent_days'] );
+		$this->assertFalse( $row['show_silent_warning'] );
+	}
+
+	public function test_handles_missing_token(): void {
+		$client = (object) array(
+			'client_id'   => 'cid-1',
+			'client_name' => 'No-token bridge',
+			'scopes'      => 'abilities:read',
+		);
+
+		$row = BridgeRowProjector::project( $client, null, null, self::NOW, 365 );
+
+		$this->assertSame( 0, $row['user_id'] );
+		$this->assertSame( array( 'abilities:read' ), $row['scopes'], 'falls back to client.scopes when token absent' );
+		$this->assertNull( $row['last_used_at'] );
+		$this->assertNull( $row['expires_at'] );
+	}
+
+	public function test_software_string_omits_version_when_blank(): void {
+		$client = (object) array(
+			'client_id'        => 'cid-1',
+			'client_name'      => 'X',
+			'software_id'      => 'com.example.bridge',
+			'software_version' => '',
+		);
+		$row = BridgeRowProjector::project( $client, null, null, self::NOW, 365 );
+		$this->assertSame( 'com.example.bridge', $row['software'] );
+	}
+}

--- a/tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php
+++ b/tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php
@@ -1,7 +1,12 @@
 <?php
 /**
- * Tests for ConnectedBridgesTab — verifies the H.2.6 diagnostic seam shipped
- * in the Phase 2 placeholder.
+ * Tests for ConnectedBridgesTab — Phase 3 content + the H.2.6 diagnostic seam.
+ *
+ * Verifies:
+ *   - The empty-state copy when no clients are registered.
+ *   - The H.2.6 diagnostic seam (filter contract preserved from Phase 2).
+ *   - The bridges table renders columns + warning icon + revoke form.
+ *   - The revoke handler verifies nonce + capability + cascades through ClientRegistry::revoke().
  *
  * @package WickedEvolutions\McpAdapter\Tests
  */
@@ -17,14 +22,25 @@ class ConnectedBridgesTabTest extends TestCase {
 
 	protected function set_up(): void {
 		parent::set_up();
-		// Reset the filter registry between cases so a stub from one test
-		// doesn't leak into the next.
-		$GLOBALS['wp_test_filters'] = array();
+		$GLOBALS['wp_test_filters']  = array();
+		$GLOBALS['wp_test_options']  = array();
+		$GLOBALS['wp_test_users']    = array();
+		// Default: empty client list. Tests can override $wpdb to seed rows.
+		$GLOBALS['wpdb'] = new class {
+			public string $prefix = 'wp_';
+			public function get_results( $query ) { return array(); }
+			public function get_row( $query ) { return null; }
+			public function get_var( $query ) { return null; }
+			public function prepare( $query, ...$args ) { return $query; }
+			public function insert( $table, $data, $format = null ) { return 1; }
+			public function update( $table, $data, $where, $format = null, $where_format = null ) { return 1; }
+			public function query( $sql ) { return true; }
+		};
 	}
 
+	// ─── Diagnostic seam (Phase 2 contract, must remain intact) ─────────────────
+
 	public function test_diagnostic_filter_name_is_documented_contract(): void {
-		// Phase 1 / Phase 3 will hook this exact name. If we ever need to
-		// rename it, that is a coordinated breaking change.
 		$this->assertSame(
 			'mcp_adapter_bridges_authorization_header_status',
 			ConnectedBridgesTab::DIAGNOSTIC_FILTER
@@ -34,7 +50,6 @@ class ConnectedBridgesTabTest extends TestCase {
 	public function test_render_emits_unknown_state_when_no_listener(): void {
 		$html = $this->capture_render();
 		$this->assertStringContainsString( 'wp-mcp-adapter-status-dot--unknown', $html );
-		// Falls back to the default operator-facing message.
 		$this->assertStringContainsString( 'has not reported yet', $html );
 	}
 
@@ -46,7 +61,6 @@ class ConnectedBridgesTabTest extends TestCase {
 				'docs_url' => 'https://example.com/setup',
 			);
 		} );
-
 		$html = $this->capture_render();
 		$this->assertStringContainsString( 'wp-mcp-adapter-status-dot--ok', $html );
 		$this->assertStringContainsString( 'Detected on last 100 requests.', $html );
@@ -60,7 +74,6 @@ class ConnectedBridgesTabTest extends TestCase {
 				'message' => 'No Authorization header detected on last 100 requests.',
 			);
 		} );
-
 		$html = $this->capture_render();
 		$this->assertStringContainsString( 'wp-mcp-adapter-status-dot--warn', $html );
 		$this->assertStringContainsString( 'No Authorization header detected', $html );
@@ -68,24 +81,139 @@ class ConnectedBridgesTabTest extends TestCase {
 
 	public function test_unknown_state_value_collapses_to_unknown(): void {
 		add_filter( ConnectedBridgesTab::DIAGNOSTIC_FILTER, function () {
-			// Listener returns a state outside the locked vocabulary.
 			return array( 'state' => 'panic', 'message' => 'should be ignored' );
 		} );
-
 		$html = $this->capture_render();
 		$this->assertStringContainsString( 'wp-mcp-adapter-status-dot--unknown', $html );
 	}
 
-	public function test_placeholder_explicitly_marks_phase_3_content_as_pending(): void {
+	// ─── Empty + table render ────────────────────────────────────────────────────
+
+	public function test_empty_state_shows_helpful_copy(): void {
 		$html = $this->capture_render();
-		// The empty-state copy is the operator's signal that the tab content
-		// is intentional Phase 2 scope, not a regression.
+		// Phase 3 copy — operator-facing message.
+		$this->assertStringContainsString( 'No bridges have completed', $html );
 		$this->assertStringContainsString( 'No bridges yet', $html );
 	}
 
+	public function test_table_renders_with_seeded_clients(): void {
+		$clients = array(
+			(object) array(
+				'client_id'        => 'cid-table-1',
+				'client_name'      => 'Test Bridge One',
+				'software_id'      => 'com.example.bridge',
+				'software_version' => '1.0.0',
+				'scopes'           => 'abilities:read',
+				'registered_ip'    => '127.0.0.1',
+				'registered_at'    => '2026-04-01 12:00:00',
+			),
+		);
+		$this->seed_client_list( $clients );
+
+		$html = $this->capture_render();
+		$this->assertStringContainsString( 'Test Bridge One', $html );
+		$this->assertStringContainsString( 'Authorized bridges', $html );
+		$this->assertStringContainsString( 'wp-mcp-bridges-table', $html );
+		// Revoke form rendered with client_id.
+		$this->assertStringContainsString( 'cid-table-1', $html );
+		$this->assertStringContainsString( 'mcp_bridges_action', $html );
+	}
+
+	// ─── Revoke handler ──────────────────────────────────────────────────────────
+
+	public function test_handle_action_does_nothing_without_capability(): void {
+		$GLOBALS['wp_test_caps'] = array();
+		$_POST = array(
+			ConnectedBridgesTab::ACTION_FIELD => ConnectedBridgesTab::ACTION_REVOKE,
+			ConnectedBridgesTab::NONCE_FIELD  => 'test-nonce',
+			'client_id'                       => 'cid-x',
+		);
+		$revoke_calls = $this->spy_revokes();
+		ConnectedBridgesTab::handle_action();
+		$this->assertSame( 0, $revoke_calls() );
+	}
+
+	public function test_handle_action_does_nothing_without_valid_nonce(): void {
+		$GLOBALS['wp_test_caps'] = array( 'manage_options' => true );
+		$_POST = array(
+			ConnectedBridgesTab::ACTION_FIELD => ConnectedBridgesTab::ACTION_REVOKE,
+			ConnectedBridgesTab::NONCE_FIELD  => 'wrong-nonce',
+			'client_id'                       => 'cid-x',
+		);
+		$revoke_calls = $this->spy_revokes();
+		ConnectedBridgesTab::handle_action();
+		$this->assertSame( 0, $revoke_calls() );
+	}
+
+	public function test_handle_action_revokes_when_nonce_and_capability_present(): void {
+		$GLOBALS['wp_test_caps'] = array( 'manage_options' => true );
+		$_POST = array(
+			ConnectedBridgesTab::ACTION_FIELD => ConnectedBridgesTab::ACTION_REVOKE,
+			ConnectedBridgesTab::NONCE_FIELD  => 'test-nonce',
+			'client_id'                       => 'cid-revoke',
+		);
+		$revoke_calls = $this->spy_revokes();
+		try {
+			ConnectedBridgesTab::handle_action();
+		} catch ( \WickedEvolutions\McpAdapter\Tests\RedirectException $e ) {
+			// Redirect is expected on success — caught by the test stub.
+		}
+		$this->assertSame( 1, $revoke_calls() );
+	}
+
+	// ─── Helpers ────────────────────────────────────────────────────────────────
+
+	/** Capture render output. */
 	private function capture_render(): string {
 		ob_start();
 		ConnectedBridgesTab::render();
 		return (string) ob_get_clean();
+	}
+
+	/** Seed a client list. Called once per test that wants a populated table. */
+	private function seed_client_list( array $clients ): void {
+		$GLOBALS['wpdb'] = new class( $clients ) {
+			public string $prefix = 'wp_';
+			private array $clients;
+			public function __construct( array $clients ) { $this->clients = $clients; }
+			public function get_results( $query ) {
+				return str_contains( (string) $query, 'kl_oauth_clients' ) ? $this->clients : array();
+			}
+			public function get_row( $query ) { return null; }
+			public function get_var( $query ) { return null; }
+			public function prepare( $query, ...$args ) { return $query; }
+			public function insert( $table, $data, $format = null ) { return 1; }
+			public function update( $table, $data, $where, $format = null, $where_format = null ) { return 1; }
+			public function query( $sql ) { return true; }
+		};
+	}
+
+	/**
+	 * Replace the $wpdb->update() implementation with a counter so we can
+	 * detect that ClientRegistry::revoke()'s cascade transaction ran.
+	 *
+	 * @return callable(): int Returns the number of UPDATE statements observed.
+	 */
+	private function spy_revokes(): callable {
+		$counter = new \stdClass();
+		$counter->n = 0;
+		$GLOBALS['wpdb'] = new class( $counter ) {
+			public string $prefix = 'wp_';
+			private \stdClass $c;
+			public function __construct( \stdClass $c ) { $this->c = $c; }
+			public function get_results( $query ) { return array(); }
+			public function get_row( $query ) { return null; }
+			public function get_var( $query ) { return null; }
+			public function prepare( $query, ...$args ) { return $query; }
+			public function insert( $table, $data, $format = null ) { return 1; }
+			public function update( $table, $data, $where, $format = null, $where_format = null ) {
+				if ( str_contains( (string) $table, 'kl_oauth_clients' ) ) {
+					$this->c->n++;
+				}
+				return 1;
+			}
+			public function query( $sql ) { return true; }
+		};
+		return static fn() => $counter->n;
 	}
 }

--- a/tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Tests for AuthorizeRequestValidator — implements the H.3.6 + H.3.5 contract.
+ *
+ * Critical invariants:
+ *   - client_id missing/unknown → PRE_REDIRECT_ERROR (NEVER redirect, even with redirect_uri set).
+ *   - redirect_uri unregistered → PRE_REDIRECT_ERROR (NEVER redirect).
+ *   - state missing or > 256 chars → REDIRECTABLE_ERROR (we have a known-good redirect_uri at this point).
+ *   - PKCE / response_type / scope errors → REDIRECTABLE_ERROR.
+ *
+ * The first two invariants together prove H.3.6: an attacker hitting
+ * /oauth/authorize with garbage cannot trigger a wp-login redirect that
+ * would leak auth state.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\AuthorizeRequestValidator;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\AuthorizeValidationResult;
+
+final class AuthorizeRequestValidatorTest extends TestCase {
+
+	private const RESOURCE = 'https://example.com/wp-json/mcp/mcp-adapter-default-server';
+
+	protected function setUp(): void {
+		// Each test starts with a clean stub registry of "registered clients".
+		$GLOBALS['wp_test_oauth_registered_clients'] = array();
+	}
+
+	// ─── H.3.6 — pre-login validation ─────────────────────────────────────────────
+
+	public function test_missing_client_id_returns_pre_redirect_error(): void {
+		$result = AuthorizeRequestValidator::validate(
+			array( 'redirect_uri' => 'http://127.0.0.1/cb', 'response_type' => 'code' ),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_pre_redirect_error(), 'No client_id MUST never redirect (H.3.6).' );
+		$this->assertSame( 'invalid_request', $result->error_code );
+	}
+
+	public function test_unknown_client_id_returns_pre_redirect_error_even_with_valid_redirect_uri(): void {
+		// No client registered for the given client_id → PRE_REDIRECT_ERROR, NEVER a redirect.
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => 'unknown-client-id',
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_pre_redirect_error(), 'Unknown client MUST never redirect (H.3.6).' );
+		$this->assertSame( 'invalid_client', $result->error_code );
+	}
+
+	public function test_unregistered_redirect_uri_returns_pre_redirect_error(): void {
+		$client_id = 'client-1';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'https://attacker.example.com/x',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_pre_redirect_error(), 'Unregistered redirect_uri MUST never redirect.' );
+		$this->assertSame( 'invalid_request', $result->error_code );
+	}
+
+	// ─── H.3.5 — state parameter ─────────────────────────────────────────────────
+
+	public function test_missing_state_returns_redirectable_error(): void {
+		$client_id = 'client-2';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => '',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'invalid_request', $result->error_code );
+		$this->assertStringContainsString( 'state', $result->error_description );
+	}
+
+	public function test_state_longer_than_256_chars_is_rejected(): void {
+		$client_id = 'client-3';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => str_repeat( 'a', 257 ),
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'invalid_request', $result->error_code );
+	}
+
+	public function test_state_at_exactly_256_chars_is_accepted(): void {
+		$client_id = 'client-4';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => str_repeat( 'a', 256 ),
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_ok(), 'state at exactly 256 chars must validate (H.3.5).' );
+	}
+
+	// ─── PKCE ────────────────────────────────────────────────────────────────────
+
+	public function test_missing_code_challenge_returns_redirectable_error(): void {
+		$client_id = 'client-5';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> '',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+	}
+
+	public function test_unsupported_code_challenge_method_returns_redirectable_error(): void {
+		$client_id = 'client-6';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'             => $client_id,
+				'redirect_uri'          => 'http://127.0.0.1/cb',
+				'response_type'         => 'code',
+				'scope'                 => 'abilities:read',
+				'state'                 => 'abc',
+				'code_challenge'        => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+				'code_challenge_method' => 'plain',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+	}
+
+	// ─── response_type ───────────────────────────────────────────────────────────
+
+	public function test_unsupported_response_type_returns_redirectable_error(): void {
+		$client_id = 'client-7';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'token',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'unsupported_response_type', $result->error_code );
+	}
+
+	// ─── scope ────────────────────────────────────────────────────────────────────
+
+	public function test_unknown_scope_returns_redirectable_error(): void {
+		$client_id = 'client-8';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:notarealmodule:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'invalid_scope', $result->error_code );
+	}
+
+	public function test_empty_scope_returns_redirectable_error(): void {
+		$client_id = 'client-9';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => '',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'invalid_scope', $result->error_code );
+	}
+
+	public function test_umbrella_scope_is_expanded_to_implicated_scopes(): void {
+		$client_id = 'client-10';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_ok() );
+		$this->assertContains( 'abilities:read',         $result->requested_scopes );
+		$this->assertContains( 'abilities:content:read', $result->requested_scopes );
+	}
+
+	// ─── resource indicator ───────────────────────────────────────────────────────
+
+	public function test_resource_mismatch_returns_redirectable_error(): void {
+		$client_id = 'client-11';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+				'resource'      => 'https://other.example.com/resource',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_redirectable_error() );
+		$this->assertSame( 'invalid_target', $result->error_code );
+	}
+
+	public function test_missing_resource_defaults_to_site_resource_indicator(): void {
+		$client_id = 'client-12';
+		$this->register_client( $client_id, array( 'http://127.0.0.1/cb' ) );
+
+		$result = AuthorizeRequestValidator::validate(
+			array(
+				'client_id'     => $client_id,
+				'redirect_uri'  => 'http://127.0.0.1/cb',
+				'response_type' => 'code',
+				'scope'         => 'abilities:read',
+				'state'         => 'abc',
+				'code_challenge'=> 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+			),
+			self::RESOURCE
+		);
+		$this->assertTrue( $result->is_ok() );
+		$this->assertSame( self::RESOURCE, $result->resource );
+	}
+
+	// ─── Helper — register a fake client by stubbing $wpdb->get_row. ─────────────
+
+	private function register_client( string $client_id, array $redirect_uris ): void {
+		$registered = $GLOBALS['wp_test_oauth_registered_clients'] ?? array();
+		$registered[ $client_id ] = (object) array(
+			'client_id'     => $client_id,
+			'client_name'   => 'Test bridge ' . $client_id,
+			'redirect_uris' => json_encode( $redirect_uris ),
+			'scopes'        => 'abilities:read',
+		);
+		$GLOBALS['wp_test_oauth_registered_clients'] = $registered;
+
+		// Re-bind $wpdb->get_row to return the matching client row.
+		$GLOBALS['wpdb'] = new class {
+			public string $prefix = 'wp_';
+			public function get_row( $query ) {
+				// Crude but deterministic: scan the prepared SQL for any registered client_id.
+				foreach ( $GLOBALS['wp_test_oauth_registered_clients'] as $cid => $row ) {
+					if ( str_contains( (string) $query, $cid ) ) {
+						return $row;
+					}
+				}
+				return null;
+			}
+			public function get_results( $query ) { return array(); }
+			public function get_var( $query )     { return null; }
+			public function prepare( $query, ...$args ) {
+				// Inline %s substitution so test assertions on get_row() can match by client_id.
+				$idx = 0;
+				return preg_replace_callback(
+					'/%s|%d/',
+					static function () use ( &$idx, $args ) {
+						$v = $args[ $idx ] ?? '';
+						$idx++;
+						return is_int( $v ) ? (string) $v : "'" . str_replace( "'", "''", (string) $v ) . "'";
+					},
+					$query
+				);
+			}
+			public function insert( $table, $data, $format = null ) { return 1; }
+			public function update( $table, $data, $where, $format = null, $where_format = null ) { return 1; }
+			public function query( $sql ) { return true; }
+		};
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Tests for ConsentDecisionEvaluator — the heart of Phase 3 routing.
+ *
+ * Binding sources:
+ *   - Sub-issue #32 auto-approve contract
+ *   - Appendix H.2.4 (silent-cap)
+ *   - Appendix H.3.4 (sensitive scopes always show consent)
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecision;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecisionEvaluator;
+
+final class ConsentDecisionEvaluatorTest extends TestCase {
+
+	private const NOW = 1_700_000_000;
+	private const DAY = 86400;
+
+	// ─── Auto-approve happy path ─────────────────────────────────────────────────
+
+	public function test_auto_approves_when_scopes_unchanged_and_within_silent_cap(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read', 'abilities:content:write' ),
+			array( 'abilities:content:read', 'abilities:content:write' ),
+			self::NOW - ( 100 * self::DAY ), // 100 days ago
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_auto_approve() );
+		$this->assertSame( ConsentDecision::AUTO_APPROVE, $decision->action );
+	}
+
+	public function test_auto_approves_when_requested_is_subset_of_previously_granted(): void {
+		// Reduction is OK — no new scopes, no sensitive scopes.
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read', 'abilities:content:write' ),
+			self::NOW - ( 10 * self::DAY ),
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_auto_approve() );
+	}
+
+	// ─── No prior grant ──────────────────────────────────────────────────────────
+
+	public function test_renders_full_consent_when_no_prior_interactive_grant(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array(),
+			null,
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'first_authorization', $decision->reason );
+	}
+
+	// ─── H.2.4 silent-cap ────────────────────────────────────────────────────────
+
+	public function test_renders_full_consent_when_silent_cap_exceeded_even_for_unchanged_scopes(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read' ),
+			self::NOW - ( 400 * self::DAY ), // > 365 days ago
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'silent_cap_exceeded', $decision->reason );
+	}
+
+	public function test_renders_full_consent_when_silent_cap_exceeded_at_exact_boundary_plus_one_second(): void {
+		// 1 second past the cap → must consent.
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read' ),
+			self::NOW - ( 365 * self::DAY ) - 1,
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'silent_cap_exceeded', $decision->reason );
+	}
+
+	public function test_silent_cap_can_be_set_to_one_day_for_high_security_sites(): void {
+		// 25 hours since last consent, cap = 1 day → must re-consent.
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read' ),
+			self::NOW - ( self::DAY + 3600 ),
+			self::NOW,
+			1
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'silent_cap_exceeded', $decision->reason );
+	}
+
+	// ─── H.3.4 sensitive scopes always show consent ──────────────────────────────
+
+	public function test_renders_full_consent_when_sensitive_scope_requested_even_if_previously_granted(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:settings:read' ),
+			array( 'abilities:settings:read' ), // PREVIOUSLY granted
+			self::NOW - ( 5 * self::DAY ),
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'sensitive_scope_requested', $decision->reason );
+	}
+
+	public function test_renders_full_consent_when_any_one_scope_in_set_is_sensitive(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read', 'abilities:settings:write' ),
+			array( 'abilities:content:read', 'abilities:settings:write' ),
+			self::NOW - self::DAY,
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'sensitive_scope_requested', $decision->reason );
+		$this->assertContains( 'abilities:settings:write', $decision->sensitive );
+	}
+
+	public function test_all_canonical_sensitive_modules_trigger_full_consent(): void {
+		// Verify every module listed in Appendix H.3.4 routes to full consent.
+		$modules = array( 'settings', 'users', 'filesystem', 'cron', 'plugins', 'multisite' );
+		foreach ( $modules as $module ) {
+			$scope    = "abilities:{$module}:read";
+			$decision = ConsentDecisionEvaluator::evaluate(
+				array( $scope ),
+				array( $scope ),
+				self::NOW - self::DAY,
+				self::NOW,
+				365
+			);
+			$this->assertTrue( $decision->is_render_full(), "{$module} sensitive scope must force full consent" );
+			$this->assertSame( 'sensitive_scope_requested', $decision->reason );
+		}
+	}
+
+	// ─── Incremental consent (new non-sensitive scopes) ──────────────────────────
+
+	public function test_renders_incremental_when_only_new_non_sensitive_scopes_added(): void {
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read', 'abilities:taxonomies:read' ),
+			array( 'abilities:content:read' ),
+			self::NOW - ( 30 * self::DAY ),
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_incremental() );
+		$this->assertSame( 'new_non_sensitive_scopes', $decision->reason );
+		$this->assertSame( array( 'abilities:taxonomies:read' ), $decision->newly_added );
+	}
+
+	public function test_renders_full_when_new_scope_is_sensitive_and_others_are_not(): void {
+		// New scope set includes a sensitive one — full consent, not incremental.
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read', 'abilities:plugins:write' ),
+			array( 'abilities:content:read' ),
+			self::NOW - self::DAY,
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'sensitive_scope_requested', $decision->reason );
+	}
+
+	// ─── Determinism / normalization ─────────────────────────────────────────────
+
+	public function test_decision_is_independent_of_input_order_or_duplicates(): void {
+		$d1 = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read', 'abilities:content:write', 'abilities:content:read' ),
+			array( 'abilities:content:write', 'abilities:content:read' ),
+			self::NOW - self::DAY,
+			self::NOW,
+			365
+		);
+		$d2 = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:write', 'abilities:content:read' ),
+			array( 'abilities:content:read', 'abilities:content:write' ),
+			self::NOW - self::DAY,
+			self::NOW,
+			365
+		);
+		$this->assertSame( $d1->action, $d2->action );
+		$this->assertSame( $d1->requested, $d2->requested );
+	}
+
+	// ─── Decision-precedence ordering ────────────────────────────────────────────
+
+	public function test_silent_cap_takes_precedence_over_sensitive_scope_check(): void {
+		// Past silent cap AND sensitive scope — reason is silent cap (we hit it first).
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:settings:read' ),
+			array( 'abilities:settings:read' ),
+			self::NOW - ( 400 * self::DAY ),
+			self::NOW,
+			365
+		);
+		$this->assertTrue( $decision->is_render_full() );
+		$this->assertSame( 'silent_cap_exceeded', $decision->reason );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Tests for ConsentScreenRenderer::build_html() and ::build_error_html().
+ *
+ * Verifies the rendered HTML contains all the operator-facing pieces the
+ * binding spec requires:
+ *   - Hidden inputs that round-trip the OAuth flow params (state, code_challenge, etc.)
+ *   - Server-issued nonce field (Appendix H.4.5)
+ *   - Each requested scope rendered as a TOGGLEABLE checkbox (H.3.4 — none locked)
+ *   - "Granted YYYY-MM-DD" badge for previously-granted scopes (H.3.4)
+ *   - Sensitive scope badge + lock icon for sensitive scopes (H.3.4)
+ *   - Role switcher constrained to provided role list (H.4.5)
+ *   - No <script> tags anywhere (server-rendered, no JS — H.4.5)
+ *   - All dynamic values escaped (no XSS surface)
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecision;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentScreenRenderer;
+
+final class ConsentScreenRendererTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_transients'] = array();
+	}
+
+	/** Build a baseline params array a test can mutate. */
+	private function params( array $overrides = array() ): array {
+		$decision = $overrides['decision'] ?? new ConsentDecision(
+			ConsentDecision::RENDER_FULL,
+			array( 'abilities:content:read', 'abilities:settings:read' ),
+			array( 'abilities:content:read' ),
+			array( 'abilities:settings:read' ),
+			array( 'abilities:settings:read' ),
+			'sensitive_scope_requested'
+		);
+		return array_merge( array(
+			'client_id'                  => 'client-uuid',
+			'client_name'                => 'Acme Bridge',
+			'redirect_uri'               => 'http://127.0.0.1:8765/cb',
+			'scope'                      => 'abilities:content:read abilities:settings:read',
+			'state'                      => 'rnd-state-xyz',
+			'code_challenge'             => 'CHALLENGE-XXXXXXXXXXXXXXXXXXXXXXXXXX',
+			'resource'                   => 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			'user_id'                    => 7,
+			'user_login'                 => 'jacob',
+			'user_display'               => 'Jacob Willow',
+			'available_roles'            => array( 'editor', 'author' ),
+			'decision'                   => $decision,
+			'previously_granted_at_unix' => 1_700_000_000,
+			'action_url'                 => 'https://example.com/oauth/authorize',
+		), $overrides );
+	}
+
+	// ─── Form structure ─────────────────────────────────────────────────────────
+
+	public function test_html_contains_form_with_action_url(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		$this->assertStringContainsString( '<form method="post"', $html );
+		$this->assertStringContainsString( 'action="https://example.com/oauth/authorize"', $html );
+	}
+
+	public function test_html_round_trips_oauth_flow_parameters_as_hidden_inputs(): void {
+		$html = $this->collapse_ws( ConsentScreenRenderer::build_html( $this->params() ) );
+
+		$this->assertStringContainsString( 'name="client_id" value="client-uuid"', $html );
+		$this->assertStringContainsString( 'name="redirect_uri" value="http://127.0.0.1:8765/cb"', $html );
+		$this->assertStringContainsString( 'name="state" value="rnd-state-xyz"', $html );
+		$this->assertStringContainsString( 'name="code_challenge" value="CHALLENGE-XXXXXXXXXXXXXXXXXXXXXXXXXX"', $html );
+		$this->assertStringContainsString( 'name="code_challenge_method" value="S256"', $html );
+		$this->assertStringContainsString( 'name="response_type" value="code"', $html );
+	}
+
+	public function test_html_contains_server_issued_scope_nonce(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::NONCE_FIELD . '"', $html );
+		$this->assertMatchesRegularExpression(
+			'/name="' . ConsentScreenRenderer::NONCE_FIELD . '" value="[a-f0-9]{32}"/',
+			$html,
+			'Nonce hidden input must contain a 32-hex-char server-issued nonce.'
+		);
+	}
+
+	// ─── Scope rendering (Appendix H.3.4) ───────────────────────────────────────
+
+	public function test_every_requested_scope_renders_as_toggleable_checkbox(): void {
+		$html = $this->collapse_ws( ConsentScreenRenderer::build_html( $this->params() ) );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::SCOPE_FIELD . '[]" value="abilities:content:read" checked', $html );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::SCOPE_FIELD . '[]" value="abilities:settings:read" checked', $html );
+
+		// H.3.4 explicitly requires NO locked rows — `disabled` must not appear on scope inputs.
+		$this->assertStringNotContainsString( 'disabled', $html, 'No scope checkbox may be disabled (H.3.4).' );
+	}
+
+	public function test_previously_granted_scope_shows_granted_date_badge(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		// timestamp 1_700_000_000 = 2023-11-14 in UTC — that's the badge text.
+		$this->assertStringContainsString( 'Granted 2023-11-14', $html );
+	}
+
+	public function test_sensitive_scope_shows_sensitive_badge_and_lock_icon(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		$this->assertStringContainsString( 'wp-mcp-consent-badge--sensitive', $html );
+		$this->assertStringContainsString( 'wp-mcp-consent-lock', $html );
+		$this->assertStringContainsString( 'wp-mcp-consent-group--sensitive', $html );
+	}
+
+	// ─── Role switcher (Appendix H.4.5) ─────────────────────────────────────────
+
+	public function test_role_select_lists_only_provided_roles(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		$this->assertStringContainsString( '<option value="editor">editor</option>', $html );
+		$this->assertStringContainsString( '<option value="author">author</option>', $html );
+		$this->assertStringNotContainsString( 'administrator', $html, 'Role switcher must not list roles outside the provided allowlist.' );
+	}
+
+	public function test_role_with_one_option_renders_as_hidden_input_not_select(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params( array( 'available_roles' => array( 'subscriber' ) ) ) );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::ROLE_FIELD . '" value="subscriber"', $html );
+		$this->assertStringNotContainsString( '<select', $html, 'Single-role users get a hidden input, not a select.' );
+	}
+
+	// ─── No JavaScript on the consent screen (Appendix H.4.5) ───────────────────
+
+	public function test_no_script_tags_in_consent_screen(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params() );
+		$this->assertStringNotContainsString( '<script', $html );
+		$this->assertStringNotContainsString( 'onload=', $html );
+		$this->assertStringNotContainsString( 'onclick=', $html );
+	}
+
+	// ─── XSS escaping ───────────────────────────────────────────────────────────
+
+	public function test_dangerous_chars_in_client_name_are_escaped(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params( array(
+			'client_name' => '<script>alert(1)</script>',
+		) ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function test_dangerous_chars_in_state_are_escaped_in_hidden_input(): void {
+		$html = ConsentScreenRenderer::build_html( $this->params( array(
+			'state' => 'state"><script>alert(1)</script>',
+		) ) );
+		$this->assertStringNotContainsString( '"><script>alert(1)', $html );
+	}
+
+	// ─── Action buttons ─────────────────────────────────────────────────────────
+
+	public function test_html_renders_authorize_and_deny_buttons(): void {
+		$html = $this->collapse_ws( ConsentScreenRenderer::build_html( $this->params() ) );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::DECISION_FIELD . '" value="' . ConsentScreenRenderer::DECISION_AUTHORIZE . '"', $html );
+		$this->assertStringContainsString( 'name="' . ConsentScreenRenderer::DECISION_FIELD . '" value="' . ConsentScreenRenderer::DECISION_DENY . '"', $html );
+	}
+
+	/** Collapse whitespace runs to a single space — lets attribute-order assertions ignore tab/newline alignment. */
+	private function collapse_ws( string $html ): string {
+		return (string) preg_replace( '/\s+/', ' ', $html );
+	}
+
+	// ─── Notice copy reflects the consent reason ────────────────────────────────
+
+	public function test_silent_cap_decision_shows_reauth_notice(): void {
+		$decision = new ConsentDecision(
+			ConsentDecision::RENDER_FULL,
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read' ),
+			array(),
+			array(),
+			'silent_cap_exceeded'
+		);
+		$html = ConsentScreenRenderer::build_html( $this->params( array( 'decision' => $decision ) ) );
+		$this->assertStringContainsString( 'wp-mcp-consent-notice--reauth', $html );
+		$this->assertStringContainsString( 'have not reviewed this bridge', $html );
+	}
+
+	public function test_incremental_decision_shows_incremental_notice(): void {
+		$decision = new ConsentDecision(
+			ConsentDecision::RENDER_INCREMENTAL,
+			array( 'abilities:content:read', 'abilities:taxonomies:read' ),
+			array( 'abilities:content:read' ),
+			array( 'abilities:taxonomies:read' ),
+			array(),
+			'new_non_sensitive_scopes'
+		);
+		$html = ConsentScreenRenderer::build_html( $this->params( array( 'decision' => $decision ) ) );
+		$this->assertStringContainsString( 'wp-mcp-consent-notice--incremental', $html );
+		$this->assertStringContainsString( 'additional permissions', $html );
+	}
+
+	// ─── Error renderer ─────────────────────────────────────────────────────────
+
+	public function test_build_error_html_contains_title_and_detail(): void {
+		$html = ConsentScreenRenderer::build_error_html( 'Authorization request invalid', 'redirect_uri is not registered for this client.' );
+		$this->assertStringContainsString( 'Authorization request invalid', $html );
+		$this->assertStringContainsString( 'redirect_uri is not registered', $html );
+		$this->assertStringContainsString( 'wp-mcp-consent-shell--error', $html );
+	}
+
+	public function test_build_error_html_escapes_user_supplied_strings(): void {
+		$html = ConsentScreenRenderer::build_error_html( 'Bad input', '<script>alert(1)</script>' );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for LastConsentLookup — record + read of the H.2.4 silent-cap timestamp.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\LastConsentLookup;
+
+final class LastConsentLookupTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options'] = array();
+	}
+
+	public function test_returns_null_when_no_consent_recorded(): void {
+		$this->assertNull( LastConsentLookup::timestamp_for( 'client-x', 1 ) );
+		$this->assertNull( LastConsentLookup::days_since( 'client-x', 1, time() ) );
+	}
+
+	public function test_record_then_read_returns_same_timestamp(): void {
+		LastConsentLookup::record( 'client-x', 1, 1_700_000_000 );
+		$this->assertSame( 1_700_000_000, LastConsentLookup::timestamp_for( 'client-x', 1 ) );
+	}
+
+	public function test_record_is_per_pair(): void {
+		LastConsentLookup::record( 'client-a', 1, 1_700_000_000 );
+		LastConsentLookup::record( 'client-b', 1, 1_700_001_000 );
+		LastConsentLookup::record( 'client-a', 2, 1_700_002_000 );
+
+		$this->assertSame( 1_700_000_000, LastConsentLookup::timestamp_for( 'client-a', 1 ) );
+		$this->assertSame( 1_700_001_000, LastConsentLookup::timestamp_for( 'client-b', 1 ) );
+		$this->assertSame( 1_700_002_000, LastConsentLookup::timestamp_for( 'client-a', 2 ) );
+	}
+
+	public function test_days_since_returns_floor_of_elapsed_days(): void {
+		$now = 1_700_000_000;
+		LastConsentLookup::record( 'client-x', 1, $now - ( 5 * 86400 ) - 3600 ); // 5 days, 1 hour
+		$this->assertSame( 5, LastConsentLookup::days_since( 'client-x', 1, $now ) );
+	}
+
+	public function test_days_since_returns_zero_for_future_consent(): void {
+		// Defensive — clock skew shouldn't underflow.
+		$now = 1_700_000_000;
+		LastConsentLookup::record( 'client-x', 1, $now + 3600 );
+		$this->assertSame( 0, LastConsentLookup::days_since( 'client-x', 1, $now ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for PolicyStore — Appendix H.2.4 silent-cap resolution.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PolicyStore;
+
+final class PolicyStoreTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_options']  = array();
+		$GLOBALS['wp_test_filters']  = array();
+	}
+
+	public function test_default_when_no_option_or_filter(): void {
+		$this->assertSame( PolicyStore::DEFAULT_SILENT_DAYS, PolicyStore::consent_max_silent_days() );
+	}
+
+	public function test_option_overrides_default(): void {
+		update_option( PolicyStore::OPTION_SILENT_DAYS, 90 );
+		$this->assertSame( 90, PolicyStore::consent_max_silent_days() );
+	}
+
+	public function test_filter_overrides_option(): void {
+		update_option( PolicyStore::OPTION_SILENT_DAYS, 90 );
+		add_filter( PolicyStore::OPTION_SILENT_DAYS, fn( $val ) => 30 );
+		$this->assertSame( 30, PolicyStore::consent_max_silent_days() );
+	}
+
+	public function test_clamped_below_min(): void {
+		update_option( PolicyStore::OPTION_SILENT_DAYS, 0 );
+		$this->assertSame( PolicyStore::DEFAULT_SILENT_DAYS, PolicyStore::consent_max_silent_days(), '0 collapses to default before clamping.' );
+
+		add_filter( PolicyStore::OPTION_SILENT_DAYS, fn( $val ) => -5 );
+		$this->assertSame( PolicyStore::DEFAULT_SILENT_DAYS, PolicyStore::consent_max_silent_days(), 'negative filter result collapses to upstream value.' );
+	}
+
+	public function test_clamped_above_max(): void {
+		update_option( PolicyStore::OPTION_SILENT_DAYS, 9_999 );
+		$this->assertSame( PolicyStore::MAX_SILENT_DAYS, PolicyStore::consent_max_silent_days() );
+	}
+
+	public function test_clamp_helper_respects_floor_and_ceiling(): void {
+		$this->assertSame( PolicyStore::MIN_SILENT_DAYS, PolicyStore::clamp( -1 ) );
+		$this->assertSame( PolicyStore::MIN_SILENT_DAYS, PolicyStore::clamp( 0 ) );
+		$this->assertSame( PolicyStore::MAX_SILENT_DAYS, PolicyStore::clamp( 100_000 ) );
+		$this->assertSame( 100, PolicyStore::clamp( 100 ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for RenderedScopeNonce — Appendix H.4.5 server-bound consent nonce.
+ *
+ * Critical invariants:
+ *   - Server is the ONLY source of truth for "what scope set was rendered."
+ *   - Submitted scope set must be a subset of the rendered scope set.
+ *   - Nonce is single-use (atomic redeem on first call).
+ *   - Mismatched user_id, client_id, redirect_uri, or state → reject.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RenderedScopeNonce;
+
+final class RenderedScopeNonceTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_transients'] = array();
+	}
+
+	private const RENDERED  = array( 'abilities:content:read', 'abilities:content:write', 'abilities:taxonomies:read' );
+	private const USER_ID   = 99;
+	private const CLIENT    = 'client-abc';
+	private const REDIRECT  = 'http://127.0.0.1/cb';
+	private const STATE     = 'state-xyz';
+
+	public function test_issued_nonce_can_be_redeemed_with_matching_request(): void {
+		$nonce   = RenderedScopeNonce::issue( self::RENDERED, self::USER_ID, self::CLIENT, self::REDIRECT, self::STATE );
+		$payload = RenderedScopeNonce::redeem( $nonce );
+
+		$this->assertIsArray( $payload );
+		$this->assertSame( self::USER_ID, $payload['user_id'] );
+		$this->assertSame( self::CLIENT, $payload['client_id'] );
+		$this->assertSame( self::REDIRECT, $payload['redirect_uri'] );
+		$this->assertSame( hash( 'sha256', self::STATE ), $payload['state_hash'] );
+		$this->assertSame( self::RENDERED, $payload['rendered_scopes'] );
+	}
+
+	public function test_redeem_is_single_use(): void {
+		$nonce = RenderedScopeNonce::issue( self::RENDERED, self::USER_ID, self::CLIENT, self::REDIRECT, self::STATE );
+		$first  = RenderedScopeNonce::redeem( $nonce );
+		$second = RenderedScopeNonce::redeem( $nonce );
+
+		$this->assertIsArray( $first );
+		$this->assertNull( $second );
+	}
+
+	public function test_redeem_returns_null_for_unknown_nonce(): void {
+		$this->assertNull( RenderedScopeNonce::redeem( 'never-issued' ) );
+	}
+
+	public function test_redeem_returns_null_for_empty_nonce(): void {
+		$this->assertNull( RenderedScopeNonce::redeem( '' ) );
+	}
+
+	// ─── Subset validation (the H.4.5 core protection) ──────────────────────────
+
+	public function test_subset_is_valid_when_submitted_equals_rendered(): void {
+		$payload = $this->payload();
+		$this->assertTrue(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, self::USER_ID, self::CLIENT, self::REDIRECT, self::STATE, self::RENDERED )
+		);
+	}
+
+	public function test_subset_is_valid_when_submitted_is_proper_subset_of_rendered(): void {
+		$payload = $this->payload();
+		$this->assertTrue(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, self::USER_ID, self::CLIENT, self::REDIRECT, self::STATE, array( 'abilities:content:read' ) )
+		);
+	}
+
+	public function test_subset_is_invalid_when_submitted_contains_unrendered_scope(): void {
+		// This is the browser-extension threat: form mutated to add a scope the server never rendered.
+		$payload = $this->payload();
+		$this->assertFalse(
+			RenderedScopeNonce::submitted_subset_is_valid(
+				$payload,
+				self::USER_ID,
+				self::CLIENT,
+				self::REDIRECT,
+				self::STATE,
+				array( 'abilities:content:read', 'abilities:settings:write' )
+			)
+		);
+	}
+
+	public function test_subset_is_invalid_for_wrong_user(): void {
+		$payload = $this->payload();
+		$this->assertFalse(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, 1234, self::CLIENT, self::REDIRECT, self::STATE, self::RENDERED )
+		);
+	}
+
+	public function test_subset_is_invalid_for_wrong_client_id(): void {
+		$payload = $this->payload();
+		$this->assertFalse(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, self::USER_ID, 'other-client', self::REDIRECT, self::STATE, self::RENDERED )
+		);
+	}
+
+	public function test_subset_is_invalid_for_wrong_redirect_uri(): void {
+		$payload = $this->payload();
+		$this->assertFalse(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, self::USER_ID, self::CLIENT, 'http://attacker/cb', self::STATE, self::RENDERED )
+		);
+	}
+
+	public function test_subset_is_invalid_for_wrong_state(): void {
+		$payload = $this->payload();
+		$this->assertFalse(
+			RenderedScopeNonce::submitted_subset_is_valid( $payload, self::USER_ID, self::CLIENT, self::REDIRECT, 'tampered-state', self::RENDERED )
+		);
+	}
+
+	private function payload(): array {
+		$nonce = RenderedScopeNonce::issue( self::RENDERED, self::USER_ID, self::CLIENT, self::REDIRECT, self::STATE );
+		return RenderedScopeNonce::redeem( $nonce );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for RoleSelector — implements the Appendix H.4.5 server-side
+ * role-escalation guard.
+ *
+ * Even if the consent form is tampered to include a role the operator does
+ * not hold, the POST handler must reject it. RoleSelector is the central
+ * arbiter of "is this role even available to this user?".
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RoleSelector;
+
+final class RoleSelectorTest extends TestCase {
+
+	public function test_returns_roles_from_resolver(): void {
+		$roles = RoleSelector::roles_for_user_id( 42, fn() => array( 'editor', 'author' ) );
+		$this->assertSame( array( 'editor', 'author' ), $roles );
+	}
+
+	public function test_drops_non_string_role_values_from_resolver(): void {
+		$roles = RoleSelector::roles_for_user_id( 42, fn() => array( 'editor', 99, null, 'author' ) );
+		$this->assertSame( array( 'editor', 'author' ), $roles );
+	}
+
+	public function test_returns_empty_array_when_resolver_returns_non_array(): void {
+		$roles = RoleSelector::roles_for_user_id( 42, fn() => null );
+		$this->assertSame( array(), $roles );
+	}
+
+	public function test_user_holds_role_returns_true_for_role_in_user_set(): void {
+		$this->assertTrue( RoleSelector::user_holds_role( 42, 'editor', fn() => array( 'editor', 'author' ) ) );
+	}
+
+	public function test_user_holds_role_returns_false_for_role_not_in_user_set(): void {
+		// This is the H.4.5 escalation prevention contract.
+		$this->assertFalse( RoleSelector::user_holds_role( 42, 'administrator', fn() => array( 'editor' ) ) );
+	}
+
+	public function test_user_holds_role_returns_false_for_empty_submitted_role(): void {
+		$this->assertFalse( RoleSelector::user_holds_role( 42, '', fn() => array( 'editor' ) ) );
+	}
+
+	public function test_user_holds_role_falls_through_to_get_userdata_when_no_resolver(): void {
+		$GLOBALS['wp_test_users'] = array(
+			7 => array( 'user_login' => 'owen', 'roles' => array( 'shop_manager', 'subscriber' ) ),
+		);
+		$this->assertTrue(  RoleSelector::user_holds_role( 7, 'shop_manager' ) );
+		$this->assertFalse( RoleSelector::user_holds_role( 7, 'administrator' ) );
+	}
+
+	public function test_user_holds_role_returns_false_when_user_does_not_exist(): void {
+		$GLOBALS['wp_test_users'] = array();
+		$this->assertFalse( RoleSelector::user_holds_role( 999, 'editor' ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for ScopeGrouper — pure visual grouping.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ScopeGrouper;
+
+final class ScopeGrouperTest extends TestCase {
+
+	public function test_groups_scopes_by_module(): void {
+		$groups = ScopeGrouper::group( array(
+			'abilities:content:read',
+			'abilities:content:write',
+			'abilities:taxonomies:read',
+		) );
+		$this->assertSame( array( 'abilities:content:read', 'abilities:content:write' ), $groups['content'] );
+		$this->assertSame( array( 'abilities:taxonomies:read' ), $groups['taxonomies'] );
+	}
+
+	public function test_umbrella_scopes_group_under_umbrella_key(): void {
+		$groups = ScopeGrouper::group( array( 'abilities:read', 'abilities:write' ) );
+		$this->assertSame( array( 'abilities:read', 'abilities:write' ), $groups['umbrella'] );
+	}
+
+	public function test_umbrella_renders_first_then_modules_alphabetically(): void {
+		$groups = ScopeGrouper::group( array(
+			'abilities:taxonomies:read',
+			'abilities:read',
+			'abilities:content:read',
+		) );
+		$keys = array_keys( $groups );
+		$this->assertSame( 'umbrella', $keys[0] );
+		$this->assertSame( array( 'umbrella', 'content', 'taxonomies' ), $keys );
+	}
+
+	public function test_group_is_sensitive_returns_true_when_any_scope_is_sensitive(): void {
+		$this->assertTrue( ScopeGrouper::group_is_sensitive( array( 'abilities:settings:read' ) ) );
+		$this->assertTrue( ScopeGrouper::group_is_sensitive( array( 'abilities:content:read', 'abilities:settings:read' ) ) );
+	}
+
+	public function test_group_is_sensitive_returns_false_for_all_non_sensitive_scopes(): void {
+		$this->assertFalse( ScopeGrouper::group_is_sensitive( array( 'abilities:content:read', 'abilities:content:write' ) ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -626,6 +626,80 @@ if ( ! function_exists( 'checked' ) ) {
 	}
 }
 
+// ---- Phase 3 stubs ----
+
+// Minimal $wpdb stub for tests that touch DB-fronting classes (ClientRegistry::list_active(),
+// PriorGrantLookup, ConnectedBridgesTab::latest_token_for, etc.). Tests that need DB fixtures
+// can swap individual methods on $GLOBALS['wpdb'] before invoking the unit under test.
+if ( ! isset( $GLOBALS['wpdb'] ) ) {
+	$GLOBALS['wpdb'] = new class {
+		public string $prefix = 'wp_';
+
+		/** Stored last-prepared query, for tests that want to assert against it. */
+		public string $last_prepared = '';
+
+		/** Default empty results — tests can override per-instance. */
+		public function get_results( $query ) { return array(); }
+		public function get_row( $query )     { return null; }
+		public function get_var( $query )     { return null; }
+		public function prepare( $query, ...$args ) {
+			$this->last_prepared = (string) $query;
+			return $query;
+		}
+		public function insert( $table, $data, $format = null ) { return 1; }
+		public function update( $table, $data, $where, $format = null, $where_format = null ) { return 1; }
+		public function query( $sql ) { return true; }
+	};
+}
+
+
+if ( ! function_exists( '_n' ) ) {
+	function _n( $single, $plural, $number, $domain = 'default' ) {
+		return ( (int) $number === 1 ) ? $single : $plural;
+	}
+}
+
+if ( ! function_exists( 'wp_login_url' ) ) {
+	function wp_login_url( $redirect_to = '' ) {
+		$base = ( $GLOBALS['wp_test_home_url'] ?? 'https://example.com' ) . '/wp-login.php';
+		return '' === $redirect_to ? $base : $base . '?redirect_to=' . rawurlencode( $redirect_to );
+	}
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+	function wp_verify_nonce( $nonce, $action = -1 ) {
+		// In tests, the nonce stub from wp_nonce_field() always emits 'test-nonce'.
+		return 'test-nonce' === $nonce ? 1 : false;
+	}
+}
+
+if ( ! function_exists( 'wp_date' ) ) {
+	function wp_date( $format, $timestamp = null, $timezone = null ) {
+		return gmdate( $format, $timestamp ?? time() );
+	}
+}
+
+if ( ! function_exists( 'get_bloginfo' ) ) {
+	function get_bloginfo( $show = '' ) {
+		return $GLOBALS['wp_test_bloginfo'][ $show ] ?? 'Test Site';
+	}
+}
+
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( $user_id ) {
+		$user = $GLOBALS['wp_test_users'][ (int) $user_id ] ?? null;
+		if ( ! $user ) {
+			return false;
+		}
+		$obj = new stdClass();
+		$obj->ID            = (int) $user_id;
+		$obj->user_login    = (string) ( $user['user_login']   ?? 'user_' . $user_id );
+		$obj->display_name  = (string) ( $user['display_name'] ?? $obj->user_login );
+		$obj->roles         = (array)  ( $user['roles']        ?? array() );
+		return $obj;
+	}
+}
+
 // Autoload global OAuth helpers from AuthorizationServer.php so all tests can call them.
 // The file guards each function with if(!function_exists(...)) so it's safe to require here.
 require_once dirname( __DIR__ ) . '/src/Auth/OAuth/AuthorizationServer.php';


### PR DESCRIPTION
Closes #32. Adapter side complete after this merges.

## Summary

- **`/oauth/authorize`** lives now (GET + POST), pre-WP at `init` priority 0.
- **Consent screen** is server-rendered, pure HTML, no JS — Phase 2 design language carried over via a dedicated `assets/consent.css` (the public consent page does not load `admin.css`, which is admin-context only).
- **Connected Bridges tab content** ships: bridges table, recent OAuth audit slice, populated H.2.6 Authorization-header diagnostic, revoke action with full cascade.

## What's bound by which spec section

| Concern | Binding section | Implementation |
|---|---|---|
| Validate `client_id`/`redirect_uri` BEFORE the login redirect | **Appendix H.3.6** | `AuthorizeRequestValidator::validate()` returns `PRE_REDIRECT_ERROR` for missing/unknown `client_id` and unregistered `redirect_uri` — never redirects. |
| `state` required, ≤256 chars, round-tripped | **Appendix H.3.5** | `AuthorizeRequestValidator::MAX_STATE_LENGTH = 256`; missing/oversized state → 400. State echoed unchanged in success / error redirects. |
| Sensitive scopes always show consent | **Appendix H.3.4** | `ConsentDecisionEvaluator::evaluate()` step (3): any sensitive scope in the request set → `RENDER_FULL`, even when previously granted. |
| All scopes toggleable, "Granted YYYY-MM-DD" + lock badge | **Appendix H.3.4** | `ConsentScreenRenderer::render_scope_groups()` — every scope is a checkbox; previously-granted shows date badge; sensitive shows lock + sensitive badge. No `disabled` attribute anywhere. |
| `consent_max_silent_days` enforcement | **Appendix H.2.4** | `PolicyStore::consent_max_silent_days()` (default 365, option + filter override, clamped 1–730). `ConsentDecisionEvaluator` step (2) routes to full consent when exceeded. |
| Connected Bridges UI shows "Last interactive consent: N days ago" + warning at cap−30d | **Appendix H.2.4** | `BridgeRowProjector::SILENT_WARNING_DAYS_BEFORE_CAP = 30`; the table renders `_n( '%d day ago', '%d days ago', ... )` with a ⚠ icon when `days_since >= cap - 30`. |
| Server-side scope re-validation on POST | **Appendix H.4.5** | `RenderedScopeNonce::issue()` stores the rendered scope set in a 15-minute server-only transient bound to `(user_id, client_id, redirect_uri, sha256(state))`. POST handler redeems atomically and rejects any scope not in the rendered set. |
| Role switcher constrained server-side | **Appendix H.4.5** | `RoleSelector::user_holds_role()` is the single arbiter — the consent form's role select only shows what the user holds, AND the POST handler re-checks. |
| Authorization-header diagnostic data source | **Appendix H.2.6** | `AuthHeaderProbe` — rolling 100-request counter populated by `AuthorizationServer::authenticate_bearer()`. Hooks the existing `mcp_adapter_bridges_authorization_header_status` filter Phase 2 reserved. |
| Revocation is zero-propagation-delay | sub-issue acceptance | `ConnectedBridgesTab::handle_action()` calls Phase 1's `ClientRegistry::revoke()` (one DB transaction across `kl_oauth_clients`, `kl_oauth_tokens`, `kl_oauth_refresh_tokens`, `kl_oauth_codes`). `TokenStore::lookup_access_token()` already bypasses object cache, so revocation is visible on the next request. |

## Two interactive vs. silent boundary events (no new tags)

H.2.4 explicitly requires the silent-cap calculation to look up "the most recent **INTERACTIVE** consent (NOT auto-approve)." Rather than introduce a new boundary tag like `decision`, this PR uses **two distinct event names** so consumers can tell them apart from the event alone:

- `boundary.oauth_authorization_granted` — interactive consent (operator clicked Authorize)
- `boundary.oauth_authorization_auto_approved` — silent re-auth

Both ship with the same already-allowlisted tags (`client_id`, `user_id`).

Other new event names (no new tags):
- `boundary.oauth_authorization_denied` — operator clicked Deny
- `boundary.oauth_authorize_error` — pre-redirect / scope-subset / role-escalation rejection

**No new boundary tags.** Every tag used is already in `BoundaryEventEmitter::TAG_ALLOWLIST` (`client_id`, `user_id`, `ip`, `reason`, `error_code`).

## Files

```
src/Auth/OAuth/Consent/
  PolicyStore.php                 — consent_max_silent_days resolution (option + filter, clamped)
  LastConsentLookup.php           — per-(client,user) last-interactive timestamp (option-backed)
  PriorGrantLookup.php            — most-recent active token's scope set
  RenderedScopeNonce.php          — server-bound consent nonce (transient, single-use)
  RoleSelector.php                — role-membership arbiter (H.4.5 escalation guard)
  ScopeGrouper.php                — pure visual grouping for the consent screen
  ConsentDecision.php             — value object
  ConsentDecisionEvaluator.php    — auto-approve / sensitive / silent-cap / scope-diff routing
  ConsentScreenRenderer.php       — server-rendered HTML; build_html() exposed for tests
  AuthorizeRequestValidator.php   — H.3.5 + H.3.6 ordering as pure logic

src/Auth/OAuth/Endpoints/
  AuthorizeEndpoint.php           — GET/POST dispatcher; minted code path; redirect helpers

src/Admin/Bridges/
  BridgeRowProjector.php          — table-row projection (pure)
  BoundaryAuditBuffer.php         — bounded ring buffer of OAuth events
  AuthHeaderProbe.php             — rolling counter feeding the H.2.6 filter

assets/
  consent.css                     — public consent screen stylesheet (NEW)
  admin.css                       — extended with bridges table + audit slice classes (no new patterns)
```

Modified files: `src/Auth/OAuth/AuthorizationServer.php` (route + boot wiring + AuthHeaderProbe::record() in `authenticate_bearer`), `src/Admin/AdapterAdminPage.php` (revoke-action dispatch), `src/Admin/Tabs/ConnectedBridgesTab.php` (placeholder body replaced with table + audit + revoke handler; H.2.6 diagnostic seam unchanged).

## Test plan

- [x] `composer install && vendor/bin/phpunit tests/` → **645 / 645 pass** (548 baseline + 97 new).
- [x] No inline `style=""` anywhere in new files (only the docblock comments forbidding them).
- [x] `php -l` on all new files — clean.
- [x] CI green on PHP 8.2, 8.3.
- [ ] Live consent flow against the Phase 0 prototype on test1.wickedevolutions.com OR the Phase 4 bridge — **deferred to Phase 6** per sprint plan. The validator + evaluator + nonce contract is fully unit-tested; the live integration adds the headers + redirect side of the path that PHPUnit can't exercise (`exit;` after `header()`).
- [ ] External Claude reviewer instance pass (fresh session) — to be scheduled before merge.

## Notes / decisions surfaced

- **Test bootstrap stubs added** for `wp_login_url`, `get_userdata`, `wp_verify_nonce`, `wp_date`, `get_bloginfo`, `_n`, plus a minimal `$wpdb` stub. Existing tests continue to pass; new tests inject per-test `$wpdb` instances when they need DB rows.
- **Renderer split into `render()` (side effects + exit) and `build_html()` (pure)**. The pure form is what tests assert against; `render()` is a thin shell that adds headers and `exit`s. The `exit;` is a hard requirement for pre-WP routing — splitting was necessary because PHPUnit cannot capture `exit`.
- **`oauth_log_boundary` and `oauth_client_ip` are imported via `use function`** from `WickedEvolutions\McpAdapter\Auth\OAuth`. Phase 1's docblock claims these globals are in the global namespace, but they're actually defined inside a namespaced file — so namespaced callers need either `use function` or an FQN. This is a callsite fix, not a Phase 1 change.
- **PHPUnit 9.6.34 on PHP 8.5** — repo's CI runs on 8.2/8.3, but local validation on 8.5 confirms forward-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)