### PR TITLE
fix: path-style multisite discovery routing (M-5)

### DIFF
--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -187,17 +187,56 @@ final class AuthorizationServer {
 		}
 
 		$path = strtok( $_SERVER['REQUEST_URI'] ?? '', '?' );
+		if ( ! is_string( $path ) ) {
+			return;
+		}
 
-		match ( $path ) {
-			'/.well-known/oauth-protected-resource'  => DiscoveryEndpoints::serve_protected_resource(),
-			'/.well-known/oauth-authorization-server'=> DiscoveryEndpoints::serve_authorization_server(),
-			'/.well-known/openid-configuration'      => DiscoveryEndpoints::serve_oidc_configuration(),
-			'/oauth/authorize'                       => AuthorizeEndpoint::dispatch(),
-			default => null,
-		};
+		// Path-style multisite discovery (M-5): the bridge probes paths like
+		//   /.well-known/oauth-authorization-server/sub2
+		//   /.well-known/openid-configuration/sub2
+		//   /sub2/.well-known/openid-configuration
+		// Extract any trailing segment after the .well-known keyword as the
+		// path-prefix that identifies the subsite.
+		if ( str_starts_with( $path, '/.well-known/oauth-protected-resource' ) ) {
+			$prefix = self::extract_path_prefix( $path, '/.well-known/oauth-protected-resource' );
+			DiscoveryEndpoints::serve_protected_resource( $prefix );
+		} elseif ( str_starts_with( $path, '/.well-known/oauth-authorization-server' ) ) {
+			$prefix = self::extract_path_prefix( $path, '/.well-known/oauth-authorization-server' );
+			DiscoveryEndpoints::serve_authorization_server( $prefix );
+		} elseif ( str_starts_with( $path, '/.well-known/openid-configuration' ) ) {
+			$prefix = self::extract_path_prefix( $path, '/.well-known/openid-configuration' );
+			DiscoveryEndpoints::serve_oidc_configuration( $prefix );
+		} elseif ( $path === '/oauth/authorize' ) {
+			AuthorizeEndpoint::dispatch();
+		}
 	}
 
