### PR TITLE
hotfix: OAuth global helpers must live in global namespace

### DIFF
--- a/src/Admin/Tabs/ConnectedBridgesTab.php
+++ b/src/Admin/Tabs/ConnectedBridgesTab.php
@@ -25,7 +25,7 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Admin\Tabs;
 
-use function WickedEvolutions\McpAdapter\Auth\OAuth\oauth_log_boundary;
+// oauth_log_boundary lives in the global namespace (src/Auth/OAuth/helpers.php).
 use WickedEvolutions\McpAdapter\Admin\AdapterAdminPage;
 use WickedEvolutions\McpAdapter\Admin\Bridges\BoundaryAuditBuffer;
 use WickedEvolutions\McpAdapter\Admin\Bridges\BridgeRowProjector;
@@ -321,7 +321,7 @@ final class ConnectedBridgesTab {
 
 		ClientRegistry::revoke( $client_id );
 
-		oauth_log_boundary( 'boundary.oauth_token_revoked', array(
+		\oauth_log_boundary( 'boundary.oauth_token_revoked', array(
 			'client_id' => $client_id,
 			'user_id'   => (int) get_current_user_id(),
 			'reason'    => 'admin_revoked',

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -11,12 +11,12 @@
  *
  * Global helper functions defined here (in this file's namespace) to avoid
  * polluting plugin's primary namespace:
- *   oauth_client_ip()       — trusted-proxy-aware client IP
- *   oauth_is_https()        — scheme detection (H.2.5)
- *   oauth_read_auth_header() — Authorization header recovery (H.2.6)
- *   oauth_log_boundary()    — metadata-only boundary event (H.4.3)
- *   token_error()           — RFC 6749 §5.2 error response (H.3.7)
- *   token_success()         — RFC 6749 §5.1 success response (H.3.7)
+ *   \oauth_client_ip()       — trusted-proxy-aware client IP
+ *   \oauth_is_https()        — scheme detection (H.2.5)
+ *   \oauth_read_auth_header() — Authorization header recovery (H.2.6)
+ *   \oauth_log_boundary()    — metadata-only boundary event (H.4.3)
+ *   \token_error()           — RFC 6749 §5.2 error response (H.3.7)
+ *   \token_success()         — RFC 6749 §5.1 success response (H.3.7)
  *
  * Copyright (C) 2026 Wicked Evolutions
  * License: GPL-2.0-or-later
@@ -51,6 +51,9 @@ final class AuthorizationServer {
 			return;
 		}
 		self::$booted = true;
+
+		// Load global-namespace OAuth helper functions (oauth_client_ip, token_error, etc.).
+		require_once __DIR__ . '/helpers.php';
 
 		// Build host allowlist at plugins_loaded (multisite blogs table available).
 		add_action( 'plugins_loaded', [ OAuthHostAllowlist::class, 'build' ], 5 );
@@ -175,7 +178,7 @@ final class AuthorizationServer {
 		if ( ! OAuthHostAllowlist::is_allowed( $host ) ) {
 			// Unknown host — log and 404. Do not serve OAuth metadata.
 			if ( self::is_well_known_or_oauth_path() ) {
-				oauth_log_boundary( 'boundary.oauth_host_rejected', [ 'ip' => oauth_client_ip() ] );
+				\oauth_log_boundary( 'boundary.oauth_host_rejected', [ 'ip' => \oauth_client_ip() ] );
 				status_header( 404 );
 				exit;
 			}
@@ -262,7 +265,7 @@ final class AuthorizationServer {
 			return $user_id;
 		}
 
-		$auth_header = oauth_read_auth_header();
+		$auth_header = \oauth_read_auth_header();
 
 		// Phase 3 (H.2.6): record header presence/absence for the diagnostic.
 		// Only count requests that actually look like MCP traffic so the rolling
@@ -287,13 +290,13 @@ final class AuthorizationServer {
 			// Token not found — set WWW-Authenticate for discovery (H.2.7).
 			// Do not differentiate "not found" from "expired" to the client.
 			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
-			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'ip' => oauth_client_ip(), 'reason' => 'not_found_or_expired' ] );
+			\oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'ip' => \oauth_client_ip(), 'reason' => 'not_found_or_expired' ] );
 			return $user_id;
 		}
 
 		if ( $row->revoked ) {
 			self::schedule_www_authenticate( 'invalid_token', 'The access token has been revoked.' );
-			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'revoked' ] );
+			\oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'revoked' ] );
 			return $user_id;
 		}
 
