### PR TITLE
fix(oauth): wire scope enforcer at every dispatch path (H-5, #39/#40/#42/#45)

### DIFF
--- a/src/Abilities/BatchExecuteAbility.php
+++ b/src/Abilities/BatchExecuteAbility.php
@@ -68,9 +68,15 @@ final class BatchExecuteAbility {
 				'execute_callback'    => array( self::class, 'execute' ),
 				'meta'                => array(
 					'annotations' => array(
+						// MCP-level destructive annotation kept for client safety: this
+						// dispatcher CAN run destructive tools via its `requests` argument.
+						// Authorization weight lives on the inner per-tool scope check
+						// (run by `ToolsHandler::handle_tool_call` for each request), so
+						// the OAuth scope mapping for *this* tool is `read` (#42, #45).
 						'readonly'    => false,
 						'destructive' => true,
 						'idempotent'  => false,
+						'permission'  => 'read',
 					),
 				),
 			)

--- a/src/Abilities/ExecuteAbilityAbility.php
+++ b/src/Abilities/ExecuteAbilityAbility.php
@@ -13,6 +13,8 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Abilities;
 
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
+
 /**
  * Execute Ability - Executes a WordPress ability with provided parameters.
  *
@@ -74,9 +76,15 @@ final class ExecuteAbilityAbility {
 				'execute_callback'    => array( self::class, 'execute' ),
 				'meta'                => array(
 					'annotations' => array(
+						// MCP-level destructive annotation kept for client safety: this
+						// dispatcher CAN run destructive abilities via its `ability_name`
+						// argument. Authorization weight lives on the inner per-underlying
+						// scope check (#39, #42, #45), not the dispatcher itself, so the
+						// OAuth scope mapping for *this* tool is `read`.
 						'readonly'    => false,
 						'destructive' => true,
 						'idempotent'  => false,
+						'permission'  => 'read',
 					),
 				),
 			)
@@ -198,6 +206,20 @@ final class ExecuteAbilityAbility {
 			return array(
 				'success' => false,
 				'error'   => "Ability '{$ability_name}' not found",
+			);
+		}
+
+		// OAuth scope gate at the per-underlying dispatch (#39, #45). The outer
+		// tools/call gate only sees `mcp-adapter/execute-ability`; without this
+		// inner check, a token with `abilities:mcp-adapter:read` could dispatch
+		// any underlying ability the WP user has caps for, bypassing scope.
+		$scope_denial = OAuthScopeEnforcer::check( $ability );
+		if ( null !== $scope_denial ) {
+			return array(
+				'success'        => false,
+				'error'          => $scope_denial['message'],
+				'error_code'     => $scope_denial['error_code'],
+				'required_scope' => $scope_denial['required_scope'],
 			);
 		}
 

--- a/src/Auth/OAuth/OAuthScopeEnforcer.php
+++ b/src/Auth/OAuth/OAuthScopeEnforcer.php
@@ -8,9 +8,11 @@
  * but never wired a consumer that gates ability execution against the granted
  * scope set. This class is that consumer.
  *
- * The gate runs at exactly one location — `ToolsHandler::handle_tool_call` —
- * before `$ability->execute( $args )` fires. Non-OAuth requests pass through
- * unchanged (WP capabilities govern; the gate becomes a no-op).
+ * The gate runs at every dispatch path that can lead to `$ability->execute()`:
+ * `ToolsHandler::handle_tool_call`, `ResourcesHandler::read_resource`,
+ * `PromptsHandler::get_prompt`, and the `mcp-adapter/execute-ability`
+ * meta-tool's per-underlying-ability dispatch (see issues #39, #40, #45).
+ * Non-OAuth requests pass through unchanged (WP capabilities govern).
  *
  * Scope mapping rule per issue #38 / Appendix A:
  *
@@ -70,12 +72,29 @@ final class OAuthScopeEnforcer {
 	 *                       'required_scope' => string ]`.
 	 */
 	public static function check( \WP_Ability $ability ): ?array {
+		return self::check_scope( self::required_scope_for( $ability ) );
+	}
+
+	/**
+	 * Gate the current OAuth request against an explicit required scope.
+	 *
+	 * Used by dispatch paths that do not have a `WP_Ability` to derive the
+	 * scope from — currently the builder-based prompts path in
+	 * `PromptsHandler::get_prompt` (see issue #45).
+	 *
+	 * Same allow/deny semantics as `check()`:
+	 * - Non-OAuth requests: returns null (allow).
+	 * - Direct match in the granted set: returns null.
+	 * - Non-sensitive scope covered by a granted umbrella: returns null.
+	 * - Sensitive scope or no match: emits `boundary.oauth_scope_denied` and
+	 *   returns the structured deny payload.
+	 */
+	public static function check_scope( string $required ): ?array {
 		if ( ! OAuthRequestContext::is_oauth_request() ) {
 			return null;
 		}
 
-		$required = self::required_scope_for( $ability );
-		$granted  = OAuthRequestContext::granted_scopes();
+		$granted = OAuthRequestContext::granted_scopes();
 
 		// Direct match — the required scope is explicitly in the granted set.
 		if ( in_array( $required, $granted, true ) ) {

--- a/src/Handlers/Prompts/PromptsHandler.php
+++ b/src/Handlers/Prompts/PromptsHandler.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Handlers\Prompts;
 
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
 use WickedEvolutions\McpAdapter\Core\McpServer;
 use WickedEvolutions\McpAdapter\Handlers\HandlerHelperTrait;
 use WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\McpErrorFactory;
@@ -121,6 +122,31 @@ class PromptsHandler {
 					);
 				}
 
+				// OAuth scope gate (#45). Builder-based prompts bypass the abilities API
+				// so there is no category/permission to derive a scope from. Require the
+				// adapter-internal read scope as a baseline; per-builder permission
+				// callbacks remain authoritative on top of this.
+				$scope_denial = OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' );
+				if ( null !== $scope_denial ) {
+					return array(
+						'error'     => array(
+							'code'    => McpErrorFactory::PERMISSION_DENIED,
+							'message' => $scope_denial['message'],
+							'data'    => array(
+								'error'          => $scope_denial['error_code'],
+								'required_scope' => $scope_denial['required_scope'],
+							),
+						),
+						'_metadata' => array(
+							'component_type' => 'prompt',
+							'prompt_name'    => $prompt_name,
+							'failure_reason' => 'insufficient_scope',
+							'error_code'     => $scope_denial['required_scope'],
+							'is_builder'     => true,
+						),
+					);
+				}
+
 				$result              = $prompt->execute_direct( $arguments );
 				$result['_metadata'] = array(
 					'component_type' => 'prompt',
@@ -186,6 +212,29 @@ class PromptsHandler {
 						'prompt_name'    => $prompt_name,
 						'ability_name'   => $ability->get_name(),
 						'failure_reason' => $failure_reason,
+						'is_builder'     => false,
+					),
+				);
+			}
+
+			// OAuth scope gate (#45). No-op for non-OAuth requests.
+			$scope_denial = OAuthScopeEnforcer::check( $ability );
+			if ( null !== $scope_denial ) {
+				return array(
+					'error'     => array(
+						'code'    => McpErrorFactory::PERMISSION_DENIED,
+						'message' => $scope_denial['message'],
+						'data'    => array(
+							'error'          => $scope_denial['error_code'],
+							'required_scope' => $scope_denial['required_scope'],
+						),
+					),
+					'_metadata' => array(
+						'component_type' => 'prompt',
+						'prompt_name'    => $prompt_name,
+						'ability_name'   => $ability->get_name(),
+						'failure_reason' => 'insufficient_scope',
+						'error_code'     => $scope_denial['required_scope'],
 						'is_builder'     => false,
 					),
 				);

--- a/src/Handlers/Resources/ResourcesHandler.php
+++ b/src/Handlers/Resources/ResourcesHandler.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 
 namespace WickedEvolutions\McpAdapter\Handlers\Resources;
 
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
 use WickedEvolutions\McpAdapter\Core\McpServer;
 use WickedEvolutions\McpAdapter\Handlers\HandlerHelperTrait;
 use WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\McpErrorFactory;
@@ -158,6 +159,29 @@ class ResourcesHandler {
 						'resource_name'  => $resource->get_name(),
 						'ability_name'   => $ability->get_name(),
 						'failure_reason' => $failure_reason,
+					),
+				);
+			}
+
+			// OAuth scope gate (H.1.3 / #45). No-op for non-OAuth requests.
+			$scope_denial = OAuthScopeEnforcer::check( $ability );
+			if ( null !== $scope_denial ) {
+				return array(
+					'error'     => array(
+						'code'    => McpErrorFactory::PERMISSION_DENIED,
+						'message' => $scope_denial['message'],
+						'data'    => array(
+							'error'          => $scope_denial['error_code'],
+							'required_scope' => $scope_denial['required_scope'],
+						),
+					),
+					'_metadata' => array(
+						'component_type' => 'resource',
+						'resource_uri'   => $uri,
+						'resource_name'  => $resource->get_name(),
+						'ability_name'   => $ability->get_name(),
+						'failure_reason' => 'insufficient_scope',
+						'error_code'     => $scope_denial['required_scope'],
 					),
 				);
 			}