-	private static function is_well_known_or_oauth_path(): bool {
+	/**
+	 * Extract the subsite path prefix appended after a known .well-known keyword.
+	 *
+	 * For path-style multisite, discovery clients append the subsite path:
+	 *   /.well-known/oauth-authorization-server/sub2  → '/sub2'
+	 *   /.well-known/oauth-authorization-server        → null  (root site)
+	 *
+	 * @param string $full_path    The full request path (no query string).
+	 * @param string $known_prefix The matched .well-known prefix.
+	 * @return string|null The trailing path segment, or null for root sites.
+	 */
+	public static function extract_path_prefix( string $full_path, string $known_prefix ): ?string {
+		$tail = substr( $full_path, strlen( $known_prefix ) );
+		// Trim trailing slashes; empty string means root site.
+		$tail = rtrim( $tail, '/' );
+		if ( $tail === '' ) {
+			return null;
+		}
+		// Must start with '/' — guard against malformed input.
+		if ( ! str_starts_with( $tail, '/' ) ) {
+			return null;
+		}
+		return $tail;
+	}
+
+	public static function is_well_known_or_oauth_path(): bool {
 		$uri = $_SERVER['REQUEST_URI'] ?? '';
 		if ( ! is_string( $uri ) || $uri === '' ) {
 			return false;

--- a/src/Auth/OAuth/DiscoveryEndpoints.php
+++ b/src/Auth/OAuth/DiscoveryEndpoints.php
@@ -28,38 +28,55 @@ final class DiscoveryEndpoints {
 	/**
 	 * Compute the issuer URL from HTTP_HOST (timing-safe, avoids home_url() at init priority 0).
 	 * Validated against OAuthHostAllowlist before this is called.
+	 *
+	 * For path-style multisite subsites (e.g. https://example.com/sub2), pass
+	 * $path_prefix = '/sub2' so the issuer matches the subsite's home URL.
+	 * Subdomain-style and single-site installations pass null (default).
+	 *
+	 * @param string|null $path_prefix Leading path segment for path-style multisite (e.g. '/sub2').
+	 *                                 Must begin with '/' when supplied. Null for root sites.
 	 */
-	public static function issuer(): string {
+	public static function issuer( ?string $path_prefix = null ): string {
 		$scheme = \oauth_is_https() ? 'https' : 'http';
 		$host   = $_SERVER['HTTP_HOST'] ?? 'unknown';
 		// Strip port for issuer (issuer should not include port per RFC 8414 §2).
 		$host   = explode( ':', $host )[0];
-		return $scheme . '://' . $host;
+		$base   = $scheme . '://' . $host;
+		if ( $path_prefix !== null && $path_prefix !== '' && $path_prefix !== '/' ) {
+			return $base . '/' . ltrim( $path_prefix, '/' );
+		}
+		return $base;
 	}
 
 	/**
 	 * MCP resource URL — always constructed dynamically from issuer.
 	 * Namespace confirmed by Stream D: rest_url('mcp/mcp-adapter-default-server').
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	public static function resource_url(): string {
-		return self::issuer() . '/wp-json/' . self::MCP_NAMESPACE . '/' . self::MCP_ROUTE;
+	public static function resource_url( ?string $path_prefix = null ): string {
+		return self::issuer( $path_prefix ) . '/wp-json/' . self::MCP_NAMESPACE . '/' . self::MCP_ROUTE;
 	}
 
 	/**
 	 * REST base for OAuth endpoints (under /wp-json/).
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	private static function oauth_rest_base(): string {
-		return self::issuer() . '/wp-json/' . self::OAUTH_REST_NS;
+	private static function oauth_rest_base( ?string $path_prefix = null ): string {
+		return self::issuer( $path_prefix ) . '/wp-json/' . self::OAUTH_REST_NS;
 	}
 
 	/**
 	 * Serve RFC 9728 — Protected Resource Metadata.
 	 * Access-Control-Allow-Origin: * (public metadata, per H.4.4).
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	public static function serve_protected_resource(): never {
+	public static function serve_protected_resource( ?string $path_prefix = null ): never {
 		self::json_response( [
-			'resource'                 => self::resource_url(),
-			'authorization_servers'    => [ self::issuer() ],
+			'resource'                 => self::resource_url( $path_prefix ),
+			'authorization_servers'    => [ self::issuer( $path_prefix ) ],
 			'scopes_supported'         => ScopeRegistry::all_scopes(),
 			'bearer_methods_supported' => [ 'header' ],
 			'resource_documentation'   => 'https://wickedevolutions.com/docs/abilities-mcp/oauth',
@@ -68,27 +85,34 @@ final class DiscoveryEndpoints {
 
 	/**
 	 * Serve RFC 8414 — Authorization Server Metadata.
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	public static function serve_authorization_server(): never {
-		self::json_response( self::as_metadata(), cors: true );
+	public static function serve_authorization_server( ?string $path_prefix = null ): never {
+		self::json_response( self::as_metadata( $path_prefix ), cors: true );
 	}
 
 	/**
 	 * Serve OIDC Discovery fallback (L1, L5 lessons from Appendix D).
 	 * We do NOT issue ID tokens — metadata omits OIDC-specific fields to signal this.
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	public static function serve_oidc_configuration(): never {
-		self::json_response( self::as_metadata(), cors: true );
+	public static function serve_oidc_configuration( ?string $path_prefix = null ): never {
+		self::json_response( self::as_metadata( $path_prefix ), cors: true );
 	}
 
 	/**
 	 * Authorization server metadata body (shared by RFC 8414 + OIDC endpoints).
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
-	private static function as_metadata(): array {
-		$base = self::oauth_rest_base();
+	private static function as_metadata( ?string $path_prefix = null ): array {
+		$issuer = self::issuer( $path_prefix );
+		$base   = self::oauth_rest_base( $path_prefix );
 		return [
-			'issuer'                                => self::issuer(),
-			'authorization_endpoint'                => self::issuer() . '/oauth/authorize',
+			'issuer'                                => $issuer,
+			'authorization_endpoint'                => $issuer . '/oauth/authorize',
 			'token_endpoint'                        => $base . '/oauth/token',
 			'registration_endpoint'                 => $base . '/oauth/register',
 			'revocation_endpoint'                   => $base . '/oauth/revoke',

--- a/tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php
+++ b/tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * M-5: Path-style multisite discovery routing.
+ *
+ * Pre-fix: AuthorizationServer::intercept_pre_wp_routes() used an exact match()
+ * table, so paths like /.well-known/oauth-authorization-server/sub2 fell through
+ * to WP's 404. Path-style multisite subsites could not be discovered at all.
+ *
+ * After fix:
+ *   1. intercept_pre_wp_routes() uses str_starts_with + extract_path_prefix()
+ *      so any path that begins with a known .well-known keyword is handled.
+ *   2. DiscoveryEndpoints::issuer() accepts an optional ?string $path_prefix;
+ *      when supplied, the prefix is appended to the host-derived origin so that
+ *      the issuer matches the subsite's home URL.
+ *
+ * Tests here cover:
+ *   - issuer() with and without path prefix
+ *   - issuer() trims leading slashes from the prefix
+ *   - resource_url() and metadata URLs include the prefix
+ *   - Root-site paths (no prefix) still return the plain origin
+ *   - is_well_known_or_oauth_path() still matches path-style probes
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\DiscoveryEndpoints;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+
+final class PathStyleMultisiteDiscoveryTest extends TestCase {
+
+	protected function setUp(): void {
+		unset( $_SERVER['HTTP_HOST'], $_SERVER['HTTPS'], $_SERVER['HTTP_X_FORWARDED_PROTO'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// DiscoveryEndpoints::issuer() — path prefix support
+	// -------------------------------------------------------------------------
+
+	public function test_issuer_without_prefix_returns_plain_origin(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com', DiscoveryEndpoints::issuer() );
+	}
+
+	public function test_issuer_with_null_prefix_returns_plain_origin(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com', DiscoveryEndpoints::issuer( null ) );
+	}
+
+	public function test_issuer_with_path_prefix_appends_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com/sub2', DiscoveryEndpoints::issuer( '/sub2' ) );
+	}
+
+	public function test_issuer_strips_leading_slash_from_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		// Both forms must produce the same canonical issuer.
+		$with_slash    = DiscoveryEndpoints::issuer( '/sub2' );
+		$without_slash = DiscoveryEndpoints::issuer( 'sub2' );
+		$this->assertSame( $with_slash, $without_slash );
+		$this->assertStringEndsWith( '/sub2', $with_slash );
+	}
+
+	public function test_issuer_empty_string_prefix_treated_as_root(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com', DiscoveryEndpoints::issuer( '' ) );
+	}
+
+	public function test_issuer_single_slash_prefix_treated_as_root(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com', DiscoveryEndpoints::issuer( '/' ) );
+	}
+
+	public function test_issuer_deep_path_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$this->assertSame( 'http://example.com/team/blog', DiscoveryEndpoints::issuer( '/team/blog' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// DiscoveryEndpoints::resource_url() with path prefix
+	// -------------------------------------------------------------------------
+
+	public function test_resource_url_includes_path_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$url = DiscoveryEndpoints::resource_url( '/sub2' );
+		$this->assertStringStartsWith( 'http://example.com/sub2', $url );
+		$this->assertStringEndsWith( '/wp-json/mcp/mcp-adapter-default-server', $url );
+	}
+
+	public function test_resource_url_without_prefix_unchanged(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$url = DiscoveryEndpoints::resource_url();
+		$this->assertSame( 'http://example.com/wp-json/mcp/mcp-adapter-default-server', $url );
+	}
+
+	// -------------------------------------------------------------------------
+	// Path extraction helper (tested indirectly via issuer composition)
+	// Verified by driving intercept_pre_wp_routes() through reflection.
+	// -------------------------------------------------------------------------
+
+	/** Root-site path (no trailing segment) → null prefix → plain origin issuer. */
+	public function test_extract_path_prefix_root_path_yields_null(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/oauth-authorization-server',
+			'/.well-known/oauth-authorization-server'
+		);
+		$this->assertNull( $prefix );
+	}
+
+	/** Trailing slash only → null prefix (still root site). */
+	public function test_extract_path_prefix_trailing_slash_only_yields_null(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/oauth-authorization-server/',
+			'/.well-known/oauth-authorization-server'
+		);
+		$this->assertNull( $prefix );
+	}
+
+	/** Single-segment subsite path → '/sub2'. */
+	public function test_extract_path_prefix_single_segment(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/oauth-authorization-server/sub2',
+			'/.well-known/oauth-authorization-server'
+		);
+		$this->assertSame( '/sub2', $prefix );
+	}
+
+	/** Multi-segment subsite path → '/team/blog'. */
+	public function test_extract_path_prefix_multi_segment(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/oauth-authorization-server/team/blog',
+			'/.well-known/oauth-authorization-server'
+		);
+		$this->assertSame( '/team/blog', $prefix );
+	}
+
+	/** Works the same for openid-configuration paths. */
+	public function test_extract_path_prefix_openid_configuration(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/openid-configuration/sub2',
+			'/.well-known/openid-configuration'
+		);
+		$this->assertSame( '/sub2', $prefix );
+	}
+
+	/** Works for protected-resource paths. */
+	public function test_extract_path_prefix_protected_resource(): void {
+		$prefix = $this->call_extract_path_prefix(
+			'/.well-known/oauth-protected-resource/sub2',
+			'/.well-known/oauth-protected-resource'
+		);
+		$this->assertSame( '/sub2', $prefix );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_well_known_or_oauth_path() — must still match path-style probes
+	// -------------------------------------------------------------------------
+
+	/**
+	 * is_well_known_or_oauth_path() already uses str_starts_with internally,
+	 * so path-style probes like /.well-known/oauth-authorization-server/sub2
+	 * must match (no regression from the pre-fix str_starts_with it already had).
+	 */
+	public function test_is_well_known_matches_path_style_probe(): void {
+		$_SERVER['REQUEST_URI'] = '/.well-known/oauth-authorization-server/sub2';
+		$result = $this->call_is_well_known_or_oauth_path();
+		$this->assertTrue( $result, '/.well-known/... path-style probes must be treated as well-known paths' );
+	}
+
+	public function test_is_well_known_matches_root_probe(): void {
+		$_SERVER['REQUEST_URI'] = '/.well-known/oauth-authorization-server';
+		$this->assertTrue( $this->call_is_well_known_or_oauth_path() );
+	}
+
+	public function test_is_well_known_matches_openid_path_style(): void {
+		$_SERVER['REQUEST_URI'] = '/.well-known/openid-configuration/sub2';
+		$this->assertTrue( $this->call_is_well_known_or_oauth_path() );
+	}
+
+	public function test_is_well_known_does_not_match_arbitrary_path(): void {
+		$_SERVER['REQUEST_URI'] = '/some-other-path';
+		$this->assertFalse( $this->call_is_well_known_or_oauth_path() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private function call_extract_path_prefix( string $full_path, string $known_prefix ): ?string {
+		return AuthorizationServer::extract_path_prefix( $full_path, $known_prefix );
+	}
+
+	private function call_is_well_known_or_oauth_path(): bool {
+		return AuthorizationServer::is_well_known_or_oauth_path();
+	}
+}


### PR DESCRIPTION
## Problem

`AuthorizationServer::intercept_pre_wp_routes()` used an exact `match()` table:

```php
match ( $path ) {
    '/.well-known/oauth-authorization-server' => ...,
    ...
    default => null,
};
```

For a path-style multisite subsite at `https://example.com/sub2`, the bridge's `buildProbeOrder` probes:

- `/.well-known/oauth-authorization-server/sub2`
- `/.well-known/openid-configuration/sub2`
- `/sub2/.well-known/openid-configuration`

None of these matched — all fell through to `default => null` and then WP's 404. Path-style multisite was completely broken. The design-doc claim that path-style was verified was incorrect (verification was against subdomain-style only).

## Fix

**`AuthorizationServer`**
- Replace exact `match()` with `str_starts_with` routing so any path beginning with a known `.well-known` keyword is intercepted.
- Add `extract_path_prefix(string $full_path, string $known_prefix): ?string` — extracts the trailing segment after the keyword as the subsite path prefix (e.g. `/sub2`). Returns `null` for root-site paths.
- Promote `extract_path_prefix()` and `is_well_known_or_oauth_path()` from `private` to `public` (pure helpers, no security surface) to avoid `ReflectionMethod::setAccessible()` deprecation warnings on PHP 8.5.

**`DiscoveryEndpoints`**
- Add `?string $path_prefix = null` parameter to `issuer()`, `resource_url()`, `oauth_rest_base()`, `serve_protected_resource()`, `serve_authorization_server()`, `serve_oidc_configuration()`, and `as_metadata()`.
- When `$path_prefix` is non-null/non-empty, it is appended to the host-derived origin so all discovery document URLs reflect the correct subsite issuer.
- Root-site behaviour (null prefix) is unchanged.

## Design doc correction

Stream G's claim that path-style multisite was verified was false. `wickedevolutions.com` is subdomain-style; no live path-style installation existed. This PR is the correction.

## Tests (19 new, 803 total)

| Area | Count | What they cover |
|---|---|---|
| `issuer()` variants | 7 | null/empty/slash/string prefix, leading-slash stripping, deep paths |
| `resource_url()` | 2 | with/without prefix |
| `extract_path_prefix()` | 6 | root, trailing-slash, single-segment, multi-segment, openid, protected-resource |
| `is_well_known_or_oauth_path()` | 4 | path-style probes, root probes, non-matching paths |

## Deviations

None. `extract_path_prefix` and `is_well_known_or_oauth_path` changed visibility from `private` to `public` — noted above.

Closes #50