### PR TITLE
fix: M-8 LastConsentLookup explicit fail-closed on Throwable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Security — Medium
+- **M-8: `LastConsentLookup::timestamp_for()` is now explicitly fail-closed.** Audit (2026-04-27) flagged the unhandled-throw path: a third-party `pre_option_*` / `option_*` filter that throws would bubble to a 500 instead of routing the operator to consent. Verified the existing flow was already implicitly fail-closed (null return → `ConsentDecisionEvaluator` branch 1 → `RENDER_FULL` with reason `first_authorization`). Locked the contract: any `\Throwable` from the option backend now returns null, which is strictly safer than a 500. `days_since()` inherits the same protection. (#65)
+
 ## [1.4.3] - 2026-04-28
 
 OAuth 2.1 second-pass hardening release. Five additional findings from external security review fixed in two PRs (#71, #72).

--- a/src/Auth/OAuth/Consent/LastConsentLookup.php
+++ b/src/Auth/OAuth/Consent/LastConsentLookup.php
@@ -46,9 +46,24 @@ final class LastConsentLookup {
 
 	/**
 	 * Most recent interactive-consent UNIX timestamp, or null if none recorded.
+	 *
+	 * Fail-closed contract (M-8 audit, 2026-04-27):
+	 *   - Missing option / empty stored value → null.
+	 *   - Any Throwable from the WP option backend (incl. third-party
+	 *     `pre_option_*` / `option_*` filters that may throw) → null.
+	 *
+	 * Null routes {@see ConsentDecisionEvaluator::evaluate()} to RENDER_FULL
+	 * with reason `first_authorization` — never auto-approve. Returning null
+	 * on Throwable is strictly safer than letting the exception bubble to a
+	 * 500: a 500 leaks "consent infrastructure broken" to the bridge, while
+	 * null silently routes the operator to the consent screen.
 	 */
 	public static function timestamp_for( string $client_id, int $user_id ): ?int {
-		$value = get_option( self::key( $client_id, $user_id ), null );
+		try {
+			$value = get_option( self::key( $client_id, $user_id ), null );
+		} catch ( \Throwable $e ) {
+			return null;
+		}
 		if ( null === $value || '' === $value ) {
 			return null;
 		}

--- a/tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php
+++ b/tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php
@@ -10,12 +10,15 @@ declare( strict_types=1 );
 namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth\Consent;
 
 use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecision;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\ConsentDecisionEvaluator;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\LastConsentLookup;
 
 final class LastConsentLookupTest extends TestCase {
 
 	protected function setUp(): void {
 		$GLOBALS['wp_test_options'] = array();
+		$GLOBALS['wp_test_filters'] = array();
 	}
 
 	public function test_returns_null_when_no_consent_recorded(): void {
@@ -49,5 +52,77 @@ final class LastConsentLookupTest extends TestCase {
 		$now = 1_700_000_000;
 		LastConsentLookup::record( 'client-x', 1, $now + 3600 );
 		$this->assertSame( 0, LastConsentLookup::days_since( 'client-x', 1, $now ) );
+	}
+
+	// ─── M-8 fail-closed contract ───────────────────────────────────────────────
+	//
+	// Audit (2026-04-27): "no fail-closed if the lookup throws."
+	// Verified contract: any Throwable from the option backend → null →
+	// ConsentDecisionEvaluator routes to RENDER_FULL ('first_authorization'),
+	// never auto-approve.
+
+	public function test_returns_null_when_pre_option_filter_throws(): void {
+		$client_id = 'client-x';
+		$user_id   = 1;
+		$key       = 'abilities_oauth_last_consent_' . sha1( $client_id . '|' . $user_id );
+
+		add_filter( 'pre_option_' . $key, function () {
+			throw new \RuntimeException( 'simulated filter failure' );
+		} );
+
+		$this->assertNull( LastConsentLookup::timestamp_for( $client_id, $user_id ) );
+	}
+
+	public function test_days_since_returns_null_when_lookup_throws(): void {
+		// days_since() reads via timestamp_for(), so it inherits the fail-closed
+		// contract. Locked in so a future refactor can't leak an unhandled throw.
+		$client_id = 'client-x';
+		$user_id   = 1;
+		$key       = 'abilities_oauth_last_consent_' . sha1( $client_id . '|' . $user_id );
+
+		add_filter( 'pre_option_' . $key, function () {
+			throw new \RuntimeException( 'simulated filter failure' );
+		} );
+
+		$this->assertNull( LastConsentLookup::days_since( $client_id, $user_id, time() ) );
+	}
+
+	public function test_throwing_lookup_routes_consent_decision_to_full_consent(): void {
+		// End-to-end fail-closed verification: even with a prior token grant of
+		// the exact same scope set well within the silent cap, a throwing lookup
+		// must route to RENDER_FULL — never AUTO_APPROVE.
+		$client_id = 'client-y';
+		$user_id   = 2;
+		$key       = 'abilities_oauth_last_consent_' . sha1( $client_id . '|' . $user_id );
+
+		add_filter( 'pre_option_' . $key, function () {
+			throw new \RuntimeException( 'simulated boom' );
+		} );
+
+		$last_interactive = LastConsentLookup::timestamp_for( $client_id, $user_id );
+		$this->assertNull( $last_interactive );
+
+		$decision = ConsentDecisionEvaluator::evaluate(
+			array( 'abilities:content:read' ),
+			array( 'abilities:content:read' ), // prior grant on a non-sensitive scope
+			$last_interactive,
+			time(),
+			365
+		);
+
+		$this->assertSame( ConsentDecision::RENDER_FULL, $decision->action );
+		$this->assertSame( 'first_authorization', $decision->reason );
+	}
+
+	public function test_returns_null_when_stored_value_is_empty_string(): void {
+		// Defensive: an option corrupted to an empty string must not coerce to
+		// 0 and produce $silent_seconds == $now → fall through into auto-approve
+		// territory if the cap were ever zero. Empty-string → null → RENDER_FULL.
+		$client_id = 'client-x';
+		$user_id   = 1;
+		$key       = 'abilities_oauth_last_consent_' . sha1( $client_id . '|' . $user_id );
+		$GLOBALS['wp_test_options'][ $key ] = '';
+
+		$this->assertNull( LastConsentLookup::timestamp_for( $client_id, $user_id ) );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,13 @@ if ( ! isset( $GLOBALS['wp_test_options'] ) ) {
 
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $option, $default = false ) {
+		// Mirror WP semantics: a `pre_option_*` filter that returns anything
+		// other than `false` short-circuits the lookup. Lets tests simulate
+		// option-backend failures (e.g. throwing filters) without a real DB.
+		$pre = apply_filters( 'pre_option_' . $option, false, $option, $default );
+		if ( false !== $pre ) {
+			return $pre;
+		}
 		return $GLOBALS['wp_test_options'][ $option ] ?? $default;
 	}
 }


### PR DESCRIPTION
Closes #65.

## Summary

- Verified the M-8 audit finding: `LastConsentLookup::timestamp_for()` is implicitly fail-closed today (null return → `ConsentDecisionEvaluator` branch 1 → `RENDER_FULL` with reason `first_authorization`), but a `\Throwable` from the WP option backend (third-party `pre_option_*` / `option_*` filter, etc.) would bubble to a 500 instead of routing to consent.
- Locked the contract: `timestamp_for()` now wraps `get_option()` in `try/catch \Throwable`, returning null on any exception. Strictly safer than a 500 — operator gets the consent screen, never auto-approve. `days_since()` inherits the protection (it reads via `timestamp_for()`).
- Tests added: filter-throws → null; `days_since()` throws → null; end-to-end fail-closed (throw → null → `RENDER_FULL`); empty-string stored value → null.
- Bootstrap `get_option()` stub now mirrors WP's `pre_option_*` filter short-circuit so tests can simulate option-backend failures without a real DB. Verified zero existing tests register `pre_option_*` / `option_*` filters; all 848 tests green locally on PHP 8.5.

## Verification trace (from issue body's three questions)

1. **Does `timestamp_for()` ever throw, or return null on lookup failure?**
   It returned `(int) get_option(...)`; `get_option()` itself doesn't throw in WP core (returns the supplied default on missing options), but the surrounding `pre_option_*` / `option_*` filter chain runs arbitrary third-party code that can throw. After this PR: any `\Throwable` is caught and reduced to null.
2. **Try/catch upstream?** None previously. This PR adds the explicit catch at the only sane boundary — the option read itself.
3. **What's the default branch in the consent decision tree?** `ConsentDecisionEvaluator::evaluate()` branch 1 (`null === \$last_interactive_unix`) → `RENDER_FULL` with reason `first_authorization`. Locked in by `test_renders_full_consent_when_no_prior_interactive_grant` (existing) plus new `test_throwing_lookup_routes_consent_decision_to_full_consent` (this PR).

Net: the audit-flagged "lookup throws" path is now explicitly fail-closed and proven by tests.

## Test plan

- [x] `composer test` green locally on PHP 8.5 (848 tests, 2218 assertions; +4 new tests in `LastConsentLookupTest`).
- [ ] CI matrix green on PHP 8.2 + 8.3.

## Deviations

None. Issue body recommended trace-then-fix-only-if-fail-open; trace confirmed implicit fail-closed; PR adds explicit fail-closed contract + tests (strictly better than implicit). The bootstrap `get_option()` enhancement is a test-infra dependency for the throw-path test and matches WP semantics exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)