--- a/tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php
+++ b/tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Scope enforcement at the `mcp-adapter/execute-ability` meta-tool's
+ * per-underlying-ability dispatch (#39, #45).
+ *
+ * Pre-fix: `ExecuteAbilityAbility::execute()` resolved an inner ability
+ * via `wp_get_ability($ability_name)` and called `$inner->execute()`
+ * without consulting OAuth scope. The outer dispatch only saw the
+ * meta-tool itself; the inner ability ran under the bound user's WP
+ * caps regardless of granted scope.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Abilities
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Abilities;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Abilities\ExecuteAbilityAbility;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+final class ExecuteAbilityScopeEnforcementTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities']    = array();
+		$GLOBALS['wp_test_current_user'] = 7;
+		$GLOBALS['wp_test_caps']         = array( 'read' => true );
+	}
+
+	protected function tearDown(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities']    = array();
+		unset( $GLOBALS['wp_test_current_user'] );
+		unset( $GLOBALS['wp_test_caps'] );
+	}
+
+	private function register_inner_ability( string $name = 'users/create' ): object {
+		$ability = new class( $name, array(
+			'category' => 'users',
+			'meta'     => array(
+				'annotations' => array( 'permission' => 'write' ),
+				'mcp'         => array( 'public' => true ),
+			),
+		) ) extends \WP_Ability {
+			public int $execute_calls = 0;
+			public function check_permissions( $args = null ) { return true; }
+			public function get_input_schema() { return array(); }
+			public function execute( $args = null ) {
+				++$this->execute_calls;
+				return array( 'created' => true );
+			}
+		};
+		$GLOBALS['wp_test_abilities'][ $name ] = $ability;
+		return $ability;
+	}
+
+	private function set_oauth_request( array $scopes ): void {
+		OAuthRequestContext::set( 7, $scopes, 'https://example.com/wp-json/mcp/mcp-adapter-default-server', 'cl_test', 1 );
+	}
+
+	public function test_inner_ability_blocked_when_token_lacks_inner_scope(): void {
+		$inner = $this->register_inner_ability( 'users/create' );
+
+		// Token has the outer meta-tool scope (read on mcp-adapter) but NOT the
+		// inner sensitive `abilities:users:write`.
+		$this->set_oauth_request( array( 'abilities:mcp-adapter:read' ) );
+
+		$result = ExecuteAbilityAbility::execute( array(
+			'ability_name' => 'users/create',
+			'parameters'   => array(),
+		) );
+
+		$this->assertSame( 0, $inner->execute_calls, 'inner execute() must not run on scope deny' );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'insufficient_scope', $result['error_code'] );
+		$this->assertSame( 'abilities:users:write', $result['required_scope'] );
+	}
+
+	public function test_inner_ability_runs_when_token_has_explicit_inner_scope(): void {
+		$inner = $this->register_inner_ability( 'users/create' );
+
+		$this->set_oauth_request( array( 'abilities:mcp-adapter:read', 'abilities:users:write' ) );
+
+		$result = ExecuteAbilityAbility::execute( array(
+			'ability_name' => 'users/create',
+			'parameters'   => array(),
+		) );
+
+		$this->assertSame( 1, $inner->execute_calls );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'created' => true ), $result['data'] );
+	}
+
+	public function test_non_oauth_request_runs_inner_ability(): void {
+		// No OAuthRequestContext → enforcer no-ops → inner ability runs under WP caps.
+		$inner = $this->register_inner_ability( 'users/create' );
+
+		$result = ExecuteAbilityAbility::execute( array(
+			'ability_name' => 'users/create',
+			'parameters'   => array(),
+		) );
+
+		$this->assertSame( 1, $inner->execute_calls );
+		$this->assertTrue( $result['success'] );
+	}
+}

