### PR TITLE
hotfix: guard is_well_known_or_oauth_path against empty REQUEST_URI

### DIFF
--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -197,7 +197,15 @@ final class AuthorizationServer {
 	}
 
 	private static function is_well_known_or_oauth_path(): bool {
-		$path = strtok( $_SERVER['REQUEST_URI'] ?? '', '?' );
+		$uri = $_SERVER['REQUEST_URI'] ?? '';
+		if ( ! is_string( $uri ) || $uri === '' ) {
+			return false;
+		}
+		// strtok( '', '?' ) returns false on PHP 8.2+; guard with explicit string check above.
+		$path = strtok( $uri, '?' );
+		if ( ! is_string( $path ) ) {
+			return false;
+		}
 		return str_starts_with( $path, '/.well-known/' ) || str_starts_with( $path, '/oauth/' );
 	}
 

--- a/tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php
+++ b/tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Regression test: AuthorizationServer::is_well_known_or_oauth_path()
+ * must not fatal on missing or empty REQUEST_URI.
+ *
+ * Phase 6 deploy caught: strtok('', '?') returns false on PHP 8.2+,
+ * which then crashes str_starts_with(false, …). Fatal during early
+ * request lifecycle on sites where REQUEST_URI is unset or empty.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+
+final class IsWellKnownOrOAuthPathTest extends TestCase {
+
+	private function call(): bool {
+		// is_well_known_or_oauth_path is private — invoke via reflection.
+		// (setAccessible is unnecessary on PHP 8.1+ and deprecated on 8.5.)
+		$ref = new \ReflectionClass( AuthorizationServer::class );
+		$m   = $ref->getMethod( 'is_well_known_or_oauth_path' );
+		return $m->invoke( null );
+	}
+
+	protected function tearDown(): void {
+		unset( $_SERVER['REQUEST_URI'] );
+	}
+
+	public function test_unset_request_uri_returns_false(): void {
+		unset( $_SERVER['REQUEST_URI'] );
+		$this->assertFalse( $this->call() );
+	}
+
+	public function test_empty_string_request_uri_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '';
+		$this->assertFalse( $this->call() );
+	}
+
+	public function test_non_string_request_uri_returns_false(): void {
+		// Hostile / corrupted superglobal — still must not fatal.
+		$_SERVER['REQUEST_URI'] = false;
+		$this->assertFalse( $this->call() );
+	}
+
+	public function test_root_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/';
+		$this->assertFalse( $this->call() );
+	}
+
+	public function test_well_known_oauth_resource_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/.well-known/oauth-protected-resource';
+		$this->assertTrue( $this->call() );
+	}
+
+	public function test_oauth_authorize_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/oauth/authorize';
+		$this->assertTrue( $this->call() );
+	}
+
+	public function test_oauth_path_with_query_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/oauth/authorize?response_type=code&client_id=abc';
+		$this->assertTrue( $this->call() );
+	}
+
+	public function test_unrelated_path_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php';
+		$this->assertFalse( $this->call() );
+	}
+
+	public function test_path_starting_with_oauth_substring_but_not_oauth_prefix_returns_false(): void {
+		// /oauthish-something — must not match /oauth/ prefix.
+		$_SERVER['REQUEST_URI'] = '/oauthlike/foo';
+		$this->assertFalse( $this->call() );
+	}
+}


### PR DESCRIPTION
Phase 6 deploy to \`abilitiesforai.io\` fataled at request init:

\`\`\`
TypeError: str_starts_with(): Argument #1 (\$haystack) must be of type string, bool given
in AuthorizationServer.php:201
\`\`\`

## Root cause

\`strtok('', '?')\` returns \`false\` on PHP 8.2+, not the empty string. The result flowed straight into \`str_starts_with\`, which fatals on \`bool\`. On sites where \`REQUEST_URI\` is unset or empty, the OAuth route-interception predicate crashes the entire request lifecycle — meaning WP admin, REST, and frontend all 500.

## Fix

Validate that \`REQUEST_URI\` is a non-empty string before calling \`strtok\`, and validate the \`strtok\` result is a string before passing to \`str_starts_with\`. Both checks are defensive — the predicate's contract is "is this an OAuth-shaped path?", and the right answer for empty / unset / corrupted input is "no," not "fatal."

## Regression test

\`IsWellKnownOrOAuthPathTest\` — 9 cases:

- unset \`REQUEST_URI\`
- empty-string \`REQUEST_URI\`
- non-string (\`false\`) \`REQUEST_URI\` — hostile-superglobal hardening
- root path
- \`/.well-known/oauth-protected-resource\`
- \`/oauth/authorize\`
- \`/oauth/authorize?<query>\`
- unrelated path
- \`/oauthlike/*\` (must not match \`/oauth/\` prefix)

## Test plan

- [x] \`vendor/bin/phpunit tests/\` — 683 / 683 green locally (657 baseline + 17 scope enforcement + 9 new)
- [ ] CI matrix [8.2, 8.3] green
- [ ] Live: deploy to abilitiesforai.io, confirm WP admin loads + adapter is active without 500s

## Why this was missed

Unit tests for \`AuthorizationServer\` covered the happy path (REQUEST_URI populated with a real path). They did not cover empty / unset \`REQUEST_URI\`. The new \`IsWellKnownOrOAuthPathTest\` closes that gap.