### PR TITLE
fix(oauth): H-6 — add token_type field to token response (RFC 6749 §5.1)

### DIFF
--- a/src/Auth/OAuth/TokenStore.php
+++ b/src/Auth/OAuth/TokenStore.php
@@ -42,13 +42,18 @@ final class TokenStore {
 	/**
 	 * Issue a new access + refresh token pair.
 	 *
+	 * The response always includes `token_type: Bearer` (RFC 6749 §5.1 REQUIRED)
+	 * and the granted `scope` as stored (the expanded set, per RFC 6749 §3.3).
+	 * Scope is always returned — the stored set is umbrella-expanded so it
+	 * always differs from the umbrella strings the client originally requested.
+	 *
 	 * @param string $client_id
 	 * @param int    $user_id
-	 * @param string $scope     Space-separated scope string.
+	 * @param string $scope     Space-separated scope string (umbrella-expanded).
 	 * @param string $resource  Resource indicator URL.
 	 * @param int    $access_ttl  Override access TTL (seconds).
 	 * @param int    $refresh_ttl Override refresh TTL (seconds).
-	 * @return array{access_token: string, refresh_token: string, expires_in: int, scope: string}
+	 * @return array{access_token: string, token_type: string, refresh_token: string, expires_in: int, scope: string}
 	 */
 	public static function issue(
 		string $client_id,
@@ -121,6 +126,7 @@ final class TokenStore {
 
 		return [
 			'access_token'  => $access_token,
+			'token_type'    => 'Bearer',
 			'refresh_token' => $refresh_token,
 			'expires_in'    => $access_ttl,
 			'scope'         => $scope,

--- a/tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php
+++ b/tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * H-6: token_type and scope fields in TokenStore::issue() response.
+ *
+ * Pre-fix: TokenStore::issue() returned {access_token, refresh_token, expires_in,
+ * scope} — `token_type` was absent. RFC 6749 §5.1 marks it REQUIRED. Standards-
+ * compliant third-party clients listed in Appendix E reject responses without it.
+ *
+ * After fix: `token_type: Bearer` is always present in the response.
+ *
+ * Scope-return policy (documented here for RFC 6749 §3.3):
+ *   The stored scope is the umbrella-expanded set (ScopeRegistry::expand() is
+ *   called in AuthorizeRequestValidator before the code is minted). The token
+ *   response returns this stored set verbatim. Because the expanded set always
+ *   differs from the umbrella strings the client requested, §3.3's "MUST include
+ *   when different from requested" rule requires returning it — which we do.
+ *   Returning the authoritative expanded set also gives the client an exact
+ *   picture of what the token can do, which is the safer choice.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\TokenStore;
+
+final class TokenStoreIssueResponseTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		$this->original_wpdb = $GLOBALS['wpdb'];
+		$this->install_stub_wpdb();
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+	}
+
+	/**
+	 * Install a $wpdb stub that satisfies TokenStore::issue():
+	 *   - query() returns true (START TRANSACTION / COMMIT)
+	 *   - insert() returns 1
+	 *   - insert_id property = 99 (access token row id for the refresh FK)
+	 * apply_filters() no-ops from bootstrap, so TTLs pass through unchanged.
+	 */
+	private function install_stub_wpdb(): void {
+		$GLOBALS['wpdb'] = new class {
+			public string $prefix    = 'wp_';
+			public int    $insert_id = 99;
+
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_row( $q )         { return null; }
+			public function get_var( $q )         { return null; }
+			public function get_results( $q )     { return array(); }
+			public function update( $t, $d, $w, $f = null, $wf = null ) { return 1; }
+			public function insert( $t, $d, $f = null ) { return 1; }
+			public function query( $sql )         { return true; }
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// token_type
+	// -------------------------------------------------------------------------
+
+	public function test_issue_includes_token_type_bearer(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+
+		$this->assertArrayHasKey( 'token_type', $pair, 'token_type must be present (RFC 6749 §5.1 REQUIRED)' );
+		$this->assertSame( 'Bearer', $pair['token_type'] );
+	}
+
+	public function test_token_type_is_case_correct_Bearer(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+
+		// RFC 6749 §7.1 defines token type identifiers as case-insensitive, but
+		// RFC 6750 §1 uses "Bearer" (capital B). Return the canonical form.
+		$this->assertSame( 'Bearer', $pair['token_type'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Existing fields still present (regression guard)
+	// -------------------------------------------------------------------------
+
+	public function test_issue_still_returns_access_token(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+		$this->assertArrayHasKey( 'access_token', $pair );
+		$this->assertNotEmpty( $pair['access_token'] );
+	}
+
+	public function test_issue_still_returns_refresh_token(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+		$this->assertArrayHasKey( 'refresh_token', $pair );
+		$this->assertNotEmpty( $pair['refresh_token'] );
+	}
+
+	public function test_issue_still_returns_expires_in(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+		$this->assertArrayHasKey( 'expires_in', $pair );
+		$this->assertSame( TokenStore::ACCESS_TTL, $pair['expires_in'] );
+	}
+
+	public function test_issue_returns_granted_scope_verbatim(): void {
+		$scope = 'abilities:content:read abilities:content:write';
+		$pair  = TokenStore::issue( 'cl_test', 1, $scope, 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+		$this->assertArrayHasKey( 'scope', $pair );
+		$this->assertSame( $scope, $pair['scope'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Scope-return policy: stored (expanded) set always returned
+	// -------------------------------------------------------------------------
+
+	public function test_scope_returned_is_the_stored_expanded_set(): void {
+		// Simulate what AuthorizeRequestValidator does: expand umbrella to granular.
+		// The token response must return this expanded set so clients know exactly
+		// what the token covers (RFC 6749 §3.3 + §5.1).
+		$expanded_scope = implode( ' ', [
+			'abilities:read',            // umbrella kept as-is in this test...
+			'abilities:content:read',    // ...alongside its expansion
+			'abilities:media:read',
+		] );
+
+		$pair = TokenStore::issue( 'cl_test', 1, $expanded_scope, 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+
+		$this->assertSame( $expanded_scope, $pair['scope'], 'Stored scope must be returned verbatim' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Exact key set (no extra surprises)
+	// -------------------------------------------------------------------------
+
+	public function test_issue_response_has_exactly_five_keys(): void {
+		$pair = TokenStore::issue( 'cl_test', 1, 'abilities:content:read', 'https://example.com/wp-json/mcp/mcp-adapter-default-server' );
+
+		$this->assertCount( 5, $pair, 'Issue response must have exactly 5 keys: access_token, token_type, refresh_token, expires_in, scope' );
+		$this->assertSame(
+			[ 'access_token', 'token_type', 'refresh_token', 'expires_in', 'scope' ],
+			array_keys( $pair )
+		);
+	}
+}


### PR DESCRIPTION
Closes #48.

## Summary

**token_type field (RFC 6749 §5.1 REQUIRED):** `TokenStore::issue()` previously returned `{access_token, refresh_token, expires_in, scope}` with no `token_type`. RFC 6749 §5.1 marks `token_type` as REQUIRED; its absence caused standards-compliant third-party MCP clients to reject the response. Added `'token_type' => 'Bearer'` to the return array.

Because `TokenEndpoint::handle_auth_code()` and `handle_refresh()` both pass the `issue()` / `rotate()` result directly to `\token_success()`, a single change in `TokenStore::issue()` covers both the `authorization_code` and `refresh_token` grant responses. The `rotate()` path returns `self::issue(...)` so it inherits the field automatically.

## Scope-return policy decision (RFC 6749 §3.3)

The issue asked to decide whether to return the requested set (umbrella strings the client sent) or the expanded set (stored on the token). **Decision: always return the stored expanded set.**

Rationale:
- `AuthorizeRequestValidator` calls `ScopeRegistry::expand()` before the authorization code is minted. The stored scope is already the expanded granular set (e.g. `abilities:read` → 16 individual scope strings).
- RFC 6749 §3.3 says "MUST include `scope` if it differs from what the client requested." Because the expanded set always differs from the umbrella strings the client sent, we must return it regardless.
- Returning the stored set gives clients an unambiguous, authoritative view of exactly which scopes the token covers — the safer choice for interop.

No code change needed for scope-return: the stored scope is already passed through verbatim.

## Test plan

- `test_issue_includes_token_type_bearer` — field present
- `test_token_type_is_case_correct_Bearer` — canonical RFC 6750 §1 casing
- `test_issue_still_returns_{access_token,refresh_token,expires_in}` — regression guards
- `test_issue_returns_granted_scope_verbatim` — scope passthrough
- `test_scope_returned_is_the_stored_expanded_set` — policy lock-in
- `test_issue_response_has_exactly_five_keys` — exact key-set lock-in

All 778 tests pass on PHP 8.5 (matrix: 8.2, 8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)