--- a/tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php
+++ b/tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * #42: meta-tool dispatchers (`mcp-adapter/execute-ability`,
+ * `mcp-adapter/batch-execute`) had `destructive=true` annotations, which
+ * `PermissionManager::get_permission` mapped to `delete`. That meant a
+ * token would need `abilities:mcp-adapter:delete` (a sensitive scope —
+ * never implied by any umbrella) just to read via the dispatcher. The
+ * dispatchers themselves are not destructive operations; per-underlying
+ * scope checks (added in #45) carry the actual authorization weight.
+ *
+ * After the fix: explicit `permission => read` annotation overrides the
+ * destructive-true derivation in PermissionManager priority 1.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Abilities
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Abilities;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Abilities\BatchExecuteAbility;
+use WickedEvolutions\McpAdapter\Abilities\ExecuteAbilityAbility;
+use WickedEvolutions\McpAdapter\Admin\PermissionManager;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
+
+final class MetaToolPermissionAnnotationTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	public function test_execute_ability_register_resolves_to_read_not_delete(): void {
+		ExecuteAbilityAbility::register();
+		$ability = wp_get_ability( 'mcp-adapter/execute-ability' );
+		$this->assertNotNull( $ability );
+
+		$this->assertSame( 'read', PermissionManager::get_permission( $ability ) );
+		$this->assertSame( 'abilities:mcp-adapter:read', OAuthScopeEnforcer::required_scope_for( $ability ) );
+	}
+
+	public function test_batch_execute_register_resolves_to_read_not_delete(): void {
+		BatchExecuteAbility::register();
+		$ability = wp_get_ability( 'mcp-adapter/batch-execute' );
+		$this->assertNotNull( $ability );
+
+		$this->assertSame( 'read', PermissionManager::get_permission( $ability ) );
+		$this->assertSame( 'abilities:mcp-adapter:read', OAuthScopeEnforcer::required_scope_for( $ability ) );
+	}
+
+	/**
+	 * Sanity: the same ability without the explicit `permission => read`
+	 * override would resolve to `delete` from priority-2 derivation. Locks
+	 * in why the explicit override is required and prevents accidental
+	 * reversion.
+	 */
+	public function test_destructive_alone_would_resolve_to_delete(): void {
+		$ability = new \WP_Ability( 'regression/destructive', array(
+			'category' => 'mcp-adapter',
+			'meta'     => array(
+				'annotations' => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
+				),
+			),
+		) );
+
+		$this->assertSame( 'delete', PermissionManager::get_permission( $ability ) );
+	}
+
+	/**
+	 * Lock-in: the destructive=true MCP-level annotation is preserved (clients
+	 * still see the dispatcher as destructive). Only the OAuth scope mapping
+	 * changes via the new `permission => read` override.
+	 */
+	public function test_meta_tools_keep_destructive_client_annotation(): void {
+		ExecuteAbilityAbility::register();
+		BatchExecuteAbility::register();
+
+		foreach ( array( 'mcp-adapter/execute-ability', 'mcp-adapter/batch-execute' ) as $name ) {
+			$meta = wp_get_ability( $name )->get_meta();
+			$this->assertTrue(
+				$meta['annotations']['destructive'] ?? false,
+				"$name should retain destructive=true for client display"
+			);
+		}
+	}
+}

