### PR TITLE
fix: redirect_uri loopback compare normalises query (H-9)

### DIFF
--- a/src/Auth/OAuth/ClientRegistry.php
+++ b/src/Auth/OAuth/ClientRegistry.php
@@ -87,8 +87,23 @@ final class ClientRegistry {
 
 	/**
 	 * Validate that a redirect_uri was registered for this client.
-	 * Loopback URIs match ignoring port (OAuth 2.1 §10.3.3).
-	 * Non-loopback URIs require exact string match.
+	 *
+	 * Loopback URIs match ignoring port (OAuth 2.1 §10.3.3 / RFC 8252 §7.3).
+	 * Loopback query strings are compared *normalized* (H-9): same key/value
+	 * pairs in any order, with consistent percent-encoding, are treated as
+	 * equivalent. Path is still compared strictly — `/callback` and
+	 * `/callback/` are distinct because most native HTTP servers route them
+	 * to different handlers, and normalising would mask client misconfig.
+	 *
+	 * Non-loopback URIs require exact string match (H.1.2 — exact-match is
+	 * the safer rule for redirect URIs that may carry tokens/codes through
+	 * proxies/CDNs/browser cache layers).
+	 *
+	 * Fragments are rejected on the candidate side (RFC 6749 §3.1.2: "The
+	 * endpoint URI MUST NOT include a fragment component."). A registered
+	 * URI that itself contains a fragment is also rejected as a non-match,
+	 * but the storage side already treats fragments as invalid input via
+	 * the registration validator — this is belt-and-suspenders.
 	 *
 	 * @param object $client   Row from find().
 	 * @param string $uri      URI to validate.
@@ -102,6 +117,15 @@ final class ClientRegistry {
 		}
 
 		$parsed_candidate = parse_url( $uri );
+		if ( ! is_array( $parsed_candidate ) ) {
+			return false;
+		}
+
+		// RFC 6749 §3.1.2: redirect_uri MUST NOT include a fragment (H-9).
+		if ( isset( $parsed_candidate['fragment'] ) ) {
+			return false;
+		}
+
 		$candidate_host   = $parsed_candidate['host'] ?? '';
 		$candidate_scheme = $parsed_candidate['scheme'] ?? '';
 		$candidate_path   = $parsed_candidate['path'] ?? '/';
@@ -118,13 +142,19 @@ final class ClientRegistry {
 
 		foreach ( $registered as $registered_uri ) {
 			if ( $is_loopback && $candidate_scheme === 'http' ) {
-				// Loopback: match scheme + host + path + query, ignore port (OAuth 2.1 §10.3.3).
+				// Loopback: match scheme + host + path; ignore port; normalize query (H-9).
 				$parsed_reg = parse_url( $registered_uri );
+				if ( ! is_array( $parsed_reg ) ) {
+					continue;
+				}
+				if ( isset( $parsed_reg['fragment'] ) ) {
+					continue;
+				}
 				if (
 					( $parsed_reg['scheme'] ?? '' ) === $candidate_scheme &&
 					( $parsed_reg['host'] ?? '' ) === $candidate_host &&
 					( $parsed_reg['path'] ?? '/' ) === $candidate_path &&
-					( $parsed_reg['query'] ?? '' ) === $candidate_query
+					self::query_normalize( $parsed_reg['query'] ?? '' ) === self::query_normalize( $candidate_query )
 				) {
 					return true;
 				}
@@ -137,6 +167,30 @@ final class ClientRegistry {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Normalize a query string for loopback redirect_uri comparison (H-9).
+	 *
+	 * - parse_str canonicalizes percent-encoding (%20 ↔ + → space) into the
+	 *   key/value pairs.
+	 * - ksort orders keys deterministically so ?foo=1&bar=2 ≡ ?bar=2&foo=1.
+	 * - http_build_query re-encodes with PHP_QUERY_RFC3986 so the canonical
+	 *   form is always %20 (never +) for spaces.
+	 * - Empty query and missing query both collapse to '' via the upstream
+	 *   `?? ''` default.
+	 */
+	private static function query_normalize( string $query ): string {
+		if ( $query === '' ) {
+			return '';
+		}
+		$parts = [];
+		parse_str( $query, $parts );
+		if ( ! is_array( $parts ) || $parts === [] ) {
+			return '';
+		}
+		ksort( $parts );
+		return http_build_query( $parts, '', '&', PHP_QUERY_RFC3986 );
 	}
 
 	/**

--- a/tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php
+++ b/tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * H-9: redirect_uri loopback compare must be RFC 8252 §7.3 compliant.
+ *
+ * Pre-fix: ClientRegistry::redirect_uri_valid() compared loopback query
+ * strings byte-for-byte. ?foo=1&bar=2 vs ?bar=2&foo=1, hello%20world vs
+ * hello+world, and trailing-? differences all rejected.
+ *
+ * After fix: query strings on loopback URIs are normalized via
+ * parse_str → ksort → http_build_query(PHP_QUERY_RFC3986). Same key/value
+ * pairs in any order with any equivalent percent-encoding compare equal.
+ *
+ * Path normalisation is intentionally NOT applied — `/callback` and
+ * `/callback/` remain distinct so client misconfiguration surfaces.
+ *
+ * Fragments on candidate or registered URI cause an outright reject
+ * (RFC 6749 §3.1.2: "redirect_uri MUST NOT include a fragment component").
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\ClientRegistry;
+
+final class RedirectUriNormalizeTest extends TestCase {
+
+	private function client( array $registered ): object {
+		$c = new \stdClass();
+		$c->redirect_uris = json_encode( $registered );
+		return $c;
+	}
+
+	// -------------------------------------------------------------------------
+	// Query order normalisation
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_query_param_order_normalized(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?foo=1&bar=2' ] );
+		// Same pairs, opposite order — must validate.
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?bar=2&foo=1' ) );
+	}
+
+	public function test_loopback_three_param_order_normalized(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?a=1&b=2&c=3' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?c=3&a=1&b=2' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Percent-encoding normalisation
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_space_encoded_as_percent20_or_plus_equivalent(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?key=hello%20world' ] );
+		// Plus-encoded form (form-encoding default) must match percent-20 form.
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?key=hello+world' ) );
+	}
+
+	public function test_loopback_percent_encoded_punctuation_normalized(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?email=a%40b.com' ] );
+		// Unencoded @ — parse_str / http_build_query round-trip should produce equivalent normalised form.
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?email=a@b.com' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Trailing ? equivalence
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_no_query_matches_empty_query(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		// parse_url returns no 'query' key for trailing-? — both sides normalise to ''.
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Different values still reject (the safety guarantee)
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_different_value_rejected(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?foo=1' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?foo=2' ) );
+	}
+
+	public function test_loopback_extra_param_rejected(): void {
+		// Don't accept a superset of registered params.
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?injected=evil' ) );
+	}
+
+	public function test_loopback_missing_param_rejected(): void {
+		// And don't accept a subset either.
+		$c = $this->client( [ 'http://127.0.0.1/cb?foo=1&bar=2' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?foo=1' ) );
+	}
+
+	public function test_loopback_different_key_rejected(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?foo=1' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?other=1' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Path normalisation NOT applied (intentional)
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_path_trailing_slash_still_distinct(): void {
+		// Documenting the deliberate non-normalisation choice — see PR body.
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		$this->assertFalse(
+			ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb/' ),
+			'Path normalisation is intentionally NOT applied; trailing slash remains distinct'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Fragment rejection (RFC 6749 §3.1.2)
+	// -------------------------------------------------------------------------
+
+	public function test_candidate_with_fragment_rejected_loopback(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb#frag' ) );
+	}
+
+	public function test_candidate_with_fragment_rejected_https(): void {
+		$c = $this->client( [ 'https://bridge.example.com/cb' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'https://bridge.example.com/cb#frag' ) );
+	}
+
+	public function test_candidate_with_empty_fragment_rejected(): void {
+		// Even an empty fragment ('#' with nothing after) must reject.
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb#' ) );
+	}
+
+	public function test_registered_with_fragment_does_not_match(): void {
+		// If somehow a fragmented URI was stored, it must not match anything.
+		$c = $this->client( [ 'http://127.0.0.1/cb#frag' ] );
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Existing port-ignore behaviour preserved
+	// -------------------------------------------------------------------------
+
+	public function test_loopback_port_still_ignored(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:1234/cb' ) );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:65535/cb' ) );
+	}
+
+	public function test_loopback_port_ignored_with_query(): void {
+		$c = $this->client( [ 'http://127.0.0.1/cb?state_seed=abc' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://127.0.0.1:9876/cb?state_seed=abc' ) );
+	}
+
+	public function test_loopback_ipv6(): void {
+		$c = $this->client( [ 'http://[::1]/cb?x=1' ] );
+		$this->assertTrue( ClientRegistry::redirect_uri_valid( $c, 'http://[::1]:5555/cb?x=1' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Non-loopback: exact-match preserved
+	// -------------------------------------------------------------------------
+
+	public function test_https_exact_match_still_required(): void {
+		$c = $this->client( [ 'https://bridge.example.com/cb?foo=1' ] );
+		// Non-loopback: query order matters (exact-match rule, H.1.2).
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'https://bridge.example.com/cb?foo=1&extra=2' ) );
+	}
+
+	public function test_https_non_normalized_compare(): void {
+		$c = $this->client( [ 'https://bridge.example.com/cb?a=1&b=2' ] );
+		// Different order — non-loopback exact-match rejects.
+		$this->assertFalse( ClientRegistry::redirect_uri_valid( $c, 'https://bridge.example.com/cb?b=2&a=1' ) );
+	}
+}


### PR DESCRIPTION
## Problem

[`ClientRegistry::redirect_uri_valid()`](src/Auth/OAuth/ClientRegistry.php) compared loopback query strings byte-for-byte:

\`\`\`php
( $parsed_reg['query'] ?? '' ) === $candidate_query
\`\`\`

This rejected:
- query-string parameter order differences (\`?foo=1&bar=2\` vs \`?bar=2&foo=1\`)
- percent-encoding differences (\`?key=hello%20world\` vs \`?key=hello+world\`)
- trailing \`?\` (empty query string vs no query string)

OAuth 2.1 §10.3.3 / RFC 8252 §7.3 require loopback URIs to be compared modulo port — and the spirit of the rule is that semantically-equivalent loopback URIs validate. Byte-for-byte query-string compare was over-strict.

**Latent.** Current bridge sends no query on loopback redirects. Fix is preemptive for future query-bearing clients.

## Fix

### Loopback path: query normalised

New private helper `query_normalize()`:

\`\`\`php
parse_str( $query, $parts );
ksort( $parts );
return http_build_query( $parts, '', '&', PHP_QUERY_RFC3986 );
\`\`\`

- \`parse_str\` canonicalises percent-encoding (\`%20\` ↔ \`+\` → space) into the key/value pairs.
- \`ksort\` orders keys deterministically.
- \`http_build_query\` with \`PHP_QUERY_RFC3986\` re-encodes consistently (always \`%20\`, never \`+\`).

Loopback compare is now: scheme + host + path strict, port ignored, query normalised on both sides.

### Non-loopback: unchanged

Exact-match remains the rule (H.1.2). Public-internet redirect URIs may carry tokens through proxies / CDNs / browser caches; exact-match is the safer rule.

### Fragments rejected

[RFC 6749 §3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2): "The endpoint URI MUST NOT include a fragment component." Both candidate and registered URIs are now rejected if a fragment is present. Belt-and-suspenders against silently-accepting non-conformant clients.

### Path normalisation NOT applied (intentional)

The issue asked to "confirm with RFC 8252 §7.3 reading" whether trailing-slash equivalence (\`/callback\` ≡ \`/callback/\`) should normalise. **Decision: leave path strict.** RFC 8252 §7.3 mandates port-only laxity, not path. Most native HTTP servers (Node http, Go net/http, Python's stdlib) route \`/callback\` and \`/callback/\` to different handlers. Normalising would mask real client misconfiguration. Documented inline and in test.

## Tests (19 new, 844 total)

| Group | Tests | What they cover |
|---|---|---|
| Query order | 2 | Two-param and three-param order swaps both validate |
| Percent encoding | 2 | \`%20\` ↔ \`+\` for space; \`%40\` ↔ \`@\` for punctuation |
| Trailing \`?\` | 1 | Registered without query matches candidate with empty query |
| Reject differences | 4 | Different value, extra param, missing param, different key all rejected |
| Path strictness | 1 | \`/cb\` vs \`/cb/\` still distinct (documents the deliberate non-normalisation) |
| Fragments | 4 | Candidate fragment, https fragment, empty fragment, registered fragment — all rejected |
| Port + IPv6 regression | 3 | Existing port-ignore on IPv4 and IPv6 plus query still works |
| Non-loopback regression | 2 | https exact-match still rejects different order and superset |

## Deviations

Path normalisation **not** applied — see above for rationale. The issue flagged this as a "confirm with RFC 8252" item, not a hard requirement. If the orchestrator wants \`/cb\` ≡ \`/cb/\`, file a follow-up issue.

Closes #63