### PR TITLE
hotfix: wire OAuth scope enforcement into ability execution

### DIFF
--- a/src/Auth/OAuth/OAuthScopeEnforcer.php
+++ b/src/Auth/OAuth/OAuthScopeEnforcer.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * OAuth scope enforcement for ability execution (H.1.3).
+ *
+ * Issue #38: every DCR-issued bearer token had effective write access to any
+ * ability the underlying user could execute, regardless of the scopes it was
+ * granted. Phase 1 populated `OAuthRequestContext` from the bearer-auth filter
+ * but never wired a consumer that gates ability execution against the granted
+ * scope set. This class is that consumer.
+ *
+ * The gate runs at exactly one location — `ToolsHandler::handle_tool_call` —
+ * before `$ability->execute( $args )` fires. Non-OAuth requests pass through
+ * unchanged (WP capabilities govern; the gate becomes a no-op).
+ *
+ * Scope mapping rule per issue #38 / Appendix A:
+ *
+ *   required_scope = abilities:<category>:<permission>
+ *
+ * where `category` comes from `WP_Ability::get_category()` and `permission`
+ * comes from `PermissionManager::get_permission( $ability )`.
+ *
+ * Sensitive scopes (per `ScopeRegistry::SENSITIVE_SCOPES`) are NEVER implied
+ * by an umbrella grant — they require an explicit grant. Issued tokens have
+ * pre-expanded scope strings (umbrella + non-sensitive children, see
+ * `AuthorizeRequestValidator::validate`), so the granted set already contains
+ * the matching child scope when the umbrella alone was requested. The umbrella
+ * fallback below is defense-in-depth: it ensures the contract holds even for
+ * tokens issued by a future code path that stores umbrellas verbatim.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+use WickedEvolutions\McpAdapter\Admin\PermissionManager;
+
+/**
+ * Maps abilities to required scopes and gates execution against the granted set.
+ */
+final class OAuthScopeEnforcer {
+
+	/**
+	 * Compute the canonical scope string required to execute the given ability.
+	 *
+	 * Falls back to `mcp-adapter` when the ability has no category, matching the
+	 * ability namespace used by the adapter's own meta-abilities.
+	 */
+	public static function required_scope_for( \WP_Ability $ability ): string {
+		$permission = PermissionManager::get_permission( $ability );
+		$category   = self::category_segment( $ability );
+
+		return sprintf( 'abilities:%s:%s', $category, $permission );
+	}
+
+	/**
+	 * Gate the given ability against the current OAuth request context.
+	 *
+	 * - Non-OAuth requests: returns null (allow; WP caps govern).
+	 * - OAuth requests with the required scope OR a permitted umbrella: returns null.
+	 * - OAuth requests missing the scope: emits a `boundary.oauth_scope_denied`
+	 *   event and returns a structured error array naming the missing scope.
+	 *
+	 * @return array|null Null when allowed; otherwise an array with shape
+	 *                    `[ 'error_code' => string, 'message' => string,
+	 *                       'required_scope' => string ]`.
+	 */
+	public static function check( \WP_Ability $ability ): ?array {
+		if ( ! OAuthRequestContext::is_oauth_request() ) {
+			return null;
+		}
+
+		$required = self::required_scope_for( $ability );
+		$granted  = OAuthRequestContext::granted_scopes();
+
+		// Direct match — the required scope is explicitly in the granted set.
+		if ( in_array( $required, $granted, true ) ) {
+			return null;
+		}
+
+		// Sensitive scopes never implied by umbrella — only an explicit grant counts.
+		// Direct match above already handles the explicit case; if we got here, deny.
+		if ( ! ScopeRegistry::is_sensitive( $required ) ) {
+			$umbrella = self::umbrella_for( $required );
+			if ( null !== $umbrella && in_array( $umbrella, $granted, true ) ) {
+				return null;
+			}
+		}
+
+		// Deny. Log a structured boundary event (metadata only, allowlisted tags).
+		\oauth_log_boundary( 'boundary.oauth_scope_denied', array(
+			'client_id'  => (string) OAuthRequestContext::client_id(),
+			'reason'     => 'insufficient_scope',
+			'error_code' => $required,
+		) );
+
+		return array(
+			'error_code'     => 'insufficient_scope',
+			'message'        => sprintf( 'Required scope: %s', $required ),
+			'required_scope' => $required,
+		);
+	}
+
+	/**
+	 * Extract the category segment used in the canonical scope string.
+	 *
+	 * `WP_Ability::get_category()` may return either an enum-like string
+	 * (`content`, `users`, …) or be missing entirely on minimally-registered
+	 * abilities. Default to `mcp-adapter` for the latter — that namespace is
+	 * already in `ScopeRegistry::all_scopes()`.
+	 */
+	private static function category_segment( \WP_Ability $ability ): string {
+		$category = method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+		$category = trim( $category );
+
+		if ( '' === $category ) {
+			return 'mcp-adapter';
+		}
+
+		return $category;
+	}
+
+	/**
+	 * The umbrella scope that, when granted, implies the given non-sensitive scope.
+	 * Returns null when the scope shape doesn't match `abilities:<category>:<op>`
+	 * or when the operation has no umbrella (only read/write/delete have umbrellas).
+	 */
+	private static function umbrella_for( string $required ): ?string {
+		$parts = explode( ':', $required );
+		if ( count( $parts ) !== 3 || 'abilities' !== $parts[0] ) {
+			return null;
+		}
+		$op = $parts[2];
+		if ( ! in_array( $op, array( 'read', 'write', 'delete' ), true ) ) {
+			return null;
+		}
+
+		$umbrella = 'abilities:' . $op;
+		if ( ! isset( ScopeRegistry::UMBRELLA_IMPLICATIONS[ $umbrella ] ) ) {
+			return null;
+		}
+		// Only count as a valid umbrella if the scope is in the umbrella's implication set.
+		// This guards against future scopes that exist but aren't covered by an umbrella.
+		if ( ! in_array( $required, ScopeRegistry::UMBRELLA_IMPLICATIONS[ $umbrella ], true ) ) {
+			return null;
+		}
+
+		return $umbrella;
+	}
+}