--- a/tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for OAuthScopeEnforcer::check_scope() — the explicit-scope entry
+ * point added in #45 for dispatch paths without a WP_Ability (currently
+ * the builder-based prompts path in PromptsHandler::get_prompt).
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthScopeEnforcer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ScopeRegistry;
+
+final class OAuthScopeEnforcerCheckScopeTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+	}
+
+	private function set_oauth_request( array $scopes ): void {
+		OAuthRequestContext::set(
+			user_id: 7,
+			scopes: $scopes,
+			resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			client_id: 'cl_test',
+			token_id: 1
+		);
+	}
+
+	public function test_non_oauth_request_is_noop(): void {
+		$this->assertFalse( OAuthRequestContext::is_oauth_request() );
+		$this->assertNull( OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' ) );
+	}
+
+	public function test_direct_match_allows(): void {
+		$this->set_oauth_request( array( 'abilities:mcp-adapter:read' ) );
+		$this->assertNull( OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' ) );
+	}
+
+	public function test_missing_scope_denies_with_required_in_payload(): void {
+		$this->set_oauth_request( array( 'abilities:content:read' ) );
+
+		$denial = OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' );
+
+		$this->assertIsArray( $denial );
+		$this->assertSame( 'insufficient_scope', $denial['error_code'] );
+		$this->assertSame( 'abilities:mcp-adapter:read', $denial['required_scope'] );
+		$this->assertStringContainsString( 'abilities:mcp-adapter:read', $denial['message'] );
+	}
+
+	public function test_umbrella_grant_covers_non_sensitive_scope(): void {
+		$this->set_oauth_request( ScopeRegistry::expand( array( 'abilities:read' ) ) );
+		// `abilities:mcp-adapter:read` is non-sensitive and in the umbrella's implications.
+		$this->assertNull( OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' ) );
+	}
+
+	public function test_check_delegates_to_check_scope_for_ability_derived_scope(): void {
+		// Regression: the existing check(WP_Ability) entry point must now route
+		// through check_scope and behave identically.
+		$this->set_oauth_request( array( 'abilities:content:write' ) );
+
+		$ability = new \WP_Ability(
+			'content/create',
+			array(
+				'category' => 'content',
+				'meta'     => array( 'annotations' => array( 'permission' => 'write' ) ),
+			)
+		);
+
+		$this->assertNull( OAuthScopeEnforcer::check( $ability ) );
+	}
+}

--- a/tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php
+++ b/tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Scope enforcement at the prompts/get dispatch path (#40, #45).
+ *
+ * Pre-fix: `PromptsHandler::get_prompt` had no reference to
+ * `OAuthRequestContext` or `OAuthScopeEnforcer`. Both the ability-based
+ * and builder-based execution paths called `execute()` / `execute_direct()`
+ * without consulting the granted scope set.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Handlers\Prompts
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Handlers\Prompts;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+use WickedEvolutions\McpAdapter\Core\McpServer;
+use WickedEvolutions\McpAdapter\Domain\Prompts\McpPrompt;
+use WickedEvolutions\McpAdapter\Handlers\Prompts\PromptsHandler;
+
+final class PromptsHandlerScopeEnforcementTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	protected function tearDown(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	private function register_writeable_ability( string $name = 'content/draft-prompt' ): object {
+		$ability = new class( $name, array(
+			'category' => 'content',
+			'meta'     => array( 'annotations' => array( 'permission' => 'write' ) ),
+		) ) extends \WP_Ability {
+			public int $execute_calls = 0;
+			public function check_permissions( $args = null ) { return true; }
+			public function execute( $args = null ) {
+				++$this->execute_calls;
+				return array( 'messages' => array( array( 'role' => 'user', 'content' => 'ok' ) ) );
+			}
+		};
+		$GLOBALS['wp_test_abilities'][ $name ] = $ability;
+		return $ability;
+	}
+
+	private function handler_with_prompt( McpPrompt $prompt ): PromptsHandler {
+		$server = new class( $prompt ) extends McpServer {
+			private McpPrompt $stub;
+			public function __construct( McpPrompt $stub ) {
+				$this->stub = $stub;
+				$this->error_handler = new class implements \WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface {
+					public function log( string $message, array $context = array(), string $type = 'error' ): void {}
+				};
+			}
+			public function get_prompt( string $prompt_name ): ?McpPrompt {
+				return $this->stub;
+			}
+		};
+		return new PromptsHandler( $server );
+	}
+
+	private function set_oauth_request( array $scopes ): void {
+		OAuthRequestContext::set( 7, $scopes, 'https://example.com/wp-json/mcp/mcp-adapter-default-server', 'cl_test', 1 );
+	}
+
+	// ---------------------------------------------------------------------
+	// Ability-based path
+	// ---------------------------------------------------------------------
+
+	public function test_ability_based_oauth_without_scope_denies(): void {
+		$ability = $this->register_writeable_ability( 'content/draft-prompt' );
+		$prompt  = new McpPrompt( 'content/draft-prompt', 'draft' );
+
+		$this->set_oauth_request( array( 'abilities:content:read' ) );
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'draft' ) );
+
+		$this->assertSame( 0, $ability->execute_calls );
+		$this->assertSame( 'insufficient_scope', $result['_metadata']['failure_reason'] );
+		$this->assertSame( 'abilities:content:write', $result['_metadata']['error_code'] );
+		$this->assertFalse( $result['_metadata']['is_builder'] );
+	}
+
+	public function test_ability_based_oauth_with_required_scope_runs_execute(): void {
+		$ability = $this->register_writeable_ability( 'content/draft-prompt' );
+		$prompt  = new McpPrompt( 'content/draft-prompt', 'draft' );
+
+		$this->set_oauth_request( array( 'abilities:content:write' ) );
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'draft' ) );
+
+		$this->assertSame( 1, $ability->execute_calls );
+		$this->assertArrayNotHasKey( 'error', $result );
+	}
+
+	public function test_ability_based_non_oauth_runs_execute(): void {
+		$ability = $this->register_writeable_ability( 'content/draft-prompt' );
+		$prompt  = new McpPrompt( 'content/draft-prompt', 'draft' );
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'draft' ) );
+
+		$this->assertSame( 1, $ability->execute_calls );
+		$this->assertArrayNotHasKey( 'error', $result );
+	}
+
+	// ---------------------------------------------------------------------
+	// Builder-based path
+	// ---------------------------------------------------------------------
+
+	private function builder_prompt(): McpPrompt {
+		// Anonymous subclass: is_builder_based() => true, with permission/execute stubs
+		// that record their invocation count.
+		return new class( 'unused', 'help-prompt' ) extends McpPrompt {
+			public int $execute_direct_calls = 0;
+			public function is_builder_based(): bool { return true; }
+			public function check_permission_direct( array $arguments ): bool { return true; }
+			public function execute_direct( array $arguments ): array {
+				++$this->execute_direct_calls;
+				return array( 'messages' => array( array( 'role' => 'user', 'content' => 'help' ) ) );
+			}
+		};
+	}
+
+	public function test_builder_oauth_without_baseline_scope_denies(): void {
+		$prompt = $this->builder_prompt();
+
+		// Token grants a different scope; the builder requires `abilities:mcp-adapter:read`.
+		$this->set_oauth_request( array( 'abilities:content:read' ) );
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'help-prompt' ) );
+
+		$this->assertSame( 0, $prompt->execute_direct_calls );
+		$this->assertSame( 'insufficient_scope', $result['_metadata']['failure_reason'] );
+		$this->assertSame( 'abilities:mcp-adapter:read', $result['_metadata']['error_code'] );
+		$this->assertTrue( $result['_metadata']['is_builder'] );
+	}
+
+	public function test_builder_oauth_with_baseline_scope_runs(): void {
+		$prompt = $this->builder_prompt();
+		$this->set_oauth_request( array( 'abilities:mcp-adapter:read' ) );
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'help-prompt' ) );
+
+		$this->assertSame( 1, $prompt->execute_direct_calls );
+		$this->assertArrayNotHasKey( 'error', $result );
+	}
+
+	public function test_builder_non_oauth_runs(): void {
+		$prompt = $this->builder_prompt();
+
+		$result = $this->handler_with_prompt( $prompt )->get_prompt( array( 'name' => 'help-prompt' ) );
+
+		$this->assertSame( 1, $prompt->execute_direct_calls );
+		$this->assertArrayNotHasKey( 'error', $result );
+	}
+}