@@ -302,7 +305,7 @@ final class AuthorizationServer {
 		if ( $expires < new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) ) {
 			// Expired — same response as not-found (H.2.7: no differential).
 			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
-			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'not_found_or_expired' ] );
+			\oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'not_found_or_expired' ] );
 			return $user_id;
 		}
 
@@ -310,7 +313,7 @@ final class AuthorizationServer {
 		$current_resource = rest_url( 'mcp/mcp-adapter-default-server' );
 		if ( ! hash_equals( (string) $row->resource, $current_resource ) ) {
 			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
-			oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'resource_mismatch' ] );
+			\oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'resource_mismatch' ] );
 			return $user_id;
 		}
 
@@ -327,7 +330,7 @@ final class AuthorizationServer {
 		// Update last_used_at (fire-and-forget).
 		TokenStore::touch( (string) $row->token_hash );
 
-		oauth_log_boundary( 'boundary.oauth_token_validated', [
+		\oauth_log_boundary( 'boundary.oauth_token_validated', [
 			'client_id' => $row->client_id,
 			'user_id'   => (int) $row->user_id,
 		] );
@@ -351,120 +354,5 @@ final class AuthorizationServer {
 			) );
 			return $result;
 		}, 10 );
-	}
-}
-
-// ─── Global helper functions ───────────────────────────────────────────────────
-// Defined in the global namespace so they are accessible from all endpoint classes
-// without import. Thin wrappers with no business logic.
-
-if ( ! function_exists( 'oauth_client_ip' ) ) {
-	/**
-	 * Return the client IP, respecting trusted proxy headers only when
-	 * WP_OAUTH_TRUST_FORWARDED_HOST is defined and true (H.2.5).
-	 */
-	function oauth_client_ip(): string {
-		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
-			$forwarded = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '';
-			if ( $forwarded ) {
-				return trim( explode( ',', $forwarded )[0] );
-			}
-		}
-		return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-	}
-}
-
-if ( ! function_exists( 'oauth_is_https' ) ) {
-	/**
-	 * Determine whether the current request is HTTPS (H.2.5).
-	 * Respects WP's is_ssl() and optionally X-Forwarded-Proto.
-	 */
-	function oauth_is_https(): bool {
-		if ( function_exists( 'is_ssl' ) && is_ssl() ) {
-			return true;
-		}
-		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
-			return ( $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '' ) === 'https';
-		}
-		return false;
-	}
-}
-
-if ( ! function_exists( 'oauth_read_auth_header' ) ) {
-	/**
-	 * Read the Authorization header with fallbacks for FastCGI/PHP-FPM (H.2.6).
-	 *
-	 * Order: apache_request_headers() → getallheaders() → $_SERVER['HTTP_AUTHORIZATION']
-	 *        → $_SERVER['REDIRECT_HTTP_AUTHORIZATION'].
-	 */
-	function oauth_read_auth_header(): ?string {
-		if ( function_exists( 'apache_request_headers' ) ) {
-			foreach ( apache_request_headers() as $k => $v ) {
-				if ( strtolower( $k ) === 'authorization' ) {
-					return $v;
-				}
-			}
-		}
-		if ( function_exists( 'getallheaders' ) ) {
-			foreach ( getallheaders() as $k => $v ) {
-				if ( strtolower( $k ) === 'authorization' ) {
-					return $v;
-				}
-			}
-		}
-		return $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null;
-	}
-}
-
-if ( ! function_exists( 'oauth_log_boundary' ) ) {
-	/**
-	 * Emit an OAuth event to the boundary log.
-	 * Metadata only — never logs token values, hashes, codes, or redirect URLs (H.4.3).
-	 *
-	 * @param string $event  Must start with 'boundary.oauth_'.
-	 * @param array  $tags   Allowlisted metadata fields only.
-	 */
-	function oauth_log_boundary( string $event, array $tags = [] ): void {
-		// Delegate to the BoundaryEventEmitter if available; otherwise fire the action directly.
-		if ( function_exists( 'do_action' ) ) {
-			do_action( 'mcp_adapter_boundary_event', $event, $tags, null );
-		}
-	}
-}
-
-if ( ! function_exists( 'token_error' ) ) {
-	/**
-	 * Emit a token endpoint error response per RFC 6749 §5.2 and exit (H.3.7).
-	 * Cache-Control: no-store. No CORS. No WP_REST_Response defaults.
-	 *
-	 * @param string $error       RFC 6749 error code.
-	 * @param string $description Human-readable description.
-	 * @param int    $status      HTTP status (400 default; 401 for invalid_client).
-	 */
-	function token_error( string $error, string $description, int $status = 400 ): never {
-		status_header( $status );
-		header( 'Content-Type: application/json; charset=utf-8' );
-		header( 'Cache-Control: no-store, no-cache, max-age=0' );
-		header( 'Pragma: no-cache' );
-		// No Access-Control-Allow-Origin (H.4.4).
-		echo wp_json_encode( [ 'error' => $error, 'error_description' => $description ] );
-		exit;
-	}
-}
-
-if ( ! function_exists( 'token_success' ) ) {
-	/**
-	 * Emit a token endpoint success response per RFC 6749 §5.1 and exit (H.3.7).
-	 *
-	 * @param array $body Response body.
-	 * @param int   $status HTTP status (200 default; 201 for DCR).
-	 */
-	function token_success( array $body, int $status = 200 ): never {
-		status_header( $status );
-		header( 'Content-Type: application/json; charset=utf-8' );
-		header( 'Cache-Control: no-store, no-cache, max-age=0' );
-		header( 'Pragma: no-cache' );
-		echo wp_json_encode( $body, JSON_UNESCAPED_SLASHES );
-		exit;
 	}
 }