--- a/src/Handlers/Tools/ToolsHandler.php
+++ b/src/Handlers/Tools/ToolsHandler.php
@@ -14,6 +14,7 @@ declare( strict_types=1 );
 namespace WickedEvolutions\McpAdapter\Handlers\Tools;
 
 use WickedEvolutions\McpAdapter\Admin\PermissionManager;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
 use WickedEvolutions\McpAdapter\Core\McpServer;
 use WickedEvolutions\McpAdapter\Domain\Tools\McpTool;
 use WickedEvolutions\McpAdapter\Handlers\HandlerHelperTrait;
@@ -415,6 +416,32 @@ class ToolsHandler {
 					'ability_name'   => $ability->get_name(),
 					'failure_reason' => 'permission_check_failed',
 					'error_type'     => get_class( $e ),
+					'input_schema'   => $ability->get_input_schema(),
+				),
+			);
+		}
+
+		// OAuth scope gate (H.1.3 / issue #38). Sole call site for scope enforcement.
+		// Returns null on non-OAuth requests (WP caps govern) or when the granted
+		// scope set covers the ability; otherwise returns a structured deny payload
+		// and the boundary event has already been emitted.
+		$scope_denial = OAuthScopeEnforcer::check( $ability );
+		if ( null !== $scope_denial ) {
+			return array(
+				'error'     => array(
+					'code'    => McpErrorFactory::PERMISSION_DENIED,
+					'message' => $scope_denial['message'],
+					'data'    => array(
+						'error'          => $scope_denial['error_code'],
+						'required_scope' => $scope_denial['required_scope'],
+					),
+				),
+				'_metadata' => array(
+					'component_type' => 'tool',
+					'tool_name'      => $tool_name,
+					'ability_name'   => $ability->get_name(),
+					'failure_reason' => 'insufficient_scope',
+					'error_code'     => $scope_denial['required_scope'],
 					'input_schema'   => $ability->get_input_schema(),
 				),
 			);

--- a/tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for OAuthScopeEnforcer (issue #38 / H.1.3).
+ *
+ * Covers the four acceptance cases from issue #38 plus the required_scope_for()
+ * mapping table.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+use WP_Ability;
+
+final class OAuthScopeEnforcerTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+	}
+
+	private function ability( string $name, string $category = '', array $annotations = array() ): WP_Ability {
+		return new WP_Ability(
+			$name,
+			array(
+				'category' => $category,
+				'meta'     => array( 'annotations' => $annotations ),
+			)
+		);
+	}
+
+	private function set_oauth_request( array $scopes ): void {
+		OAuthRequestContext::set(
+			user_id: 7,
+			scopes: $scopes,
+			resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			client_id: 'cl_test',
+			token_id: 1
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// Acceptance case 1 — abilities:read + module reads.
+	// ---------------------------------------------------------------------
+
+	public function test_abilities_read_allows_content_list(): void {
+		// Issued tokens contain the umbrella plus its expanded children, so the
+		// realistic granted set for `--scope abilities:read` includes both.
+		$this->set_oauth_request( ScopeRegistry::expand( array( 'abilities:read' ) ) );
+
+		$content_list = $this->ability( 'content/list', 'content', array( 'readonly' => true ) );
+
+		$this->assertNull( OAuthScopeEnforcer::check( $content_list ) );
+	}
+
+	public function test_abilities_read_denies_content_create(): void {
+		$this->set_oauth_request( ScopeRegistry::expand( array( 'abilities:read' ) ) );
+
+		$content_create = $this->ability( 'content/create', 'content', array( 'permission' => 'write' ) );
+
+		$denial = OAuthScopeEnforcer::check( $content_create );
+
+		$this->assertIsArray( $denial );
+		$this->assertSame( 'insufficient_scope', $denial['error_code'] );
+		$this->assertSame( 'abilities:content:write', $denial['required_scope'] );
+		$this->assertStringContainsString( 'abilities:content:write', $denial['message'] );
+	}
+
+	// ---------------------------------------------------------------------
+	// Acceptance case 2 — abilities:write umbrella (non-sensitive vs sensitive).
+	// ---------------------------------------------------------------------
+
+	public function test_abilities_write_umbrella_allows_non_sensitive_write(): void {
+		// Pre-expanded write umbrella — content:write IS in the implications list.
+		$this->set_oauth_request( ScopeRegistry::expand( array( 'abilities:write' ) ) );
+
+		$content_create = $this->ability( 'content/create', 'content', array( 'permission' => 'write' ) );
+
+		$this->assertNull( OAuthScopeEnforcer::check( $content_create ) );
+	}
+
+	public function test_abilities_write_umbrella_denies_sensitive_users_create(): void {
+		// Pre-expanded write umbrella — users:write is NOT in the implications list,
+		// so the granted set won't contain it. Sensitive scopes are never implied.
+		$this->set_oauth_request( ScopeRegistry::expand( array( 'abilities:write' ) ) );
+
+		$users_create = $this->ability( 'users/create', 'users', array( 'permission' => 'write' ) );
+
+		$denial = OAuthScopeEnforcer::check( $users_create );
+
+		$this->assertIsArray( $denial );
+		$this->assertSame( 'abilities:users:write', $denial['required_scope'] );
+	}
+
+	public function test_umbrella_only_token_still_denies_sensitive_scope(): void {
+		// Defense-in-depth: even if a token somehow has only the umbrella string
+		// (e.g. issued by a future code path that skipped expansion), sensitive
+		// scopes must NOT be implied.
+		$this->set_oauth_request( array( 'abilities:write' ) );
+
+		$users_create = $this->ability( 'users/create', 'users', array( 'permission' => 'write' ) );
+
+		$denial = OAuthScopeEnforcer::check( $users_create );
+
+		$this->assertIsArray( $denial );
+		$this->assertSame( 'abilities:users:write', $denial['required_scope'] );
+	}
+
+	public function test_umbrella_only_token_allows_non_sensitive_via_umbrella_fallback(): void {
+		// Same defense-in-depth: umbrella-only token still allows non-sensitive
+		// children when the umbrella covers them.
+		$this->set_oauth_request( array( 'abilities:write' ) );
+
+		$content_create = $this->ability( 'content/create', 'content', array( 'permission' => 'write' ) );
+
+		$this->assertNull( OAuthScopeEnforcer::check( $content_create ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// Acceptance case 3 — explicit sensitive scope.
+	// ---------------------------------------------------------------------
+
+	public function test_explicit_sensitive_scope_allows_users_create(): void {
+		$this->set_oauth_request( array( 'abilities:users:write' ) );
+
+		$users_create = $this->ability( 'users/create', 'users', array( 'permission' => 'write' ) );
+
+		$this->assertNull( OAuthScopeEnforcer::check( $users_create ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// Acceptance case 4 — non-OAuth request is a no-op.
+	// ---------------------------------------------------------------------
+
+	public function test_non_oauth_request_is_noop(): void {
+		// No OAuthRequestContext::set() call — gate must allow.
+		$users_create = $this->ability( 'users/create', 'users', array( 'permission' => 'write' ) );
+
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+		$this->assertNull( OAuthScopeEnforcer::check( $users_create ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// required_scope_for() mapping table.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @dataProvider mapping_cases
+	 */
+	public function test_required_scope_for_maps_category_and_permission(
+		string $category,
+		array $annotations,
+		string $expected
+	): void {
+		$ability = $this->ability( 'whatever', $category, $annotations );
+		$this->assertSame( $expected, OAuthScopeEnforcer::required_scope_for( $ability ) );
+	}
+
+	public static function mapping_cases(): array {
+		return array(
+			'content read (explicit)'   => array( 'content', array( 'permission' => 'read' ),    'abilities:content:read' ),
+			'content write (explicit)'  => array( 'content', array( 'permission' => 'write' ),   'abilities:content:write' ),
+			'content delete (explicit)' => array( 'content', array( 'permission' => 'delete' ),  'abilities:content:delete' ),
+			'users write (explicit)'    => array( 'users',   array( 'permission' => 'write' ),   'abilities:users:write' ),
+			'plugins delete (explicit)' => array( 'plugins', array( 'permission' => 'delete' ),  'abilities:plugins:delete' ),
+			'readonly annotation'       => array( 'media',   array( 'readonly' => true ),        'abilities:media:read' ),
+			'destructive annotation'    => array( 'menus',   array( 'destructive' => true ),     'abilities:menus:delete' ),
+			'no annotations defaults read' => array( 'taxonomies', array(),                      'abilities:taxonomies:read' ),
+			'empty category falls back to mcp-adapter' => array( '', array( 'permission' => 'read' ), 'abilities:mcp-adapter:read' ),
+		);
+	}
+}


### PR DESCRIPTION
Closes #38.

## Summary

Phase 1 populated `OAuthRequestContext` from the bearer-auth filter but never wired a consumer that gates ability execution against the granted scope set. Live-test repro on Phase 6 caught a token issued for `abilities:read` successfully executing `content-create` (HTTP 200, real post written). This PR plugs that gap at the dispatch layer.

## Architecture decision — Option A (MCP dispatch layer)

Issue #38 lays out two options. Default recommendation was Option B (gate in the Abilities API via a `wp_ability_pre_execute`-style filter). Investigation:

- The `wordpress/abilities-api` package is **not vendored** into this plugin — `composer show` and `find vendor/` confirm. The abilities API is a runtime dependency loaded by WP core / a sibling plugin.
- The package's tests use a stub `WP_Ability` that has no `execute()` method at all (see `tests/bootstrap.php` — only getters are stubbed). Even if a `wp_ability_pre_execute` filter exists upstream, the adapter's call sites still enter through `$ability->execute( $args )`, and a hook inside that method is opaque from this codebase.
- Without the abilities-api source available, it is not possible to verify a hook contract that would survive future upstream changes.

**Decision:** Option A. Gate in the adapter's MCP dispatch layer, where the granted scope set + the dispatched ability are both unambiguously in scope.

## Implementation

- **New class:** `WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer` with:
  - `required_scope_for( WP_Ability $ability ): string` — canonical mapping per issue #38: `abilities:{category}:{permission}` (category from `WP_Ability::get_category()`, permission from `PermissionManager::get_permission()`). Falls back to `abilities:mcp-adapter:*` when the ability has no category.
  - `check( WP_Ability $ability ): ?array` — the gate. Returns `null` (allow) for non-OAuth requests, direct-match scopes, and umbrella-implied non-sensitive scopes. Returns a structured deny payload otherwise and emits `boundary.oauth_scope_denied` with `client_id`, `reason: 'insufficient_scope'`, `error_code: <missing_scope>`.
- **Single call site:** `ToolsHandler::handle_tool_call` — immediately before `$ability->execute( $args )`. On deny, returns the standard MCP error shape (`PERMISSION_DENIED` / -32008 → HTTP 403 via the existing `mcp_error_to_http_status` mapping) with `_metadata.failure_reason: 'insufficient_scope'` and `_metadata.error_code: <missing_scope>` to feed the boundary audit pipeline.
- **`error_code` already in `BoundaryEventEmitter::TAG_ALLOWLIST`** (line 55 prior to this PR). No allowlist change needed.
- **Sensitive scope handling:** `ScopeRegistry::SENSITIVE_SCOPES` are never implied by an umbrella. Direct-grant only. Verified by both the unit tests and by the umbrella-fallback shape (`umbrella_for()` returns null for any scope not in `UMBRELLA_IMPLICATIONS[$umbrella]`, and sensitive scopes are excluded from those lists by construction).
- **Pre-expansion of granted scopes:** `AuthorizeRequestValidator::validate` already calls `ScopeRegistry::expand()` before storing the scope string on the authorization code, so issued tokens have both the umbrella and its non-sensitive children. The umbrella-fallback path in the enforcer is defense-in-depth (covered by `test_umbrella_only_token_allows_non_sensitive_via_umbrella_fallback` / `test_umbrella_only_token_still_denies_sensitive_scope`).

## Tests

`tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php` — 17 tests covering all four acceptance cases from #38:

1. `abilities:read` token: `content-list` allowed, `content-create` denied with `abilities:content:write` named in the deny payload.
2. `abilities:write` umbrella: `content-create` (non-sensitive) allowed, `users-create` (sensitive) denied. Tested both for pre-expanded tokens and for umbrella-only tokens (defense-in-depth).
3. Explicit `abilities:users:write` allows `users-create`.
4. Non-OAuth requests are no-ops.
5. `required_scope_for()` mapping: 9 dataProvider cases covering explicit permission annotations, `readonly`/`destructive` derivation, no-annotation default, and the empty-category fallback.

Full suite: **674/674 passing, 1936 assertions** (657 baseline + 17 new). Zero regressions.

## Out of scope (separate issues filed)

While auditing the dispatch surface for the gate, two related-but-distinct bypass paths surfaced. Both filed as follow-ups per the orchestrator's instruction to not expand this PR's scope:

- **#39 — `ExecuteAbilityAbility` meta-tool bypass.** The meta-ability resolves an inner ability by name (`wp_get_ability( $ability_name )`) and executes it; the dispatch-layer gate only sees `execute-ability`, not the inner one. Same enforcer is reusable verbatim — needs one extra invocation at the inner-ability resolution point.
- **#40 — `prompts/get` bypass.** `PromptsHandler::handle_prompt_get` also calls `$ability->execute()` with no scope gate. Same pattern.

Neither is in this PR's scope per #38's "exactly ONE location" rule and the orchestrator's "second defect → separate issue" instruction. The enforcer is designed to be reusable across these call sites without code duplication when those follow-ups land.

## Out of scope (already noted in #38)

- `family_id` rotation defect — separate issue.
- Revocation cascade across rotation chain — separate issue.
- Phase 5 CLI keychain UX polish after revoke — separate issue.

## Verification

- [x] `composer install && vendor/bin/phpunit tests/` → 674/674 OK locally.
- [ ] CI matrix `[8.2, 8.3]` green (will populate after push).
- [x] All four acceptance criteria from #38 covered by unit tests.
- [x] Single scope-check call site (`ToolsHandler::handle_tool_call`).
- [x] Boundary event `boundary.oauth_scope_denied` fires with allowlisted tags only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)