--- a/tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php
+++ b/tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Scope enforcement at the resources/read dispatch path (#45).
+ *
+ * Before the fix: `ResourcesHandler::read_resource` had no reference to
+ * `OAuthRequestContext` or `OAuthScopeEnforcer`. A token whose granted
+ * scopes did not cover an exposed resource's ability still executed it
+ * (under the bound user's WP capabilities) — the H.1.3 enforcer was
+ * simply not wired into this handler.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Handlers\Resources
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Handlers\Resources;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+use WickedEvolutions\McpAdapter\Core\McpServer;
+use WickedEvolutions\McpAdapter\Domain\Resources\McpResource;
+use WickedEvolutions\McpAdapter\Handlers\Resources\ResourcesHandler;
+
+final class ResourcesHandlerScopeEnforcementTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	protected function tearDown(): void {
+		OAuthRequestContext::reset();
+		$GLOBALS['wp_test_abilities'] = array();
+	}
+
+	/**
+	 * Register a stub ability that records whether execute() was called and
+	 * returns a sentinel string. Tests assert against this counter to prove
+	 * whether the scope gate short-circuited before execution.
+	 */
+	private function register_writeable_ability( string $name = 'content/get-secret' ): object {
+		$ability = new class( $name, array(
+			'category' => 'content',
+			'meta'     => array( 'annotations' => array( 'permission' => 'write' ) ),
+		) ) extends \WP_Ability {
+			public int $execute_calls = 0;
+			public function check_permissions( $args = null ) { return true; }
+			public function execute( $args = null ) {
+				++$this->execute_calls;
+				return 'EXECUTED';
+			}
+		};
+		$GLOBALS['wp_test_abilities'][ $name ] = $ability;
+		return $ability;
+	}
+
+	/** Build a ResourcesHandler whose mcp server returns the given resource. */
+	private function handler_with_resource( McpResource $resource ): ResourcesHandler {
+		$server = new class( $resource ) extends McpServer {
+			private McpResource $stub;
+			public function __construct( McpResource $stub ) {
+				$this->stub = $stub;
+				$this->error_handler = new class implements \WickedEvolutions\McpAdapter\Infrastructure\ErrorHandling\Contracts\McpErrorHandlerInterface {
+					public function log( string $message, array $context = array(), string $type = 'error' ): void {}
+				};
+			}
+			public function get_resource( string $resource_uri ): ?McpResource {
+				return $this->stub;
+			}
+		};
+		return new ResourcesHandler( $server );
+	}
+
+	private function set_oauth_request( array $scopes ): void {
+		OAuthRequestContext::set( 7, $scopes, 'https://example.com/wp-json/mcp/mcp-adapter-default-server', 'cl_test', 1 );
+	}
+
+	public function test_oauth_request_without_required_scope_denies_with_insufficient_scope(): void {
+		$ability  = $this->register_writeable_ability( 'content/get-secret' );
+		$resource = new McpResource( 'content/get-secret', 'mcp://test/secret' );
+
+		// Token has only `abilities:content:read`; the resource's ability requires
+		// `abilities:content:write`. Pre-fix the handler called execute() anyway —
+		// the gate must short-circuit before that.
+		$this->set_oauth_request( array( 'abilities:content:read' ) );
+
+		$result = $this->handler_with_resource( $resource )->read_resource( array( 'uri' => 'mcp://test/secret' ) );
+
+		$this->assertSame( 0, $ability->execute_calls, 'execute() must not run when scope is denied' );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( 'insufficient_scope', $result['_metadata']['failure_reason'] );
+		$this->assertSame( 'abilities:content:write', $result['_metadata']['error_code'] );
+		$this->assertSame( 'abilities:content:write', $result['error']['data']['required_scope'] );
+		$this->assertArrayNotHasKey( 'contents', $result );
+	}
+
+	public function test_non_oauth_request_runs_execute_unchanged(): void {
+		// No OAuthRequestContext → enforcer no-ops → execute() must still run.
+		// This proves the gate doesn't break the WP-cookie-auth path.
+		$ability  = $this->register_writeable_ability( 'content/get-secret' );
+		$resource = new McpResource( 'content/get-secret', 'mcp://test/secret' );
+
+		$result = $this->handler_with_resource( $resource )->read_resource( array( 'uri' => 'mcp://test/secret' ) );
+
+		$this->assertSame( 1, $ability->execute_calls );
+		$this->assertSame( 'EXECUTED', $result['contents'] );
+	}
+
+	public function test_oauth_request_with_required_scope_proceeds_to_execute(): void {
+		$ability  = $this->register_writeable_ability( 'content/get-secret' );
+		$resource = new McpResource( 'content/get-secret', 'mcp://test/secret' );
+		$this->set_oauth_request( array( 'abilities:content:write' ) );
+
+		$result = $this->handler_with_resource( $resource )->read_resource( array( 'uri' => 'mcp://test/secret' ) );
+
+		$this->assertSame( 1, $ability->execute_calls );
+		$this->assertSame( 'EXECUTED', $result['contents'] );
+	}
+}


### PR DESCRIPTION
## Summary

The H.1.3 scope enforcer was previously wired only at `ToolsHandler::handle_tool_call`. `ResourcesHandler::read_resource` and `PromptsHandler::get_prompt` had **zero** references to `OAuthRequestContext` or the enforcer, and the meta-tool `mcp-adapter/execute-ability` dispatched to underlying abilities without per-underlying scope checks. Tokens whose granted scope didn't cover an exposed resource / prompt / inner ability still executed it under the bound user's WP capabilities.

This PR threads the same enforcer through every dispatch site, then adds the #42 annotation flip on the dispatcher meta-tools.

Closes #39, #40, #42, #45.

## Changes

- **`OAuthScopeEnforcer::check_scope(string)`** — explicit-scope entry point for dispatch paths that have no `WP_Ability` to derive a scope from. `check(WP_Ability)` now delegates to it. Same allow/deny semantics (direct match, umbrella for non-sensitive, sensitive-never-implied, boundary event on deny).
- **`ResourcesHandler::read_resource`** — gate added before `$ability->execute()`, wire-format mirrors `ToolsHandler`.
- **`PromptsHandler::get_prompt`** — gate on both branches:
  - Ability-based path: `OAuthScopeEnforcer::check( $ability )`.
  - Builder-based path: `OAuthScopeEnforcer::check_scope( 'abilities:mcp-adapter:read' )`. Builders bypass the abilities API entirely so there is no category/permission to derive from; the adapter-internal read scope is the conservative baseline. See spec ambiguity below.
- **`ExecuteAbilityAbility::execute`** — per-underlying gate at the inner ability resolution point (#39). The outer `tools/call` gate only sees the meta-tool itself.
- **`BatchExecuteAbility`** — no code change. Each sub-request routes through `ToolsHandler::call_tool → handle_tool_call`, so the inner per-tool gate is automatic. Verified by re-using ToolsHandler's existing call site.
- **`mcp-adapter/execute-ability` and `mcp-adapter/batch-execute` annotations** (#42) — explicit `'permission' => 'read'` added. PermissionManager priority 1 (explicit) overrides the priority-2 destructive=true → delete derivation. The `destructive=true` MCP-level annotation is preserved for client display: these dispatchers CAN run destructive abilities/tools via their arguments, so clients should still see the warning. The OAuth authorization weight lives on the per-underlying scope check, not the dispatcher itself.

## Spec ambiguities resolved

1. **Builder-based prompts have no ability → no scope.** Picked `abilities:mcp-adapter:read` as the baseline OAuth scope for the builder path. Per-builder `check_permission_direct` callbacks remain authoritative on top of this gate. Documented in `PromptsHandler::get_prompt` with an inline comment. Alternative considered: deny all OAuth-based access to builder prompts. Rejected as more disruptive than necessary — builders are often help/discovery content, and a baseline read scope is what `abilities:read` umbrellas already cover.
2. **Should we strip `destructive=true` on the dispatchers when adding `permission=read`?** No — kept as-is. The annotations carry two meanings: client-facing destructiveness hint and OAuth scope derivation. Decoupling via the explicit `permission` override keeps both correct.

## Test plan

- [x] `composer install && vendor/bin/phpunit tests/` → **728 / 728** locally (707 baseline + 21 new across 5 new test files).
  - `OAuthScopeEnforcerCheckScopeTest` — 5 cases for the new entry point.
  - `ResourcesHandlerScopeEnforcementTest` — 3 cases (deny, non-OAuth pass-through, allow).
  - `PromptsHandlerScopeEnforcementTest` — 6 cases covering both ability and builder paths.
  - `ExecuteAbilityScopeEnforcementTest` — 3 cases for the meta-tool's per-underlying gate.
  - `MetaToolPermissionAnnotationTest` — 4 cases locking in #42 (read, not delete; destructive client annotation preserved; sanity test that proves the override is required).
- [ ] CI matrix `[8.2, 8.3]` green.
- [ ] Live re-test: token with `abilities:read` calling `resources/read` for a write-permission resource → 403 `insufficient_scope`. Token with `abilities:mcp-adapter:read` calling `mcp-adapter/execute-ability` to dispatch `users/create` → inner deny `abilities:users:write` instead of falling through.

## Out of scope

- `tools/list`, `resources/list`, `prompts/list` — these only return descriptors and do not execute abilities, so no scope check is required at list time. Listing is unauthenticated-discovery semantics.
- Filesystem / cron / multisite scope categories — covered by the existing scope registry.
- The `_metadata` shape on the deny path (`failure_reason: insufficient_scope`, `error_code: <required>`) was already used by ToolsHandler for the same purpose. Reused verbatim.

## Adjacent defects spotted

Filed only on request — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)