### PR TITLE
fix: refresh idempotent retry returns original plaintext pair (C-2)

### DIFF
--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -84,7 +84,7 @@ final class AuthorizationServer {
 	/** Run DB migration if schema version has changed. */
 	public static function maybe_run_migration(): void {
 		$version_key = 'abilities_oauth_db_version';
-		$current     = '1.0.0';
+		$current     = '1.1.0'; // 1.1.0: refresh replay blob columns (C-2).
 
 		if ( get_option( $version_key ) === $current ) {
 			return;
@@ -165,6 +165,8 @@ final class AuthorizationServer {
 			revoked          TINYINT(1)      NOT NULL DEFAULT 0,
 			rotated_at       DATETIME                 DEFAULT NULL,
 			rotated_to_hash  VARCHAR(64)              DEFAULT NULL,
+			replay_blob      LONGBLOB                 DEFAULT NULL,
+			replay_blob_iv   VARCHAR(32)              DEFAULT NULL,
 			created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
 			UNIQUE KEY token_hash (token_hash),

--- a/src/Auth/OAuth/Endpoints/TokenEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/TokenEndpoint.php
@@ -105,13 +105,9 @@ final class TokenEndpoint {
 			\token_error( 'invalid_grant', 'Refresh token is invalid, expired, or has been revoked.', 400 );
 		}
 
-		if ( isset( $result['__idempotent_retry__'] ) ) {
-			// Within 30-second grace — we can't return the original plaintext (hashed).
-			// Return an error that tells the bridge to wait and retry — it still has the token.
-			// In practice the bridge should re-use the access token it already has.
-			\token_error( 'invalid_grant', 'Refresh already rotated. Use current access token or retry after grace window.', 400 );
-		}
-
+		// Both initial rotation and idempotent retry-within-grace return the
+		// same shape — the retry path returns the original plaintext pair from
+		// the encrypted replay blob (C-2). No special-case handling needed.
 		\oauth_log_boundary( 'boundary.oauth_token_refreshed', [ 'client_id' => $client_id ] );
 
 		\token_success( $result );

--- a/src/Auth/OAuth/TokenStore.php
+++ b/src/Auth/OAuth/TokenStore.php
@@ -138,12 +138,22 @@ final class TokenStore {
 
 	/**
 	 * Rotate a refresh token. Returns a new access+refresh pair.
-	 * Implements family revocation and idempotent retry grace (H.2.1).
+	 *
+	 * Implements family revocation and idempotent retry grace (H.2.1, C-2):
+	 *
+	 *   - Within ROTATION_GRACE_SECONDS of a successful rotation, a retry with
+	 *     the same old refresh token returns the *same* plaintext pair issued
+	 *     at rotation time. The pair is stored encrypted-at-rest under a key
+	 *     derived from the old plaintext token (HKDF over AUTH_KEY); only a
+	 *     client presenting the original token can decrypt. On successful
+	 *     retry the blob is wiped (one-shot delivery).
+	 *
+	 *   - Outside the grace window, a retry is treated as replay: the entire
+	 *     token family is revoked and the blob is wiped.
 	 *
 	 * @param string $refresh_token Plaintext refresh token.
 	 * @param string $client_id     Must match stored client_id.
 	 * @return array|null Token pair on success; null triggers invalid_grant.
-	 *                    Returns 'family_revoked' key = true if family was revoked.
 	 */
 	public static function rotate( string $refresh_token, string $client_id ): ?array {
 		global $wpdb;
@@ -173,20 +183,31 @@ final class TokenStore {
 			$age           = time() - $rotated_at_ts;
 
 			if ( $age <= self::ROTATION_GRACE_SECONDS ) {
-				// Idempotent retry within grace window — return the same pair.
-				$new_access_row = $wpdb->get_row(
-					$wpdb->prepare(
-						'SELECT * FROM `' . self::access_table() . '` WHERE token_hash = %s',
-						$row->rotated_to_hash
-					)
+				// Idempotent retry within grace window — decrypt and return the
+				// original plaintext pair issued at rotation time.
+				$pair = self::decrypt_replay_blob( $row, $refresh_token );
+				if ( $pair === null ) {
+					// Blob missing or decryption failed — pre-C-2 row, or row
+					// already consumed by a prior retry. Fall through to invalid_grant.
+					return null;
+				}
+
+				// One-shot delivery: wipe the blob so a subsequent retry within
+				// the grace window cannot replay the same plaintext again.
+				$wpdb->update(
+					self::refresh_table(),
+					[ 'replay_blob' => null, 'replay_blob_iv' => null ],
+					[ 'token_hash' => $refresh_hash ],
+					[ '%s', '%s' ],
+					[ '%s' ]
 				);
-				// We can't return the plaintext (it's hashed) — tell caller to re-issue with the existing row.
-				return [ '__idempotent_retry__' => true, 'access_row' => $new_access_row, 'refresh_row' => $row ];
-			} else {
-				// Replay detected — revoke entire family.
-				self::revoke_family( $row->family_id );
-				return null; // invalid_grant — also signals family revoked.
+
+				return $pair;
 			}
+
+			// Replay detected outside grace — revoke entire family and wipe blob.
+			self::revoke_family( $row->family_id );
+			return null;
 		}
 
 		// Normal rotation path: token is valid, not yet rotated.
@@ -204,6 +225,11 @@ final class TokenStore {
 		$new_pair = self::issue( $row->client_id, (int) $row->user_id, $row->scope, $row->resource, self::ACCESS_TTL, self::REFRESH_TTL, $row->family_id );
 		$new_refresh_hash = hash( 'sha256', $new_pair['refresh_token'] );
 
+		// Encrypt the plaintext pair under a key derived from the *old* refresh
+		// token. Stored on the old row so a retry with the same old token can
+		// decrypt it within the grace window.
+		$encrypted = self::encrypt_replay_blob( $new_pair, $refresh_token );
+
 		// Mark old refresh as rotated (atomic update with condition).
 		$updated = $wpdb->update(
 			self::refresh_table(),
@@ -211,9 +237,11 @@ final class TokenStore {
 				'revoked'         => 1,
 				'rotated_at'      => gmdate( 'Y-m-d H:i:s' ),
 				'rotated_to_hash' => $new_refresh_hash,
+				'replay_blob'     => $encrypted['ciphertext'],
+				'replay_blob_iv'  => $encrypted['iv'],
 			],
 			[ 'token_hash' => $refresh_hash, 'revoked' => 0 ],
-			[ '%d', '%s', '%s' ],
+			[ '%d', '%s', '%s', '%s', '%s' ],
 			[ '%s', '%d' ]
 		);
 
@@ -223,6 +251,80 @@ final class TokenStore {
 		}
 
 		return $new_pair;
+	}
+
+	/**
+	 * Derive a 32-byte AES-256-GCM key from the old refresh token's plaintext.
+	 *
+	 * HKDF-SHA256 binds the key to (a) the plaintext of the old refresh token
+	 * — supplied by the retrying client — and (b) AUTH_KEY, which is private to
+	 * the WP installation. A DB exfiltrator without the original plaintext
+	 * cannot decrypt the blob; the original plaintext is never persisted.
+	 *
+	 * If AUTH_KEY is not defined (e.g. test environment), an empty salt is used.
+	 * The token plaintext alone still provides 256 bits of secret input.
+	 */
+	private static function replay_blob_key( string $old_refresh_plaintext ): string {
+		$salt = defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '';
+		return hash_hkdf( 'sha256', $old_refresh_plaintext, 32, 'oauth-replay-blob', $salt );
+	}
+
+	/**
+	 * Encrypt the new token pair for grace-window replay.
+	 *
+	 * @param array  $pair                  The pair returned by issue().
+	 * @param string $old_refresh_plaintext Used to derive the encryption key.
+	 * @return array{ciphertext: string, iv: string}
+	 */
+	private static function encrypt_replay_blob( array $pair, string $old_refresh_plaintext ): array {
+		$plaintext = json_encode( [
+			'access_token'  => $pair['access_token'],
+			'token_type'    => $pair['token_type'],
+			'refresh_token' => $pair['refresh_token'],
+			'expires_in'    => $pair['expires_in'],
+			'scope'         => $pair['scope'],
+		] );
+		$key = self::replay_blob_key( $old_refresh_plaintext );
+		$iv  = random_bytes( 12 );
+		$tag = '';
+		$ct  = openssl_encrypt( $plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag );
+		// ciphertext is stored as ciphertext || tag; iv stored as hex.
+		return [
+			'ciphertext' => $ct . $tag,
+			'iv'         => bin2hex( $iv ),
+		];
+	}
+
+	/**
+	 * Decrypt a stored replay blob using the supplied old refresh token plaintext.
+	 *
+	 * Returns the original token-pair array shape, or null if the blob is missing,
+	 * malformed, or the supplied plaintext does not derive the correct key.
+	 */
+	private static function decrypt_replay_blob( object $row, string $old_refresh_plaintext ): ?array {
+		if ( empty( $row->replay_blob ) || empty( $row->replay_blob_iv ) ) {
+			return null;
+		}
+		$blob = (string) $row->replay_blob;
+		if ( strlen( $blob ) < 16 ) {
+			return null;
+		}
+		$tag = substr( $blob, -16 );
+		$ct  = substr( $blob, 0, -16 );
+		$iv  = @hex2bin( (string) $row->replay_blob_iv );
+		if ( $iv === false || strlen( $iv ) !== 12 ) {
+			return null;
+		}
+		$key = self::replay_blob_key( $old_refresh_plaintext );
+		$pt  = openssl_decrypt( $ct, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag );
+		if ( $pt === false ) {
+			return null;
+		}
+		$decoded = json_decode( $pt, true );
+		if ( ! is_array( $decoded ) || ! isset( $decoded['access_token'], $decoded['refresh_token'] ) ) {
+			return null;
+		}
+		return $decoded;
 	}
 
 	/**

--- a/tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php
+++ b/tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * C-2: Refresh idempotent retry returns the original plaintext pair.
+ *
+ * Pre-fix: TokenStore::rotate() recognised the retry-within-grace case but
+ * returned a sentinel ['__idempotent_retry__' => true, ...] which TokenEndpoint
+ * converted into a 400 invalid_grant. The bridge's retry-on-network-blip path
+ * (the very scenario H.2.1's grace was designed for) hit that 400, marked the
+ * site auth_status=expired, and evicted the operator to reauth.
+ *
+ * After fix (Option A — encrypt-at-rest):
+ *   - On rotation, the new plaintext pair is AES-256-GCM encrypted under a key
+ *     HKDF-derived from the old refresh token plaintext + AUTH_KEY. Ciphertext
+ *     and IV are stored on the old refresh token row (replay_blob,
+ *     replay_blob_iv columns).
+ *   - On retry within ROTATION_GRACE_SECONDS, the stored blob is decrypted
+ *     using the supplied old plaintext and the original pair is returned.
+ *   - The blob is wiped after one successful retry (one-shot delivery). A
+ *     second retry within the same grace window finds an empty blob and
+ *     returns null. (Same plaintext can't be redelivered indefinitely.)
+ *   - A retry outside the grace window revokes the entire family.
+ *
+ * Security argument:
+ *   - The decryption key is bound to the old refresh token's plaintext, which
+ *     is provided by the retrying client itself in the request body and never
+ *     persisted server-side. A DB exfiltrator with access to the blob alone
+ *     cannot decrypt it without ALSO having that plaintext.
+ *   - AUTH_KEY (server-private) is mixed into HKDF salt so two installations
+ *     with the same token plaintext (impossibly improbable, but theoretical)
+ *     produce different keys.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\TokenStore;
+
+final class TokenStoreReplayBlobTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		$this->original_wpdb = $GLOBALS['wpdb'];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+	}
+
+	// -------------------------------------------------------------------------
+	// Initial rotation populates replay_blob / replay_blob_iv
+	// -------------------------------------------------------------------------
+
+	public function test_initial_rotation_writes_replay_blob_and_iv(): void {
+		$family_id       = 'fam_' . bin2hex( random_bytes( 8 ) );
+		$old_plaintext   = bin2hex( random_bytes( 32 ) );
+		$old_hash        = hash( 'sha256', $old_plaintext );
+
+		$updates = new \stdClass();
+		$updates->captured = [];
+
+		$GLOBALS['wpdb'] = $this->make_normal_rotate_wpdb( $old_hash, $family_id, $updates );
+
+		$result = TokenStore::rotate( $old_plaintext, 'cl_test' );
+
+		$this->assertNotNull( $result, 'Normal rotation must succeed' );
+		$this->assertArrayHasKey( 'access_token', $result );
+		$this->assertArrayHasKey( 'refresh_token', $result );
+		$this->assertArrayHasKey( 'token_type', $result );
+		$this->assertSame( 'Bearer', $result['token_type'] );
+
+		// One of the captured updates is the rotation marker — it must include
+		// non-empty replay_blob and replay_blob_iv.
+		$rotation_update = null;
+		foreach ( $updates->captured as $upd ) {
+			if ( isset( $upd['rotated_to_hash'] ) ) {
+				$rotation_update = $upd;
+				break;
+			}
+		}
+		$this->assertNotNull( $rotation_update, 'Rotation marker UPDATE must be issued' );
+		$this->assertArrayHasKey( 'replay_blob', $rotation_update );
+		$this->assertArrayHasKey( 'replay_blob_iv', $rotation_update );
+		$this->assertNotEmpty( $rotation_update['replay_blob'], 'replay_blob must be non-empty ciphertext' );
+		$this->assertSame( 24, strlen( $rotation_update['replay_blob_iv'] ), 'IV is 12 bytes hex-encoded → 24 chars' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Idempotent retry decrypts blob → returns original plaintext pair
+	// -------------------------------------------------------------------------
+
+	public function test_idempotent_retry_returns_original_plaintext_pair(): void {
+		// Pre-stage: encrypt a known pair under a known plaintext, then drive
+		// rotate() through the retry path with a row that already contains the
+		// blob and a recent rotated_at.
+		$old_plaintext = bin2hex( random_bytes( 32 ) );
+		$old_hash      = hash( 'sha256', $old_plaintext );
+		$family_id     = 'fam_' . bin2hex( random_bytes( 8 ) );
+
+		$original_pair = [
+			'access_token'  => 'access_' . bin2hex( random_bytes( 16 ) ),
+			'token_type'    => 'Bearer',
+			'refresh_token' => 'refresh_' . bin2hex( random_bytes( 16 ) ),
+			'expires_in'    => 86400,
+			'scope'         => 'abilities:content:read',
+		];
+		$blob = $this->encrypt_pair( $original_pair, $old_plaintext );
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb( $old_hash, $family_id, $blob, rotated_age: 5 );
+
+		$result = TokenStore::rotate( $old_plaintext, 'cl_test' );
+
+		$this->assertNotNull( $result, 'Retry within grace must succeed' );
+		$this->assertSame( $original_pair['access_token'], $result['access_token'], 'Original access_token returned verbatim' );
+		$this->assertSame( $original_pair['refresh_token'], $result['refresh_token'], 'Original refresh_token returned verbatim' );
+		$this->assertSame( 'Bearer', $result['token_type'] );
+		$this->assertSame( 86400, $result['expires_in'] );
+		$this->assertSame( 'abilities:content:read', $result['scope'] );
+	}
+
+	public function test_idempotent_retry_wipes_blob_after_delivery(): void {
+		$old_plaintext = bin2hex( random_bytes( 32 ) );
+		$old_hash      = hash( 'sha256', $old_plaintext );
+		$family_id     = 'fam_' . bin2hex( random_bytes( 8 ) );
+		$pair          = [
+			'access_token'  => 'a',
+			'token_type'    => 'Bearer',
+			'refresh_token' => 'r',
+			'expires_in'    => 86400,
+			'scope'         => 's',
+		];
+		$blob = $this->encrypt_pair( $pair, $old_plaintext );
+
+		$updates = new \stdClass();
+		$updates->captured = [];
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb( $old_hash, $family_id, $blob, rotated_age: 5, updates: $updates );
+
+		TokenStore::rotate( $old_plaintext, 'cl_test' );
+
+		// One update must NULL both blob columns.
+		$found_wipe = false;
+		foreach ( $updates->captured as $upd ) {
+			if ( array_key_exists( 'replay_blob', $upd ) && array_key_exists( 'replay_blob_iv', $upd ) && $upd['replay_blob'] === null ) {
+				$found_wipe = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_wipe, 'Blob columns must be NULL-ed after one-shot delivery' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Retry without blob → null (no panic, no fresh family revocation either)
+	// -------------------------------------------------------------------------
+
+	public function test_grace_retry_without_blob_returns_null(): void {
+		$old_plaintext = bin2hex( random_bytes( 32 ) );
+		$old_hash      = hash( 'sha256', $old_plaintext );
+		$family_id     = 'fam_legacy';
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb( $old_hash, $family_id, blob: null, rotated_age: 5 );
+
+		$this->assertNull( TokenStore::rotate( $old_plaintext, 'cl_test' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Replay outside grace → null + family revoke (existing behaviour, unchanged)
+	// -------------------------------------------------------------------------
+
+	public function test_replay_outside_grace_revokes_family(): void {
+		$old_plaintext = bin2hex( random_bytes( 32 ) );
+		$old_hash      = hash( 'sha256', $old_plaintext );
+		$family_id     = 'fam_replay';
+
+		$queries = new \stdClass();
+		$queries->captured = [];
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb(
+			$old_hash,
+			$family_id,
+			blob: $this->encrypt_pair(
+				[ 'access_token' => 'x', 'token_type' => 'Bearer', 'refresh_token' => 'y', 'expires_in' => 1, 'scope' => '' ],
+				$old_plaintext
+			),
+			rotated_age: 60, // Outside 30s grace.
+			query_capture: $queries
+		);
+
+		$this->assertNull( TokenStore::rotate( $old_plaintext, 'cl_test' ) );
+
+		$family_revoke_seen = false;
+		foreach ( $queries->captured as $q ) {
+			if ( str_contains( $q, 'family_id' ) && stripos( $q, 'UPDATE' ) !== false ) {
+				$family_revoke_seen = true;
+				break;
+			}
+		}
+		$this->assertTrue( $family_revoke_seen, 'Replay outside grace must trigger family-revoke UPDATE' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Wrong plaintext (key mismatch) → null
+	// -------------------------------------------------------------------------
+
+	public function test_grace_retry_with_wrong_plaintext_returns_null(): void {
+		$correct_plaintext = bin2hex( random_bytes( 32 ) );
+		$wrong_plaintext   = bin2hex( random_bytes( 32 ) );
+		// The DB lookup is by token_hash of the plaintext supplied to rotate(),
+		// so to exercise "row-found-but-decrypt-fails" we craft a row whose
+		// hash matches the wrong plaintext, but whose blob was encrypted under
+		// the correct one.
+		$wrong_hash = hash( 'sha256', $wrong_plaintext );
+
+		$pair = [ 'access_token' => 'a', 'token_type' => 'Bearer', 'refresh_token' => 'r', 'expires_in' => 1, 'scope' => '' ];
+		$blob = $this->encrypt_pair( $pair, $correct_plaintext );
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb( $wrong_hash, 'fam_x', $blob, rotated_age: 5 );
+
+		$this->assertNull( TokenStore::rotate( $wrong_plaintext, 'cl_test' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tampered ciphertext → null (GCM tag verification)
+	// -------------------------------------------------------------------------
+
+	public function test_tampered_ciphertext_fails_decryption(): void {
+		$old_plaintext = bin2hex( random_bytes( 32 ) );
+		$old_hash      = hash( 'sha256', $old_plaintext );
+
+		$pair = [ 'access_token' => 'a', 'token_type' => 'Bearer', 'refresh_token' => 'r', 'expires_in' => 1, 'scope' => '' ];
+		$blob = $this->encrypt_pair( $pair, $old_plaintext );
+		// Flip a byte in the middle of the ciphertext (not in the auth tag).
+		$blob['ciphertext'][5] = chr( ord( $blob['ciphertext'][5] ) ^ 0x01 );
+
+		$GLOBALS['wpdb'] = $this->make_grace_retry_wpdb( $old_hash, 'fam_t', $blob, rotated_age: 5 );
+
+		$this->assertNull( TokenStore::rotate( $old_plaintext, 'cl_test' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Encrypt a token pair the same way TokenStore does internally, so the
+	 * test can pre-populate a row with a valid blob.
+	 */
+	private function encrypt_pair( array $pair, string $old_refresh_plaintext ): array {
+		$salt = defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '';
+		$key  = hash_hkdf( 'sha256', $old_refresh_plaintext, 32, 'oauth-replay-blob', $salt );
+		$iv   = random_bytes( 12 );
+		$tag  = '';
+		$pt   = json_encode( [
+			'access_token'  => $pair['access_token'],
+			'token_type'    => $pair['token_type'],
+			'refresh_token' => $pair['refresh_token'],
+			'expires_in'    => $pair['expires_in'],
+			'scope'         => $pair['scope'],
+		] );
+		$ct   = openssl_encrypt( $pt, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag );
+		return [
+			'ciphertext' => $ct . $tag,
+			'iv'         => bin2hex( $iv ),
+		];
+	}
+
+	/**
+	 * $wpdb stub for the normal rotation path (token not yet rotated, still valid).
+	 * Captures every update() call so the test can assert the rotation marker
+	 * includes replay_blob / replay_blob_iv.
+	 */
+	private function make_normal_rotate_wpdb( string $old_hash, string $family_id, object $updates ): object {
+		$future = gmdate( 'Y-m-d H:i:s', time() + 7776000 );
+
+		return new class( $old_hash, $family_id, $future, $updates ) {
+			public string $prefix    = 'wp_';
+			public int    $insert_id = 99;
+			private string $old_hash;
+			private string $family_id;
+			private string $future;
+			private object $updates;
+			private int    $get_row_calls = 0;
+
+			public function __construct( string $h, string $f, string $exp, object $u ) {
+				$this->old_hash  = $h;
+				$this->family_id = $f;
+				$this->future    = $exp;
+				$this->updates   = $u;
+			}
+
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_var( $q )         { return null; }
+			public function get_results( $q )     { return array(); }
+			public function query( $sql )         { return true; }
+
+			public function get_row( $q ) {
+				$this->get_row_calls++;
+				if ( $this->get_row_calls === 1 ) {
+					return (object) [
+						'token_hash'      => $this->old_hash,
+						'client_id'       => 'cl_test',
+						'user_id'         => 1,
+						'scope'           => 'abilities:content:read',
+						'resource'        => 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+						'family_id'       => $this->family_id,
+						'expires_at'      => $this->future,
+						'revoked'         => 0,
+						'rotated_at'      => null,
+						'rotated_to_hash' => null,
+						'replay_blob'     => null,
+						'replay_blob_iv'  => null,
+					];
+				}
+				return null;
+			}
+
+			public function update( $table, $data, $where, $format = null, $where_format = null ) {
+				$this->updates->captured[] = $data;
+				return 1;
+			}
+
+			public function insert( $t, $d, $f = null ) { return 1; }
+		};
+	}
+
+	/**
+	 * $wpdb stub for the retry-within-grace path. Returns a row whose
+	 * rotated_at is $rotated_age seconds ago, with $blob populated.
+	 *
+	 * @param array<string,string>|null $blob   ['ciphertext' => ..., 'iv' => ...] or null
+	 * @param object|null               $updates Capture for update() calls
+	 * @param object|null               $query_capture Capture for query() calls
+	 */
+	private function make_grace_retry_wpdb(
+		string $old_hash,
+		string $family_id,
+		?array $blob,
+		int    $rotated_age,
+		?object $updates       = null,
+		?object $query_capture = null
+	): object {
+		$rotated_at = gmdate( 'Y-m-d H:i:s', time() - $rotated_age );
+		$future     = gmdate( 'Y-m-d H:i:s', time() + 7776000 );
+
+		return new class( $old_hash, $family_id, $rotated_at, $future, $blob, $updates, $query_capture ) {
+			public string $prefix    = 'wp_';
+			public int    $insert_id = 99;
+			private string $old_hash;
+			private string $family_id;
+			private string $rotated_at;
+			private string $future;
+			private ?array $blob;
+			private ?object $updates;
+			private ?object $query_capture;
+
+			public function __construct( string $h, string $f, string $rat, string $exp, ?array $b, ?object $u, ?object $qc ) {
+				$this->old_hash      = $h;
+				$this->family_id     = $f;
+				$this->rotated_at    = $rat;
+				$this->future        = $exp;
+				$this->blob          = $b;
+				$this->updates       = $u;
+				$this->query_capture = $qc;
+			}
+
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_var( $q )         { return null; }
+			public function get_results( $q )     { return array(); }
+
+			public function query( $sql ) {
+				if ( $this->query_capture ) {
+					$this->query_capture->captured[] = $sql;
+				}
+				return 1;
+			}
+
+			public function get_row( $q ) {
+				return (object) [
+					'token_hash'      => $this->old_hash,
+					'client_id'       => 'cl_test',
+					'user_id'         => 1,
+					'scope'           => 'abilities:content:read',
+					'resource'        => 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+					'family_id'       => $this->family_id,
+					'expires_at'      => $this->future,
+					'revoked'         => 1,
+					'rotated_at'      => $this->rotated_at,
+					'rotated_to_hash' => 'newhash',
+					'replay_blob'     => $this->blob['ciphertext'] ?? null,
+					'replay_blob_iv'  => $this->blob['iv'] ?? null,
+				];
+			}
+
+			public function update( $table, $data, $where, $format = null, $where_format = null ) {
+				if ( $this->updates ) {
+					$this->updates->captured[] = $data;
+				}
+				return 1;
+			}
+
+			public function insert( $t, $d, $f = null ) { return 1; }
+		};
+	}
+}

--- a/tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php
+++ b/tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php
@@ -108,28 +108,29 @@ final class TokenStoreRotationFamilyTest extends TestCase {
 		$result = TokenStore::rotate( $plaintext_token, 'cl_test' );
 
 		$this->assertNotNull( $result, 'rotate() must succeed' );
-		$this->assertNotSame( '__idempotent_retry__', array_key_first( $result ) );
+		$this->assertArrayHasKey( 'access_token', $result, 'rotate() returns the standard token-pair shape (post-C-2)' );
 		$this->assertSame( $parent_family, $captured->family_id, 'rotate() must pass parent family_id into issue()' );
 	}
 
 	/**
-	 * Rotating the same token twice within the grace window returns the idempotent
-	 * response and must NOT generate a second new family_id.
+	 * A retry within the grace window without a stored replay blob (e.g. a row
+	 * created before the C-2 schema upgrade, or an already-consumed retry)
+	 * resolves to invalid_grant — never generates a new family_id.
+	 *
+	 * Full plaintext-replay coverage lives in TokenStoreReplayBlobTest (C-2).
 	 */
-	public function test_idempotent_retry_does_not_change_family_id(): void {
+	public function test_grace_retry_without_blob_returns_null(): void {
 		$parent_family   = 'deadbeefcafe00112233445566778899';
 		$plaintext_token = bin2hex( random_bytes( 32 ) );
 		$token_hash      = hash( 'sha256', $plaintext_token );
 
-		// Simulate a token that was already rotated 5 seconds ago (within 30s grace).
+		// Simulate a token that was already rotated 5 seconds ago (within 30s grace),
+		// but with no replay blob recorded (legacy row).
 		$GLOBALS['wpdb'] = $this->make_already_rotated_wpdb( $token_hash, $parent_family, rotated_age: 5 );
 
 		$result = TokenStore::rotate( $plaintext_token, 'cl_test' );
 
-		$this->assertNotNull( $result );
-		$this->assertArrayHasKey( '__idempotent_retry__', $result, 'Must return idempotent-retry sentinel' );
-		// No new issue() call is made, so family_id is untouched — the assertion is
-		// that we reached here without null-pointer / type errors.
+		$this->assertNull( $result, 'No blob → null (invalid_grant); no new issue() and no new family_id' );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

H.2.1 (binding) requires that a retry within the grace window return the *same* access+refresh pair issued at \`rotated_at\`. \`TokenStore::rotate()\` detected the retry case but returned a sentinel \`['__idempotent_retry__' => true, ...]\` which \`TokenEndpoint::handle_refresh\` converted into:

\`\`\`php
\token_error( 'invalid_grant', 'Refresh already rotated. Use current access token or retry after grace window.', 400 );
\`\`\`

The bridge's \`token-manager.js\` treats any 4xx as terminal failure → marks the site \`auth_status=expired\` → tells the operator to run \`reauth\`. The bridge's retry/backoff path (500ms / 1500ms, 2 retries within ~3s) is supposed to be *safe* per H.2.1's grace window. The first request to race a network blip would:

1. Server: rotate, mint new pair, response dropped on the wire.
2. Bridge: retry with same refresh token within 3s.
3. Server: detects \`rotated_at < 30s\` → returns 400 invalid_grant.
4. Bridge: marks expired, evicts operator to reauth.

Phase 6 acceptance for H.2.1 was a false PASS — only the happy refresh was tested, not the network-blip retry.

## Design choice — Option A (encrypt-at-rest)

Issue #51 listed three options. **Option A chosen.**

| Option | Why not |
|---|---|
| **B** — Treat pre-rotation token as still valid for 30s | Issue itself flags: \"opens a window we'd need to argue about.\" Multiple plaintext refresh tokens valid simultaneously breaks the rotation invariant. |
| **C** — Bridge-side keychain replay (H-7) | Requires bridge changes; this PR is adapter-only and the queue cannot ship a coordinated bridge fix. |
| **A** — Encrypt-at-rest | Preserves rotation invariant. Decryption key bound to caller-supplied old plaintext + \`AUTH_KEY\`; not derivable from DB alone. Self-contained adapter change. |

## Implementation

### Schema (db_version 1.1.0)

Two new nullable columns on \`kl_oauth_refresh_tokens\`:

- \`replay_blob LONGBLOB DEFAULT NULL\` — AES-256-GCM ciphertext of \`json_encode(pair)\`, with the 16-byte GCM tag appended.
- \`replay_blob_iv VARCHAR(32) DEFAULT NULL\` — 12-byte IV, hex-encoded.

\`dbDelta\` handles the in-place upgrade idempotently. Pre-1.1.0 rows have NULL blobs and gracefully fall through to the legacy invalid_grant path until rotated.

### Key derivation

\`\`\`php
hash_hkdf( 'sha256', \$old_refresh_plaintext, 32, 'oauth-replay-blob', AUTH_KEY )
\`\`\`

- Input keying material = the old refresh token's plaintext, supplied by the retrying client in the request body. Never persisted server-side.
- Salt = \`AUTH_KEY\` (server-private, per WP install).
- Info = \`'oauth-replay-blob'\` (domain separation).

A DB exfiltrator with only the blob cannot decrypt without ALSO obtaining the original refresh-token plaintext from the client.

### Flow

| Path | Behaviour |
|---|---|
| Normal rotation | Encrypt new pair under old plaintext, store blob+IV alongside \`rotated_at\` / \`rotated_to_hash\` in the same UPDATE |
| Retry within grace | Decrypt blob using caller-supplied old plaintext, return original pair, NULL the blob (one-shot delivery) |
| Retry outside grace | Revoke entire family (unchanged) |
| Retry without blob (legacy row, or already-consumed) | null → invalid_grant |
| Retry with wrong plaintext / tampered blob | GCM verification fails → null → invalid_grant |

### Endpoint simplification

\`TokenEndpoint::handle_refresh\` no longer has a special \`__idempotent_retry__\` branch. Both initial rotation and grace retry return the same pair shape; the endpoint just calls \`token_success(\$result)\`.

## Tests (810 total, 8 new in TokenStoreReplayBlobTest, 1 updated in TokenStoreRotationFamilyTest)

| Test | What it covers |
|---|---|
| \`test_initial_rotation_writes_replay_blob_and_iv\` | Rotation marker UPDATE includes non-empty ciphertext + 24-char hex IV |
| \`test_idempotent_retry_returns_original_plaintext_pair\` | Retry decrypts blob, returns the exact \`access_token\` / \`refresh_token\` / \`token_type\` / \`expires_in\` / \`scope\` |
| \`test_idempotent_retry_wipes_blob_after_delivery\` | One-shot — blob columns NULLed after successful retry |
| \`test_grace_retry_without_blob_returns_null\` | Legacy rows without blob → invalid_grant (no panic) |
| \`test_replay_outside_grace_revokes_family\` | Existing family-revoke path still triggers |
| \`test_grace_retry_with_wrong_plaintext_returns_null\` | Wrong plaintext → key mismatch → null |
| \`test_tampered_ciphertext_fails_decryption\` | GCM tag verification catches bit-flip |

\`TokenStoreRotationFamilyTest::test_idempotent_retry_does_not_change_family_id\` renamed to \`test_grace_retry_without_blob_returns_null\` to reflect post-C-2 contract; assertion updated.

## Deviations

None from the issue's design space. Option A chosen as recommended.

Closes #51