### PR TITLE
fix: OAuth boundary plumbing — M-2 / M-4 / M-6 / L-1 bundle

### DIFF
--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -71,7 +71,12 @@ final class AuthorizationServer {
 		// Bearer token authentication (priority 20 — after WP core's auth).
 		add_filter( 'determine_current_user', [ self::class, 'authenticate_bearer' ], 20 );
 
-		// Reset OAuthRequestContext at the start of each REST request.
+		// Reset OAuthRequestContext at the start of every WP-bootstrapped request,
+		// REST or otherwise (M-2). Priority 0 fires before any other init handler
+		// could read the singleton. The duplicate rest_api_init wiring is kept so
+		// that requests reaching REST routing still get a clean context even on
+		// init handlers that ran before reset.
+		add_action( 'init', [ OAuthRequestContext::class, 'reset' ], 0 );
 		add_action( 'rest_api_init', [ OAuthRequestContext::class, 'reset' ], 1 );
 
 		// Phase 3: capture OAuth boundary events for the Connected Bridges audit slice.
@@ -254,17 +259,18 @@ final class AuthorizationServer {
 	/** Register REST routes for DCR, token, revoke. */
 	public static function register_rest_routes(): void {
 		$ns = self::REST_NS;
+		$gate = [ self::class, 'rest_host_allowlist_gate' ];
 
 		register_rest_route( $ns, '/oauth/register', [
 			[
 				'methods'             => 'GET',
 				'callback'            => [ RegisterEndpoint::class, 'handle_get' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 			[
 				'methods'             => 'POST',
 				'callback'            => [ RegisterEndpoint::class, 'handle_post' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 		] );
 
@@ -272,12 +278,12 @@ final class AuthorizationServer {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ TokenEndpoint::class, 'handle_get' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 			[
 				'methods'             => 'POST',
 				'callback'            => [ TokenEndpoint::class, 'handle_post' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 		] );
 
@@ -285,14 +291,41 @@ final class AuthorizationServer {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ RevokeEndpoint::class, 'handle_get' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 			[
 				'methods'             => 'POST',
 				'callback'            => [ RevokeEndpoint::class, 'handle_post' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => $gate,
 			],
 		] );
+	}
+
+	/**
+	 * REST permission_callback that mirrors the pre-WP host check (M-6).
+	 *
+	 * Without this, /wp-json/mcp/oauth/{register,token,revoke} accepted requests
+	 * from any host while /oauth/authorize and /.well-known/* were properly
+	 * gated — a real defense bypass of the host allowlist control.
+	 *
+	 * Returns a WP_Error (404) on rejection to give the same response shape as
+	 * the pre-WP path's `status_header(404); exit`. Logs the same boundary
+	 * event so an unknown-host rejection is visible regardless of which entry
+	 * point the request hit.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public static function rest_host_allowlist_gate() {
+		$host = $_SERVER['HTTP_HOST'] ?? '';
+		if ( OAuthHostAllowlist::is_allowed( $host ) ) {
+			return true;
+		}
+		\oauth_log_boundary( 'boundary.oauth_host_rejected', [ 'ip' => \oauth_client_ip() ] );
+		return new \WP_Error(
+			'rest_no_route',
+			'No route was found matching the URL and request method.',
+			[ 'status' => 404 ]
+		);
 	}
 
 	/**
@@ -352,7 +385,9 @@ final class AuthorizationServer {
 			return $user_id;
 		}
 
-		$bearer_token = substr( $auth_header, 7 );
+		// L-1: trim() the token so a misbehaving proxy that adds whitespace
+		// (e.g. "Bearer  TOKEN" with two spaces) doesn't silently break auth.
+		$bearer_token = trim( substr( $auth_header, 7 ) );
 		if ( ! $bearer_token ) {
 			return $user_id;
 		}

--- a/src/Auth/OAuth/Endpoints/TokenEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/TokenEndpoint.php
@@ -49,7 +49,12 @@ final class TokenEndpoint {
 	private static function handle_auth_code( array $params ): never {
 		$code         = sanitize_text_field( $params['code'] ?? '' );
 		$client_id    = sanitize_text_field( $params['client_id'] ?? '' );
-		$redirect_uri = esc_url_raw( $params['redirect_uri'] ?? '' );
+		// M-4: do NOT esc_url_raw() the redirect_uri here. The storage path in
+		// AuthorizeRequestValidator only trim()s the raw value, so any mutation
+		// applied here breaks AuthorizationCodeStore::consume()'s timing-safe
+		// hash_equals() compare. Match the storage-side normalisation exactly.
+		$raw_redirect = $params['redirect_uri'] ?? '';
+		$redirect_uri = is_string( $raw_redirect ) ? trim( $raw_redirect ) : '';
 		$code_verifier = $params['code_verifier'] ?? '';
 
 		if ( ! $code || ! $client_id || ! $redirect_uri || ! $code_verifier ) {

--- a/tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php
+++ b/tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * L-1: Bearer token must be trim()ed after extraction.
+ *
+ * Pre-fix: $bearer_token = substr( $auth_header, 7 ); — a header like
+ * "Authorization: Bearer  TOKEN" (two spaces) becomes " TOKEN", hashed as
+ * " TOKEN", which never matches a stored token. A misbehaving proxy that
+ * adds whitespace silently breaks auth and the operator sees invalid_token
+ * with no obvious cause.
+ *
+ * After fix: $bearer_token = trim( substr( $auth_header, 7 ) ); — leading,
+ * trailing, and tab whitespace is stripped before hashing.
+ *
+ * Drives AuthorizationServer::authenticate_bearer() with a header that has
+ * extra whitespace, and asserts the bound user_id is returned (i.e. the
+ * trimmed token hashed correctly).
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+if ( ! defined( 'REST_REQUEST' ) ) {
+	define( 'REST_REQUEST', true );
+}
+
+final class BearerHeaderTrimTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->original_wpdb = $GLOBALS['wpdb'];
+		OAuthRequestContext::reset();
+		// Target the MCP resource so authenticate_bearer doesn't no-op via C-1.
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server';
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+		unset( $_SERVER['REQUEST_URI'], $_SERVER['HTTP_AUTHORIZATION'] );
+		OAuthRequestContext::reset();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a $wpdb stub that returns a valid token row only when the
+	 * lookup hash matches the canonical (un-padded) token. Used to assert
+	 * that authenticate_bearer hashed the trimmed value.
+	 */
+	private function install_token_row_for_canonical( string $canonical_plaintext, int $user_id ): void {
+		$canonical_hash = hash( 'sha256', $canonical_plaintext );
+		$expires_at     = ( new \DateTimeImmutable( '+1 hour', new \DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
+
+		$GLOBALS['wpdb'] = new class( $canonical_hash, $user_id, $expires_at ) {
+			public string $prefix = 'wp_';
+			private string $expected_hash;
+			private int    $user_id;
+			private string $expires_at;
+
+			public function __construct( string $h, int $uid, string $exp ) {
+				$this->expected_hash = $h;
+				$this->user_id       = $uid;
+				$this->expires_at    = $exp;
+			}
+
+			public function prepare( $q, ...$a ) {
+				// $a[0] is the hash bound by TokenStore::lookup_access_token.
+				$this->captured_hash = $a[0] ?? '';
+				return $q;
+			}
+
+			public string $captured_hash = '';
+
+			public function get_row( $q ) {
+				if ( $this->captured_hash !== $this->expected_hash ) {
+					return null;
+				}
+				$row = new \stdClass();
+				$row->id          = 7;
+				$row->user_id     = $this->user_id;
+				$row->client_id   = 'cl_test';
+				$row->scope       = 'abilities:content:read';
+				$row->resource    = 'https://example.com/wp-json/mcp/mcp-adapter-default-server';
+				$row->token_hash  = $this->expected_hash;
+				$row->expires_at  = $this->expires_at;
+				$row->revoked     = 0;
+				return $row;
+			}
+
+			public function get_results( $q ) { return array(); }
+			public function get_var( $q )     { return null; }
+			public function update( $t, $d, $w, $f = null, $wf = null ) { return 1; }
+			public function insert( $t, $d, $f = null )                  { return 1; }
+			public function query( $sql )                                 { return true; }
+		};
+	}
+
+	public function test_token_with_extra_leading_space_authenticates(): void {
+		$canonical = bin2hex( random_bytes( 16 ) );
+		$this->install_token_row_for_canonical( $canonical, 42 );
+		// Two spaces after "Bearer" — bug case.
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer  ' . $canonical;
+
+		$result = AuthorizationServer::authenticate_bearer( false );
+
+		$this->assertSame(
+			42,
+			$result,
+			'Header "Bearer  TOKEN" (extra space) must trim to TOKEN and authenticate the bound user (L-1)'
+		);
+	}
+
+	public function test_token_with_trailing_whitespace_authenticates(): void {
+		$canonical = bin2hex( random_bytes( 16 ) );
+		$this->install_token_row_for_canonical( $canonical, 99 );
+		// Trailing newline — observed in the wild from sloppy curl / proxy chains.
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $canonical . "\n";
+
+		$this->assertSame( 99, AuthorizationServer::authenticate_bearer( false ) );
+	}
+
+	public function test_token_with_tab_whitespace_authenticates(): void {
+		$canonical = bin2hex( random_bytes( 16 ) );
+		$this->install_token_row_for_canonical( $canonical, 13 );
+		$_SERVER['HTTP_AUTHORIZATION'] = "Bearer \t" . $canonical . "\t";
+
+		$this->assertSame( 13, AuthorizationServer::authenticate_bearer( false ) );
+	}
+
+	public function test_clean_bearer_header_still_authenticates(): void {
+		// Regression: the trim must not break the canonical "Bearer TOKEN" form.
+		$canonical = bin2hex( random_bytes( 16 ) );
+		$this->install_token_row_for_canonical( $canonical, 7 );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $canonical;
+
+		$this->assertSame( 7, AuthorizationServer::authenticate_bearer( false ) );
+	}
+}

--- a/tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php
+++ b/tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * M-2: OAuthRequestContext::reset() must fire on every WP-bootstrapped request.
+ *
+ * Pre-fix: reset was wired only to rest_api_init. PHP-FPM workers handling
+ * a sequence of REST + non-REST requests retained stale singleton state. A
+ * future caller adding has_scope() / is_oauth_request() on a non-REST surface
+ * (cron, admin-ajax, CLI) would read context from a prior REST request on
+ * the same worker.
+ *
+ * After fix: reset is also wired to init priority 0 — fires for every
+ * WP-bootstrapped request. The rest_api_init wiring is kept as belt-and-suspenders.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+final class OAuthRequestContextResetTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['wp_test_actions'] = array();
+		// Flip the boot guard so we can re-run boot() in the test. The static
+		// property is private; we read by name not value to keep the test from
+		// caring about other properties on the class.
+		$ref = new \ReflectionClass( AuthorizationServer::class );
+		$prop = $ref->getProperty( 'booted' );
+		$prop->setValue( null, false );
+
+		AuthorizationServer::boot();
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wp_test_actions'] = array();
+	}
+
+	public function test_reset_is_wired_to_init_priority_zero(): void {
+		$found = false;
+		foreach ( $GLOBALS['wp_test_actions'] as $entry ) {
+			if (
+				$entry['hook'] === 'init'
+				&& $entry['priority'] === 0
+				&& is_array( $entry['callback'] )
+				&& $entry['callback'][0] === OAuthRequestContext::class
+				&& $entry['callback'][1] === 'reset'
+			) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'OAuthRequestContext::reset() must be wired to init priority 0 (M-2)' );
+	}
+
+	public function test_reset_is_still_wired_to_rest_api_init(): void {
+		// Belt-and-suspenders: the rest_api_init wiring is retained.
+		$found = false;
+		foreach ( $GLOBALS['wp_test_actions'] as $entry ) {
+			if (
+				$entry['hook'] === 'rest_api_init'
+				&& is_array( $entry['callback'] )
+				&& $entry['callback'][0] === OAuthRequestContext::class
+				&& $entry['callback'][1] === 'reset'
+			) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'rest_api_init reset wiring must be preserved' );
+	}
+
+	public function test_reset_clears_set_context(): void {
+		// Functional verification that reset() actually clears state — the
+		// behaviour the wiring is meant to invoke between requests.
+		OAuthRequestContext::set(
+			user_id: 7,
+			scopes: array( 'abilities:content:read' ),
+			resource: 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			client_id: 'cl_test',
+			token_id: 1
+		);
+		$this->assertTrue( OAuthRequestContext::is_oauth_request() );
+
+		OAuthRequestContext::reset();
+		$this->assertFalse( OAuthRequestContext::is_oauth_request(), 'After reset, no OAuth context should remain' );
+	}
+}

--- a/tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php
+++ b/tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * M-6: REST routes for /wp-json/mcp/oauth/{register,token,revoke} must run
+ * the OAuthHostAllowlist gate as their permission_callback.
+ *
+ * Pre-fix: only the pre-WP path (/oauth/authorize, /.well-known/*) checked
+ * the allowlist. The REST endpoints used '__return_true' as their callback,
+ * so a request from an unknown host could register clients, exchange codes,
+ * and revoke tokens — defeating the allowlist.
+ *
+ * After fix: AuthorizationServer::rest_host_allowlist_gate() runs before
+ * each REST callback; unknown hosts get a 404 WP_Error and a
+ * boundary.oauth_host_rejected event is logged.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthHostAllowlist;
+
+final class RestRouteHostAllowlistTest extends TestCase {
+
+	protected function setUp(): void {
+		OAuthHostAllowlist::reset();
+		$GLOBALS['wp_test_actions_invoked'] = array();
+		// Keep global host clean; each test sets its own.
+		unset( $_SERVER['HTTP_HOST'] );
+	}
+
+	protected function tearDown(): void {
+		OAuthHostAllowlist::reset();
+		$GLOBALS['wp_test_actions_invoked'] = array();
+		unset( $_SERVER['HTTP_HOST'] );
+	}
+
+	public function test_gate_allows_request_from_allowed_host(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		$_SERVER['HTTP_HOST'] = 'allowed.example.com';
+
+		$result = AuthorizationServer::rest_host_allowlist_gate();
+		$this->assertTrue( $result, 'Allowed hosts must pass the gate (return true)' );
+	}
+
+	public function test_gate_rejects_request_from_unknown_host(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		$_SERVER['HTTP_HOST'] = 'attacker.example.com';
+
+		$result = AuthorizationServer::rest_host_allowlist_gate();
+		$this->assertInstanceOf( \WP_Error::class, $result, 'Unknown host must return WP_Error' );
+		$this->assertSame( 'rest_no_route', $result->get_error_code() );
+	}
+
+	public function test_gate_returns_404_status_on_rejection(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		$_SERVER['HTTP_HOST'] = 'attacker.example.com';
+
+		$result = AuthorizationServer::rest_host_allowlist_gate();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 404, $data['status'] ?? 0, 'Rejection status must be 404 (parity with pre-WP path)' );
+	}
+
+	public function test_gate_emits_boundary_event_on_rejection(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		$_SERVER['HTTP_HOST'] = 'attacker.example.com';
+
+		AuthorizationServer::rest_host_allowlist_gate();
+
+		$saw_event = false;
+		foreach ( $GLOBALS['wp_test_actions_invoked'] as $entry ) {
+			if (
+				$entry['hook'] === 'mcp_adapter_boundary_event'
+				&& isset( $entry['args'][0] )
+				&& $entry['args'][0] === 'boundary.oauth_host_rejected'
+			) {
+				$saw_event = true;
+				break;
+			}
+		}
+		$this->assertTrue( $saw_event, 'Rejection must emit boundary.oauth_host_rejected (parity with pre-WP path)' );
+	}
+
+	public function test_gate_does_not_emit_boundary_event_on_allow(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		$_SERVER['HTTP_HOST'] = 'allowed.example.com';
+
+		AuthorizationServer::rest_host_allowlist_gate();
+
+		$saw_event = false;
+		foreach ( $GLOBALS['wp_test_actions_invoked'] as $entry ) {
+			if (
+				$entry['hook'] === 'mcp_adapter_boundary_event'
+				&& isset( $entry['args'][0] )
+				&& $entry['args'][0] === 'boundary.oauth_host_rejected'
+			) {
+				$saw_event = true;
+				break;
+			}
+		}
+		$this->assertFalse( $saw_event, 'Allowed requests must not log a host_rejected event' );
+	}
+
+	public function test_gate_with_missing_http_host_is_rejected(): void {
+		OAuthHostAllowlist::override( array( 'allowed.example.com' ) );
+		// HTTP_HOST not set — empty string is not in the allowlist.
+		$result = AuthorizationServer::rest_host_allowlist_gate();
+		$this->assertInstanceOf( \WP_Error::class, $result, 'Missing HTTP_HOST must be rejected' );
+	}
+}

--- a/tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php
+++ b/tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * M-4: TokenEndpoint must NOT esc_url_raw() the redirect_uri before the
+ * timing-safe compare in AuthorizationCodeStore::consume().
+ *
+ * Pre-fix:
+ *   $redirect_uri = esc_url_raw( $params['redirect_uri'] ?? '' );
+ *   ...
+ *   AuthorizationCodeStore::consume( $code, $client_id, $redirect_uri, $verifier );
+ *
+ * The storage path (AuthorizeRequestValidator::str()) only trim()s the raw value.
+ * Any character esc_url_raw mutates (or any rule change) breaks hash_equals on
+ * exchange — the operator gets invalid_grant despite a perfectly valid code.
+ *
+ * After fix: raw input is read with only trim() applied, matching the storage path.
+ *
+ * The test drives TokenEndpoint::handle_post() end-to-end with a redirect_uri
+ * containing a character esc_url_raw mutates (a literal space). With a stub
+ * $wpdb whose stored redirect_uri is the un-mutated value, consume() must
+ * succeed → token_success → TokenResponseSentinel with status 200.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationCodeStore;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\TokenEndpoint;
+use WickedEvolutions\McpAdapter\Tests\TokenResponseSentinel;
+
+final class TokenEndpointRedirectUriRawTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		$this->original_wpdb = $GLOBALS['wpdb'];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+	}
+
+	/**
+	 * The token endpoint must accept a raw redirect_uri string verbatim (post-trim)
+	 * — no esc_url_raw mutation.
+	 *
+	 * If TokenEndpoint applied esc_url_raw, the encoded form would no longer
+	 * hash_equals the stored raw form, AuthorizationCodeStore::consume() would
+	 * return null, and the endpoint would call token_error('invalid_grant', ..., 400).
+	 */
+	public function test_consume_succeeds_with_unmutated_raw_redirect_uri(): void {
+		$verifier = str_repeat( 'a', 50 );
+		// Compute the matching code_challenge (S256) the way the validator does.
+		$challenge = AuthorizationCodeStore::compute_challenge( $verifier );
+
+		// A redirect_uri that esc_url_raw would mutate at least minimally
+		// (space → +, fragment removal, control char strip). Use a value
+		// containing a literal space to maximise visibility.
+		$raw_redirect = 'https://client.example.com/cb?x=a b';
+
+		$plaintext_code = bin2hex( random_bytes( 16 ) );
+
+		$GLOBALS['wpdb'] = $this->install_consume_wpdb( $plaintext_code, $raw_redirect, $challenge );
+
+		$req = new \WP_REST_Request();
+		$req->set_param( 'grant_type', 'authorization_code' );
+		$req->set_param( 'code', $plaintext_code );
+		$req->set_param( 'client_id', 'cl_test' );
+		$req->set_param( 'redirect_uri', $raw_redirect );
+		$req->set_param( 'code_verifier', $verifier );
+
+		try {
+			TokenEndpoint::handle_post( $req );
+			$this->fail( 'Expected TokenResponseSentinel' );
+		} catch ( TokenResponseSentinel $e ) {
+			$this->assertSame(
+				200,
+				$e->status,
+				'redirect_uri must round-trip without esc_url_raw mutation: got status ' . $e->status . ', body=' . json_encode( $e->body )
+			);
+			$this->assertArrayHasKey( 'access_token', $e->body );
+		}
+	}
+
+	/**
+	 * Sanity guard: confirm esc_url_raw really does mutate the chosen test value.
+	 * If WP's esc_url_raw is patched in the future to be a no-op on this input,
+	 * this test would silently pass even with the bug present.
+	 */
+	public function test_chosen_redirect_uri_would_be_mutated_by_esc_url_raw(): void {
+		$raw = 'https://client.example.com/cb?x=a b';
+		$this->assertNotSame(
+			$raw,
+			esc_url_raw( $raw ),
+			'Test sentinel: this redirect_uri value must be mutated by esc_url_raw — otherwise the M-4 test cannot detect a regression'
+		);
+	}
+
+	/**
+	 * Stub $wpdb that:
+	 *   - Returns a code row matching $code with stored redirect_uri = $expected_raw.
+	 *   - Accepts the mark-as-used UPDATE.
+	 *   - Accepts the access/refresh INSERTs from TokenStore::issue().
+	 *
+	 * No client lookup is needed — TokenEndpoint::handle_auth_code calls
+	 * ClientRegistry::find() before consume(); we satisfy that with a row whose
+	 * client_id matches.
+	 */
+	private function install_consume_wpdb( string $code, string $expected_redirect, string $challenge ): object {
+		$code_hash = hash( 'sha256', $code );
+
+		return new class( $code_hash, $expected_redirect, $challenge ) {
+			public string $prefix    = 'wp_';
+			public int    $insert_id = 99;
+			private string $code_hash;
+			private string $expected_redirect;
+			private string $challenge;
+			private int    $get_row_calls = 0;
+
+			public function __construct( string $h, string $r, string $c ) {
+				$this->code_hash         = $h;
+				$this->expected_redirect = $r;
+				$this->challenge         = $c;
+			}
+
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_var( $q )         { return null; }
+			public function get_results( $q )     { return array(); }
+			public function query( $sql )         { return true; }
+
+			public function get_row( $q ) {
+				$this->get_row_calls++;
+				// Call 1: ClientRegistry::find() — return a non-revoked client.
+				if ( $this->get_row_calls === 1 ) {
+					return (object) [
+						'client_id'     => 'cl_test',
+						'client_name'   => 'Test',
+						'redirect_uris' => json_encode( [ $this->expected_redirect ] ),
+						'revoked_at'    => null,
+					];
+				}
+				// Call 2: AuthorizationCodeStore::consume() lookup.
+				if ( $this->get_row_calls === 2 ) {
+					return (object) [
+						'id'                    => 1,
+						'code_hash'             => $this->code_hash,
+						'client_id'             => 'cl_test',
+						'user_id'               => 7,
+						'redirect_uri'          => $this->expected_redirect,
+						'scope'                 => 'abilities:content:read',
+						'resource'              => 'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+						'code_challenge'        => $this->challenge,
+						'code_challenge_method' => 'S256',
+						'expires_at'            => gmdate( 'Y-m-d H:i:s', time() + 600 ),
+						'used'                  => 0,
+					];
+				}
+				return null;
+			}
+
+			public function update( $t, $d, $w, $f = null, $wf = null ) { return 1; }
+			public function insert( $t, $d, $f = null )                  { return 1; }
+		};
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -225,13 +225,31 @@ if ( ! function_exists( 'remove_all_filters' ) ) {
 
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $hook, ...$args ) {
-		// Tests don't assert action invocations.
+		// Capture into a global buffer so tests can assert action emissions
+		// without standing up a full filter pipeline. Tests opt in by reading
+		// $GLOBALS['wp_test_actions_invoked']; the array is cleared per-test.
+		if ( ! isset( $GLOBALS['wp_test_actions_invoked'] ) ) {
+			$GLOBALS['wp_test_actions_invoked'] = array();
+		}
+		$GLOBALS['wp_test_actions_invoked'][] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
 		return null;
 	}
 }
 
 if ( ! function_exists( 'add_action' ) ) {
 	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		// Record so tests can assert specific (hook, callback, priority) wiring.
+		if ( ! isset( $GLOBALS['wp_test_actions'] ) ) {
+			$GLOBALS['wp_test_actions'] = array();
+		}
+		$GLOBALS['wp_test_actions'][] = array(
+			'hook'     => $hook,
+			'callback' => $callback,
+			'priority' => $priority,
+		);
 		return true;
 	}
 }


### PR DESCRIPTION
## Why bundled

All four findings live at the OAuth request boundary and touch the same wiring surfaces (`AuthorizationServer::boot()`, `TokenEndpoint::handle_auth_code`, REST route registration, bearer extraction). Splitting would create four near-identical PRs that all touch the same files.

## Findings

### M-2 — `OAuthRequestContext::reset()` only fired on `rest_api_init`

PHP-FPM workers handling REST + non-REST requests in sequence retained stale singleton state across requests. C-1 narrowed bearer auth to MCP paths but `has_scope()` / `is_oauth_request()` are still callable from anywhere. A future caller adding a scope check on cron / admin-ajax / CLI would read context from a prior REST request on the same worker.

**Fix:** add `init` priority 0 wiring. `init` fires for every WP-bootstrapped request. The `rest_api_init` wiring is kept as belt-and-suspenders.

### M-4 — `esc_url_raw($params['redirect_uri'])` mutated before timing-safe compare

[`TokenEndpoint::handle_auth_code`](src/Auth/OAuth/Endpoints/TokenEndpoint.php) called `esc_url_raw()` on the redirect_uri before passing it to `AuthorizationCodeStore::consume()`, which compares via `hash_equals()` against the stored value. The storage path ([`AuthorizeRequestValidator::str()`](src/Auth/OAuth/Consent/AuthorizeRequestValidator.php)) only `trim()`s the raw input. Asymmetric normalisation = brittle compare.

**Fix:** `$redirect_uri = is_string($raw_redirect) ? trim($raw_redirect) : '';` — exactly mirror the storage-side normalisation. The value has no SQL injection surface (passed through prepared statements via `hash_equals`).

### M-6 — REST routes bypassed `OAuthHostAllowlist` (real defense bypass)

`/oauth/authorize` and `/.well-known/*` were gated against the allowlist via the pre-WP path. `/wp-json/mcp/oauth/register|token|revoke` used `permission_callback => '__return_true'` and accepted requests from any host. A request from an unknown host could register clients, exchange codes, and revoke tokens.

**Fix:** add `AuthorizationServer::rest_host_allowlist_gate()` and wire it as the `permission_callback` on all three REST routes. Unknown hosts get a 404 `WP_Error` (parity with the pre-WP `status_header(404); exit`) and the same `boundary.oauth_host_rejected` event is emitted.

### L-1 — Bearer token not trimmed

`$bearer_token = substr($auth_header, 7);` — a header like `Authorization: Bearer  TOKEN` (two spaces) became ` TOKEN`, hashed as ` TOKEN`, never matched any stored token. A misbehaving proxy that added whitespace silently broke auth and the operator saw `invalid_token` with no obvious cause.

**Fix:** `$bearer_token = trim(substr($auth_header, 7));`. One word.

## Test bootstrap upgrades

Two stubs in [tests/bootstrap.php](tests/bootstrap.php) were upgraded to capture-mode for these tests (no behaviour change for existing tests):

- `add_action()` records `(hook, callback, priority)` tuples into `$GLOBALS['wp_test_actions']` — used by the M-2 wiring assertion.
- `do_action()` captures emissions into `$GLOBALS['wp_test_actions_invoked']` — used by the M-6 boundary-event assertion.

## Tests (15 new, 825 total)

| Test | Covers |
|---|---|
| `OAuthRequestContextResetTest` ×3 | M-2 — init priority 0 wiring, rest_api_init wiring preserved, reset clears state |
| `TokenEndpointRedirectUriRawTest` ×2 | M-4 — round-trip succeeds with a redirect_uri that esc_url_raw would mutate, plus a sentinel guard ensuring the test value really is mutated |
| `RestRouteHostAllowlistTest` ×6 | M-6 — allowed host passes, unknown host returns WP_Error with status 404, boundary event emitted on rejection but not on allow, missing HTTP_HOST rejected |
| `BearerHeaderTrimTest` ×4 | L-1 — extra leading space, trailing newline, tabs, and clean canonical form all authenticate the bound user |

## Deviations

None. All four findings shipped exactly as specified.

Closes #62