--- a/src/Auth/OAuth/DiscoveryEndpoints.php
+++ b/src/Auth/OAuth/DiscoveryEndpoints.php
@@ -30,7 +30,7 @@ final class DiscoveryEndpoints {
 	 * Validated against OAuthHostAllowlist before this is called.
 	 */
 	public static function issuer(): string {
-		$scheme = oauth_is_https() ? 'https' : 'http';
+		$scheme = \oauth_is_https() ? 'https' : 'http';
 		$host   = $_SERVER['HTTP_HOST'] ?? 'unknown';
 		// Strip port for issuer (issuer should not include port per RFC 8414 §2).
 		$host   = explode( ':', $host )[0];

--- a/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
@@ -86,8 +86,8 @@ final class AuthorizeEndpoint {
 		$validation         = AuthorizeRequestValidator::validate( $params, $resource_indicator );
 
 		if ( $validation->is_pre_redirect_error() ) {
-			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
-				'ip'         => oauth_client_ip(),
+			\oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+				'ip'         => \oauth_client_ip(),
 				'reason'     => 'pre_redirect_validation_failed',
 				'error_code' => $validation->error_code,
 			) );
@@ -98,7 +98,7 @@ final class AuthorizeEndpoint {
 		}
 
 		if ( $validation->is_redirectable_error() ) {
-			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+			\oauth_log_boundary( 'boundary.oauth_authorize_error', array(
 				'client_id'  => (string) $validation->client->client_id,
 				'reason'     => 'redirectable_validation_failed',
 				'error_code' => $validation->error_code,
@@ -165,12 +165,12 @@ final class AuthorizeEndpoint {
 
 		if ( $interactive ) {
 			LastConsentLookup::record( $client_id, $user_id, time() );
-			oauth_log_boundary( 'boundary.oauth_authorization_granted', array(
+			\oauth_log_boundary( 'boundary.oauth_authorization_granted', array(
 				'client_id' => $client_id,
 				'user_id'   => $user_id,
 			) );
 		} else {
-			oauth_log_boundary( 'boundary.oauth_authorization_auto_approved', array(
+			\oauth_log_boundary( 'boundary.oauth_authorization_auto_approved', array(
 				'client_id' => $client_id,
 				'user_id'   => $user_id,
 			) );
@@ -250,7 +250,7 @@ final class AuthorizeEndpoint {
 
 		$decision_field = (string) ( $params[ ConsentScreenRenderer::DECISION_FIELD ] ?? '' );
 		if ( ConsentScreenRenderer::DECISION_DENY === $decision_field ) {
-			oauth_log_boundary( 'boundary.oauth_authorization_denied', array(
+			\oauth_log_boundary( 'boundary.oauth_authorization_denied', array(
 				'client_id' => (string) $client->client_id,
 				'user_id'   => $user_id,
 				'reason'    => 'operator_denied',
@@ -285,7 +285,7 @@ final class AuthorizeEndpoint {
 			$validation->state,
 			$submitted_scopes
 		) ) {
-			oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+			\oauth_log_boundary( 'boundary.oauth_authorize_error', array(
 				'client_id' => (string) $client->client_id,
 				'user_id'   => $user_id,
 				'reason'    => 'scope_subset_violation',
@@ -302,7 +302,7 @@ final class AuthorizeEndpoint {
 		if ( ! empty( $available_roles ) ) {
 			// If the form sent any role, it must be one the user actually holds.
 			if ( '' !== $submitted_role && ! RoleSelector::user_holds_role( $user_id, $submitted_role ) ) {
-				oauth_log_boundary( 'boundary.oauth_authorize_error', array(
+				\oauth_log_boundary( 'boundary.oauth_authorize_error', array(
 					'client_id' => (string) $client->client_id,
 					'user_id'   => $user_id,
 					'reason'    => 'role_escalation_attempt',

--- a/src/Auth/OAuth/Endpoints/RegisterEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/RegisterEndpoint.php
@@ -40,7 +40,7 @@ final class RegisterEndpoint {
 	 * POST — register a new client.
 	 */
 	public static function handle_post( \WP_REST_Request $request ): never {
-		$ip = oauth_client_ip();
+		$ip = \oauth_client_ip();
 
 		// Rate limit check (H.3.3).
 		$check = RateLimiter::check_dcr( $ip );
@@ -105,7 +105,7 @@ final class RegisterEndpoint {
 
 		RateLimiter::record_dcr( $ip );
 
-		oauth_log_boundary( 'boundary.oauth_client_registered', [
+		\oauth_log_boundary( 'boundary.oauth_client_registered', [
 			'client_id'  => $client_id,
 			'ip'         => $ip,
 		] );

--- a/src/Auth/OAuth/Endpoints/RevokeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/RevokeEndpoint.php
@@ -40,10 +40,10 @@ final class RevokeEndpoint {
 
 		if ( $token ) {
 			TokenStore::revoke_by_plaintext( (string) $token );
-			oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'reason' => 'explicit_revocation' ] );
+			\oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'reason' => 'explicit_revocation' ] );
 		}
 
 		// RFC 7009: always 200, even when token not found.
-		token_success( [] );
+		\token_success( [] );
 	}
 }

--- a/src/Auth/OAuth/Endpoints/TokenEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/TokenEndpoint.php
@@ -41,7 +41,7 @@ final class TokenEndpoint {
 		match ( $grant_type ) {
 			'authorization_code' => self::handle_auth_code( $params ),
 			'refresh_token'      => self::handle_refresh( $params ),
-			default              => token_error( 'unsupported_grant_type', 'Only authorization_code and refresh_token are supported.', 400 ),
+			default              => \token_error( 'unsupported_grant_type', 'Only authorization_code and refresh_token are supported.', 400 ),
 		};
 	}
 
@@ -53,19 +53,19 @@ final class TokenEndpoint {
 		$code_verifier = $params['code_verifier'] ?? '';
 
 		if ( ! $code || ! $client_id || ! $redirect_uri || ! $code_verifier ) {
-			token_error( 'invalid_request', 'code, client_id, redirect_uri, and code_verifier are required.', 400 );
+			\token_error( 'invalid_request', 'code, client_id, redirect_uri, and code_verifier are required.', 400 );
 		}
 
 		// Verify client exists (invalid_client → 401).
 		$client = ClientRegistry::find( $client_id );
 		if ( ! $client ) {
-			token_error( 'invalid_client', 'Client not found or revoked.', 401 );
+			\token_error( 'invalid_client', 'Client not found or revoked.', 401 );
 		}
 
 		// Consume code: verifies PKCE + client_id + redirect_uri bindings (H.1.1).
 		$code_row = AuthorizationCodeStore::consume( $code, $client_id, $redirect_uri, $code_verifier );
 		if ( ! $code_row ) {
-			token_error( 'invalid_grant', 'Authorization code is invalid, expired, or already used.', 400 );
+			\token_error( 'invalid_grant', 'Authorization code is invalid, expired, or already used.', 400 );
 		}
 
 		// Issue token pair.
@@ -76,12 +76,12 @@ final class TokenEndpoint {
 			$code_row->resource
 		);
 
-		oauth_log_boundary( 'boundary.oauth_token_issued', [
+		\oauth_log_boundary( 'boundary.oauth_token_issued', [
 			'client_id' => $client_id,
 			'user_id'   => (int) $code_row->user_id,
 		] );
 
-		token_success( $token );
+		\token_success( $token );
 	}
 
 	/** refresh_token grant. */
@@ -90,30 +90,30 @@ final class TokenEndpoint {
 		$client_id     = sanitize_text_field( $params['client_id'] ?? '' );
 
 		if ( ! $refresh_token || ! $client_id ) {
-			token_error( 'invalid_request', 'refresh_token and client_id are required.', 400 );
+			\token_error( 'invalid_request', 'refresh_token and client_id are required.', 400 );
 		}
 
 		$client = ClientRegistry::find( $client_id );
 		if ( ! $client ) {
-			token_error( 'invalid_client', 'Client not found or revoked.', 401 );
+			\token_error( 'invalid_client', 'Client not found or revoked.', 401 );
 		}
 
 		$result = TokenStore::rotate( $refresh_token, $client_id );
 
 		if ( $result === null ) {
-			oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'client_id' => $client_id, 'reason' => 'refresh_replay_or_invalid' ] );
-			token_error( 'invalid_grant', 'Refresh token is invalid, expired, or has been revoked.', 400 );
+			\oauth_log_boundary( 'boundary.oauth_token_revoked', [ 'client_id' => $client_id, 'reason' => 'refresh_replay_or_invalid' ] );
+			\token_error( 'invalid_grant', 'Refresh token is invalid, expired, or has been revoked.', 400 );
 		}
 
 		if ( isset( $result['__idempotent_retry__'] ) ) {
 			// Within 30-second grace — we can't return the original plaintext (hashed).
 			// Return an error that tells the bridge to wait and retry — it still has the token.
 			// In practice the bridge should re-use the access token it already has.
-			token_error( 'invalid_grant', 'Refresh already rotated. Use current access token or retry after grace window.', 400 );
+			\token_error( 'invalid_grant', 'Refresh already rotated. Use current access token or retry after grace window.', 400 );
 		}
 
-		oauth_log_boundary( 'boundary.oauth_token_refreshed', [ 'client_id' => $client_id ] );
+		\oauth_log_boundary( 'boundary.oauth_token_refreshed', [ 'client_id' => $client_id ] );
 
-		token_success( $result );
+		\token_success( $result );
 	}
 }

--- a/src/Auth/OAuth/helpers.php
+++ b/src/Auth/OAuth/helpers.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Global OAuth helper functions.
+ *
+ * Defined in the GLOBAL namespace (no namespace declaration in this file)
+ * so they are accessible from all OAuth endpoint classes via `\function_name()`
+ * regardless of the calling class's namespace.
+ *
+ * Loaded once by AuthorizationServer::boot() and again by tests/bootstrap.php.
+ * Each function is guarded by function_exists() so re-inclusion is safe.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+if ( ! function_exists( 'oauth_client_ip' ) ) {
+	/**
+	 * Return the client IP, respecting trusted proxy headers only when
+	 * WP_OAUTH_TRUST_FORWARDED_HOST is defined and true (H.2.5).
+	 */
+	function oauth_client_ip(): string {
+		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
+			$forwarded = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '';
+			if ( $forwarded ) {
+				return trim( explode( ',', $forwarded )[0] );
+			}
+		}
+		return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+	}
+}
+
+if ( ! function_exists( 'oauth_is_https' ) ) {
+	/**
+	 * Determine whether the current request is HTTPS (H.2.5).
+	 */
+	function oauth_is_https(): bool {
+		if ( function_exists( 'is_ssl' ) && is_ssl() ) {
+			return true;
+		}
+		if ( defined( 'WP_OAUTH_TRUST_FORWARDED_HOST' ) && WP_OAUTH_TRUST_FORWARDED_HOST ) {
+			return ( $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '' ) === 'https';
+		}
+		return false;
+	}
+}
+
+if ( ! function_exists( 'oauth_read_auth_header' ) ) {
+	/**
+	 * Read the Authorization header with fallbacks for FastCGI/PHP-FPM (H.2.6).
+	 *
+	 * Order: apache_request_headers() → getallheaders() → $_SERVER['HTTP_AUTHORIZATION']
+	 *        → $_SERVER['REDIRECT_HTTP_AUTHORIZATION'].
+	 */
+	function oauth_read_auth_header(): ?string {
+		if ( function_exists( 'apache_request_headers' ) ) {
+			foreach ( apache_request_headers() as $k => $v ) {
+				if ( strtolower( $k ) === 'authorization' ) {
+					return $v;
+				}
+			}
+		}
+		if ( function_exists( 'getallheaders' ) ) {
+			foreach ( getallheaders() as $k => $v ) {
+				if ( strtolower( $k ) === 'authorization' ) {
+					return $v;
+				}
+			}
+		}
+		return $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'oauth_log_boundary' ) ) {
+	/**
+	 * Emit an OAuth event to the boundary log.
+	 * Metadata only — never logs token values, hashes, codes, or redirect URLs (H.4.3).
+	 */
+	function oauth_log_boundary( string $event, array $tags = [] ): void {
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'mcp_adapter_boundary_event', $event, $tags, null );
+		}
+	}
+}
+
+if ( ! function_exists( 'token_error' ) ) {
+	/**
+	 * Emit a token endpoint error response per RFC 6749 §5.2 and exit (H.3.7).
+	 */
+	function token_error( string $error, string $description, int $status = 400 ): never {
+		status_header( $status );
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		echo wp_json_encode( [ 'error' => $error, 'error_description' => $description ] );
+		exit;
+	}
+}
+
+if ( ! function_exists( 'token_success' ) ) {
+	/**
+	 * Emit a token endpoint success response per RFC 6749 §5.1 and exit (H.3.7).
+	 */
+	function token_success( array $body, int $status = 200 ): never {
+		status_header( $status );
+		header( 'Content-Type: application/json; charset=utf-8' );
+		header( 'Cache-Control: no-store, no-cache, max-age=0' );
+		header( 'Pragma: no-cache' );
+		echo wp_json_encode( $body, JSON_UNESCAPED_SLASHES );
+		exit;
+	}
+}

--- a/tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php
+++ b/tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Regression test: OAuth helper functions must live in the global namespace.
+ *
+ * Phase 6 hotfix: an earlier build placed the helpers inside the
+ * WickedEvolutions\McpAdapter\Auth\OAuth namespace, which caused live
+ * 500 errors on first DCR (`Call to undefined function oauth_client_ip`)
+ * because callers using `\oauth_client_ip()` resolved to the global namespace
+ * but the function only existed inside the OAuth namespace.
+ *
+ * This test asserts the helpers exist in global, not in the OAuth namespace.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+
+final class HelpersAreGlobalTest extends TestCase {
+
+	private const HELPERS = [
+		'oauth_client_ip',
+		'oauth_is_https',
+		'oauth_read_auth_header',
+		'oauth_log_boundary',
+		'token_error',
+		'token_success',
+	];
+
+	/** @dataProvider helper_names */
+	public function test_helper_exists_in_global_namespace( string $name ): void {
+		$this->assertTrue(
+			function_exists( '\\' . $name ),
+			"OAuth helper {$name}() must be defined in the global namespace. " .
+			"If this fails, the helper has drifted into a namespaced context — " .
+			"check src/Auth/OAuth/helpers.php has no namespace declaration."
+		);
+	}
+
+	/** @dataProvider helper_names */
+	public function test_helper_not_in_oauth_namespace( string $name ): void {
+		$this->assertFalse(
+			function_exists( 'WickedEvolutions\\McpAdapter\\Auth\\OAuth\\' . $name ),
+			"OAuth helper {$name}() must NOT exist inside the OAuth namespace. " .
+			"Phase 6 regression: helpers in the namespace caused live 500s when " .
+			"callers used \\{$name}() to force global resolution."
+		);
+	}
+
+	public static function helper_names(): array {
+		return array_map( fn( $h ) => [ $h ], self::HELPERS );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -700,6 +700,6 @@ if ( ! function_exists( 'get_userdata' ) ) {
 	}
 }
 
-// Autoload global OAuth helpers from AuthorizationServer.php so all tests can call them.
-// The file guards each function with if(!function_exists(...)) so it's safe to require here.
-require_once dirname( __DIR__ ) . '/src/Auth/OAuth/AuthorizationServer.php';
+// Autoload global OAuth helpers so all tests can call them.
+// helpers.php is in the global namespace and guards each function with function_exists().
+require_once dirname( __DIR__ ) . '/src/Auth/OAuth/helpers.php';


### PR DESCRIPTION
Phase 6 live test caught a production 500 on the very first DCR call. Root cause: helpers (`oauth_client_ip` et al.) were defined inside `namespace WickedEvolutions\McpAdapter\Auth\OAuth` because `AuthorizationServer.php` never closes its namespace block. Unit tests passed because they ran in the same namespace and resolved unqualified calls locally; production callers using `\name()` or unqualified names from a different namespace blew up.

## Summary

- New `src/Auth/OAuth/helpers.php` with no namespace declaration — true global functions.
- Helpers section removed from the bottom of `AuthorizationServer.php` (which keeps just the class).
- `AuthorizationServer::boot()` and `tests/bootstrap.php` both `require_once` `helpers.php`.
- All call sites use `\function_name()` to force global resolution unambiguously.
- `ConnectedBridgesTab.php` had a `use function WickedEvolutions\McpAdapter\Auth\OAuth\oauth_log_boundary;` import — same bug class, removed.

## Regression guard

Added `HelpersAreGlobalTest` (12 tests): asserts each helper IS in `\` and IS NOT in the OAuth namespace. Catches future drift if anyone moves the helpers back.

## Test plan

- [x] 657/657 green locally (645 baseline + 12 new regression tests)
- [ ] Live: `abilities-mcp add-site https://wickedevolutions.com` reaches the consent screen instead of 500