### PR TITLE
fix(oauth): narrow bearer auth to MCP resource requests (C-1)

### DIFF
--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -11,12 +11,13 @@
  *
  * Global helper functions defined here (in this file's namespace) to avoid
  * polluting plugin's primary namespace:
- *   \oauth_client_ip()       — trusted-proxy-aware client IP
- *   \oauth_is_https()        — scheme detection (H.2.5)
- *   \oauth_read_auth_header() — Authorization header recovery (H.2.6)
- *   \oauth_log_boundary()    — metadata-only boundary event (H.4.3)
- *   \token_error()           — RFC 6749 §5.2 error response (H.3.7)
- *   \token_success()         — RFC 6749 §5.1 success response (H.3.7)
+ *   \oauth_client_ip()              — trusted-proxy-aware client IP
+ *   \oauth_is_https()               — scheme detection (H.2.5)
+ *   \oauth_read_auth_header()       — Authorization header recovery (H.2.6)
+ *   \oauth_log_boundary()           — metadata-only boundary event (H.4.3)
+ *   \oauth_is_mcp_resource_request() — bearer-auth gate (C-1, H.1.2)
+ *   \token_error()                  — RFC 6749 §5.2 error response (H.3.7)
+ *   \token_success()                — RFC 6749 §5.1 success response (H.3.7)
  *
  * Copyright (C) 2026 Wicked Evolutions
  * License: GPL-2.0-or-later
@@ -256,7 +257,13 @@ final class AuthorizationServer {
 	/**
 	 * Bearer token authentication hook (determine_current_user, priority 20).
 	 *
-	 * If no user is resolved yet and an OAuth Bearer token is present:
+	 * Bearer authentication is narrowed to requests targeting the MCP resource
+	 * endpoint (C-1, H.1.2). On every other URI this filter is a no-op; the
+	 * token never authenticates the user on /wp-json/wp/v2/* or any other REST
+	 * route — those are not the resource the token was issued for.
+	 *
+	 * If no user is resolved yet, the request targets the MCP resource, and
+	 * an OAuth Bearer token is present:
 	 * - Validates token (not expired, not revoked, resource matches)
 	 * - Sets OAuthRequestContext with user_id, scopes, resource, client_id, token_id
 	 * - Returns user_id to WordPress
@@ -281,6 +288,16 @@ final class AuthorizationServer {
 		$path = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
 		if ( str_contains( $path, '/wp-json/mcp/' ) || str_contains( $path, '/wp-json/abilities-mcp-adapter/' ) ) {
 			AuthHeaderProbe::record( null !== $auth_header && '' !== $auth_header );
+		}
+
+		// C-1 / H.1.2: Bearer auth is scoped to the MCP resource endpoint.
+		// `determine_current_user` fires on every REST request; without this gate
+		// a token issued for the MCP resource would authenticate the bound user
+		// on /wp-json/wp/v2/users, /wp-json/wp/v2/plugins, etc., where the H.1.3
+		// scope enforcer never fires — silently granting full WP capabilities.
+		// On any non-MCP-resource URI, bearer auth is a no-op.
+		if ( ! \oauth_is_mcp_resource_request() ) {
+			return $user_id;
 		}
 
 		if ( ! $auth_header || ! str_starts_with( $auth_header, 'Bearer ' ) ) {

--- a/src/Auth/OAuth/helpers.php
+++ b/src/Auth/OAuth/helpers.php
@@ -86,6 +86,55 @@ if ( ! function_exists( 'oauth_log_boundary' ) ) {
 	}
 }
 
+if ( ! function_exists( 'oauth_is_mcp_resource_request' ) ) {
+	/**
+	 * Whether the current REST request targets the MCP resource endpoint (C-1, H.1.2).
+	 *
+	 * Bearer auth must be a no-op for any other URI: tokens are bound to
+	 * /wp-json/mcp/mcp-adapter-default-server, but `determine_current_user`
+	 * fires on every REST request. Without this gate a token issued for the
+	 * MCP resource silently authenticates the bound user on /wp-json/wp/v2/*,
+	 * /wp-json/wp/v2/plugins, etc. — where the H.1.3 scope enforcer never
+	 * fires — effectively turning the Bearer into a session cookie.
+	 *
+	 * Matches both pretty-permalinks (/wp-json/<ns>/<route>) and plain-permalinks
+	 * (?rest_route=/<ns>/<route>).
+	 */
+	function oauth_is_mcp_resource_request(): bool {
+		$uri = $_SERVER['REQUEST_URI'] ?? '';
+		if ( ! is_string( $uri ) || $uri === '' ) {
+			return false;
+		}
+
+		$rest_route = '/mcp/mcp-adapter-default-server';
+
+		// Pretty permalinks. Derive the path from rest_url() so subdir / multisite
+		// installs (e.g. /wp/wp-json/...) are matched against their actual prefix.
+		if ( function_exists( 'rest_url' ) ) {
+			$resource_url  = (string) rest_url( 'mcp/mcp-adapter-default-server' );
+			$resource_path = (string) parse_url( $resource_url, PHP_URL_PATH );
+			if ( $resource_path !== '' && str_starts_with( $uri, $resource_path ) ) {
+				$tail = substr( $uri, strlen( $resource_path ) );
+				if ( $tail === '' || $tail[0] === '/' || $tail[0] === '?' ) {
+					return true;
+				}
+			}
+		}
+
+		// Plain permalinks: ?rest_route=/mcp/mcp-adapter-default-server.
+		$query = (string) parse_url( $uri, PHP_URL_QUERY );
+		if ( $query !== '' ) {
+			parse_str( $query, $params );
+			$route = (string) ( $params['rest_route'] ?? '' );
+			if ( $route === $rest_route || str_starts_with( $route, $rest_route . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
 if ( ! function_exists( 'token_error' ) ) {
 	/**
 	 * Emit a token endpoint error response per RFC 6749 §5.2 and exit (H.3.7).

--- a/tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php
+++ b/tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Regression test for C-1: AuthorizationServer::authenticate_bearer() must
+ * be a no-op on every URI that is not the MCP resource endpoint, even when
+ * a valid token is in the database.
+ *
+ * Before the fix: a token issued for the MCP resource passed the
+ * resource_match check (which only compared the token's resource against
+ * a constant) and authenticated the user on /wp-json/wp/v2/* and every
+ * other REST route, where the OAuth scope enforcer never fires.
+ *
+ * After the fix: bearer auth is gated on
+ * oauth_is_mcp_resource_request() — non-MCP REST routes return the input
+ * $user_id unchanged.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+if ( ! defined( 'REST_REQUEST' ) ) {
+	define( 'REST_REQUEST', true );
+}
+
+final class AuthenticateBearerNarrowsToMcpResourceTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->original_wpdb = $GLOBALS['wpdb'];
+		OAuthRequestContext::reset();
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb']                  = $this->original_wpdb;
+		unset( $_SERVER['REQUEST_URI'] );
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		OAuthRequestContext::reset();
+		parent::tearDown();
+	}
+
+	/** Build a $wpdb stub whose get_row() returns a not-expired, not-revoked token row. */
+	private function install_valid_token_row(): void {
+		$expires_at = ( new \DateTimeImmutable( '+1 hour', new \DateTimeZone( 'UTC' ) ) )
+			->format( 'Y-m-d H:i:s' );
+
+		$row              = new \stdClass();
+		$row->id          = 7;
+		$row->user_id     = 42;
+		$row->client_id   = 'client_abc';
+		$row->scope       = 'abilities:content:read';
+		$row->resource    = 'https://example.com/wp-json/mcp/mcp-adapter-default-server';
+		$row->token_hash  = 'h';
+		$row->expires_at  = $expires_at;
+		$row->revoked     = 0;
+
+		$GLOBALS['wpdb'] = new class( $row ) {
+			public string $prefix = 'wp_';
+			private \stdClass $row;
+			public function __construct( \stdClass $row ) { $this->row = $row; }
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_row( $q )     { return $this->row; }
+			public function get_results( $q ) { return [ $this->row ]; }
+			public function get_var( $q )     { return null; }
+			public function update( $t, $d, $w, $f = null, $wf = null ) { return 1; }
+			public function insert( $t, $d, $f = null )                  { return 1; }
+			public function query( $sql )                                 { return true; }
+		};
+	}
+
+	public function test_no_op_on_wp_v2_users_even_with_valid_token(): void {
+		$this->install_valid_token_row();
+		$_SERVER['REQUEST_URI']        = '/wp-json/wp/v2/users';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-plaintext-token';
+
+		$result = AuthorizationServer::authenticate_bearer( false );
+
+		$this->assertFalse( $result, '/wp-json/wp/v2/users must not authenticate via the MCP token' );
+		$this->assertFalse(
+			OAuthRequestContext::is_oauth_request(),
+			'OAuthRequestContext must not be populated on non-MCP routes'
+		);
+	}
+
+	public function test_no_op_on_wp_v2_plugins_even_with_valid_token(): void {
+		$this->install_valid_token_row();
+		$_SERVER['REQUEST_URI']        = '/wp-json/wp/v2/plugins';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-plaintext-token';
+
+		$this->assertFalse( AuthorizationServer::authenticate_bearer( false ) );
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+	}
+
+	public function test_no_op_on_oauth_token_endpoint_even_with_valid_token(): void {
+		// /wp-json/mcp/oauth/token is in the MCP namespace but is not the
+		// MCP resource — bearer auth must not fire (RFC 7009 client auth on
+		// the revoke endpoint is the concern of #46, not bearer auth here).
+		$this->install_valid_token_row();
+		$_SERVER['REQUEST_URI']        = '/wp-json/mcp/oauth/token';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-plaintext-token';
+
+		$this->assertFalse( AuthorizationServer::authenticate_bearer( false ) );
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+	}
+
+	public function test_authenticates_on_mcp_resource_with_valid_token(): void {
+		$this->install_valid_token_row();
+		$_SERVER['REQUEST_URI']        = '/wp-json/mcp/mcp-adapter-default-server';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-plaintext-token';
+
+		$result = AuthorizationServer::authenticate_bearer( false );
+
+		$this->assertSame( 42, $result, 'Valid token must authenticate on the MCP resource' );
+		$this->assertTrue(
+			OAuthRequestContext::is_oauth_request(),
+			'OAuthRequestContext must be populated on the MCP resource'
+		);
+		$this->assertSame( 42, OAuthRequestContext::user_id() );
+		$this->assertSame( [ 'abilities:content:read' ], OAuthRequestContext::granted_scopes() );
+	}
+
+	public function test_already_authenticated_user_passes_through_unchanged(): void {
+		$_SERVER['REQUEST_URI']        = '/wp-json/wp/v2/posts';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-plaintext-token';
+
+		// Higher-priority filter has already resolved a user (e.g., cookie auth).
+		$this->assertSame( 11, AuthorizationServer::authenticate_bearer( 11 ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the global oauth_is_mcp_resource_request() helper (C-1, H.1.2).
+ *
+ * The helper gates Bearer authentication: only requests that target the MCP
+ * resource endpoint (/wp-json/mcp/mcp-adapter-default-server) may
+ * be authenticated by an OAuth bearer token. Every other URI must return
+ * false so determine_current_user can no-op.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+
+final class OAuthIsMcpResourceRequestTest extends TestCase {
+
+	protected function tearDown(): void {
+		unset( $_SERVER['REQUEST_URI'] );
+	}
+
+	public function test_unset_request_uri_returns_false(): void {
+		unset( $_SERVER['REQUEST_URI'] );
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_empty_request_uri_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_non_string_request_uri_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = false;
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_root_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_wp_v2_users_returns_false(): void {
+		// C-1: a token issued for the MCP resource MUST NOT authenticate
+		// the user on /wp-json/wp/v2/users.
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/users';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_wp_v2_posts_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts?per_page=10';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_wp_v2_plugins_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/plugins';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_oauth_token_endpoint_returns_false(): void {
+		// /wp-json/mcp/oauth/token is in the MCP namespace but is not the
+		// MCP resource — bearer auth must not fire here.
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/oauth/token';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_oauth_register_endpoint_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/oauth/register';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_oauth_revoke_endpoint_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/oauth/revoke';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_pretty_permalink_mcp_resource_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server';
+		$this->assertTrue( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_pretty_permalink_mcp_resource_with_query_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server?foo=bar';
+		$this->assertTrue( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_pretty_permalink_mcp_resource_with_subpath_returns_true(): void {
+		// Defensive: should the MCP server ever expose a sub-resource, the
+		// gate must still admit it. The token's resource binding still
+		// covers the canonical endpoint.
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server/anything';
+		$this->assertTrue( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_plain_permalink_mcp_resource_returns_true(): void {
+		$_SERVER['REQUEST_URI'] = '/index.php?rest_route=/mcp/mcp-adapter-default-server';
+		$this->assertTrue( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_plain_permalink_other_route_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/index.php?rest_route=/wp/v2/users';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_resource_prefix_with_extra_chars_is_not_a_match(): void {
+		// /wp-json/mcp/mcp-adapter-default-server-extra must not match the
+		// canonical /wp-json/mcp/mcp-adapter-default-server prefix.
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server-extra';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_oauth_authorize_returns_false(): void {
+		// /oauth/authorize is intercepted pre-WP and is not a REST route at all.
+		$_SERVER['REQUEST_URI'] = '/oauth/authorize?response_type=code&client_id=abc';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_well_known_resource_metadata_returns_false(): void {
+		$_SERVER['REQUEST_URI'] = '/.well-known/oauth-protected-resource';
+		$this->assertFalse( \oauth_is_mcp_resource_request() );
+	}
+
+	public function test_subdir_install_uses_rest_url_prefix(): void {
+		// Multisite path-based / subdirectory installs.
+		$prev_home = $GLOBALS['wp_test_home_url'] ?? null;
+		$GLOBALS['wp_test_home_url'] = 'https://example.com/sub';
+		try {
+			$_SERVER['REQUEST_URI'] = '/sub/wp-json/mcp/mcp-adapter-default-server';
+			$this->assertTrue( \oauth_is_mcp_resource_request() );
+
+			$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server';
+			$this->assertFalse(
+				\oauth_is_mcp_resource_request(),
+				'subdir install must not match the bare /wp-json/ path'
+			);
+		} finally {
+			if ( null === $prev_home ) {
+				unset( $GLOBALS['wp_test_home_url'] );
+			} else {
+				$GLOBALS['wp_test_home_url'] = $prev_home;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `determine_current_user` previously fired bearer-auth on every REST request. A token issued for the MCP resource therefore authenticated the bound user on `/wp-json/wp/v2/users`, `/wp-json/wp/v2/plugins`, `/wp-json/wp/v2/posts`, etc. — where the H.1.3 OAuth scope enforcer never fires — silently granting full WP capabilities under that user. Critical from external review.
- New global helper `oauth_is_mcp_resource_request()` matches the request URI against the canonical MCP resource path, handling both pretty-permalink (`/wp-json/mcp/mcp-adapter-default-server`) and plain-permalink (`?rest_route=/mcp/mcp-adapter-default-server`) forms.
- `AuthorizationServer::authenticate_bearer()` returns the input `$user_id` unchanged when the request is not for the MCP resource. The existing token validation + H.1.2 resource-binding check + H.1.3 scope enforcer remain unchanged; this PR is strictly *additional*, narrowing where bearer auth is allowed to fire.

Closes #44.

## Spec ambiguity resolved

H.1.2 binds tokens to a resource but does not mandate that the *request* must also target that resource — the issue calls this out as a spec gap. Default chosen here: bearer auth no-ops on any URI whose path/`rest_route` does not match the canonical MCP server endpoint. The `/wp-json/mcp/oauth/*` endpoints (token, register, revoke) are also gated out — they do not consume bearer tokens for their own auth in this code path. (RFC 7009 §2.1 client auth on revoke is #46's concern; the revoke endpoint will validate the presented token itself, independent of `determine_current_user`.)

## Subdir / multisite

The pretty-permalink branch derives the resource path from `rest_url('mcp/mcp-adapter-default-server')` rather than hard-coding `/wp-json/...`, so subdirectory installs (`/sub/wp-json/...`) are matched against their actual prefix. Covered by `test_subdir_install_uses_rest_url_prefix`.

## Test plan

- [x] `composer install && vendor/bin/phpunit tests/` → **707 / 707 green** locally (683 baseline + 24 new across two new test files).
  - `OAuthIsMcpResourceRequestTest` — 19 helper cases (unset/empty/non-string URI, `/wp-json/wp/v2/*`, `/wp-json/mcp/oauth/*`, pretty + plain permalinks, prefix-but-not-prefix-match, subdir install).
  - `AuthenticateBearerNarrowsToMcpResourceTest` — 5 integration cases proving the gate is enforced at the bearer-auth filter even when a valid token exists in the DB (covers `/wp-json/wp/v2/users`, `/wp-json/wp/v2/plugins`, `/wp-json/mcp/oauth/token`, the MCP resource happy path, and the already-authenticated pass-through).
- [ ] CI matrix `[8.2, 8.3]` green.
- [ ] Live re-test of original review's Items 9 / 10 / 12: bearer token presented to non-MCP REST routes returns 401 with no user resolved.

## Out of scope

- `/wp-json/abilities-mcp-adapter/` namespace appears in `AuthHeaderProbe` recording logic but is not registered anywhere in `src/`. Did not touch — diagnostic-only, separate cleanup.
- Revoke endpoint client auth (#46).
- Bearer auth on the bridge side / discovery (#50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)