### PR TITLE
refactor: L-2 TokenStore::touch deferred-write via shutdown flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Performance / tech-debt
+- **L-2: `TokenStore::touch()` no longer issues a synchronous `UPDATE` per request.** Previously every authenticated MCP request blocked on a `wpdb->update` of `last_used_at` on the access-token table — a hot row under burst load. `touch()` now stamps a per-request in-memory buffer keyed by `token_hash` and registers a `register_shutdown_function` flush on first use. Multiple touches for the same token within one request coalesce into one UPDATE; distinct tokens flush as N UPDATEs after the response is sent. Cross-request batching (transient + cron flush, issue body's Option A) is intentionally not introduced — the simpler shutdown-flush refactor is sufficient at current scale and leaves Option A as a future move without changing the `touch()` API. (#67)
+
 ### Security — Medium
 - **M-8: `LastConsentLookup::timestamp_for()` is now explicitly fail-closed.** Audit (2026-04-27) flagged the unhandled-throw path: a third-party `pre_option_*` / `option_*` filter that throws would bubble to a 500 instead of routing the operator to consent. Verified the existing flow was already implicitly fail-closed (null return → `ConsentDecisionEvaluator` branch 1 → `RENDER_FULL` with reason `first_authorization`). Locked the contract: any `\Throwable` from the option backend now returns null, which is strictly safer than a 500. `days_since()` inherits the same protection. (#65)
 

--- a/src/Auth/OAuth/TokenStore.php
+++ b/src/Auth/OAuth/TokenStore.php
@@ -453,15 +453,82 @@ final class TokenStore {
 		}
 	}
 
-	/** Update last_used_at for a token. Fire-and-forget — no error handling needed. */
+	// ─── L-2: deferred last_used_at write ────────────────────────────────────────
+	//
+	// Per-request buffer of token_hash → last_used_at timestamp. `touch()` no
+	// longer issues a synchronous UPDATE; it stamps the buffer and registers a
+	// shutdown flush on first use. At request shutdown, distinct token_hashes
+	// are flushed with one UPDATE each. Effects:
+	//   - N `touch()` calls for the same token in one request → 1 UPDATE.
+	//   - Write happens after the response is sent (off the critical path).
+	//   - PHP's shared-nothing per-request lifecycle resets the buffer between
+	//     requests, so cross-request batching is not attempted here. Operator
+	//     scale that justifies cross-request batching (transient + cron flush,
+	//     issue body's Option A) can be added later without changing the
+	//     `touch()` API.
+
+	/** @var array<string, string> token_hash => Y-m-d H:i:s */
+	private static array $pending_touches = array();
+
+	/** Whether shutdown flush has been registered for this request. */
+	private static bool $touch_flush_registered = false;
+
+	/**
+	 * Mark a token as used. Fire-and-forget — no error handling needed.
+	 *
+	 * Coalesces multiple calls for the same token within one request into a
+	 * single UPDATE deferred to request shutdown (L-2 audit, 2026-04-27).
+	 * Cuts the redundant-write multiplier and moves the write off the
+	 * response critical path. Empty token_hash is a no-op.
+	 */
 	public static function touch( string $token_hash ): void {
+		if ( '' === $token_hash ) {
+			return;
+		}
+
+		self::$pending_touches[ $token_hash ] = gmdate( 'Y-m-d H:i:s' );
+
+		if ( ! self::$touch_flush_registered && function_exists( 'register_shutdown_function' ) ) {
+			register_shutdown_function( array( self::class, 'flush_pending_touches' ) );
+			self::$touch_flush_registered = true;
+		}
+	}
+
+	/**
+	 * Flush buffered last_used_at writes to the DB.
+	 *
+	 * Invoked by `register_shutdown_function` at request shutdown. Public so
+	 * tests can drive flushes deterministically; production callers should
+	 * not invoke it directly.
+	 */
+	public static function flush_pending_touches(): void {
+		if ( empty( self::$pending_touches ) ) {
+			return;
+		}
 		global $wpdb;
-		$wpdb->update(
-			self::access_table(),
-			[ 'last_used_at' => gmdate( 'Y-m-d H:i:s' ) ],
-			[ 'token_hash' => $token_hash ],
-			[ '%s' ],
-			[ '%s' ]
-		);
+
+		$pending               = self::$pending_touches;
+		self::$pending_touches = array();
+
+		foreach ( $pending as $token_hash => $stamp ) {
+			$wpdb->update(
+				self::access_table(),
+				array( 'last_used_at' => $stamp ),
+				array( 'token_hash' => $token_hash ),
+				array( '%s' ),
+				array( '%s' )
+			);
+		}
+	}
+
+	/**
+	 * Reset the per-request touch buffer + shutdown registration flag.
+	 *
+	 * Test hook only — phpunit runs many tests in one process and statics
+	 * persist across tests. Production code must not call this.
+	 */
+	public static function reset_pending_touches_for_tests(): void {
+		self::$pending_touches        = array();
+		self::$touch_flush_registered = false;
 	}
 }

--- a/tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php
+++ b/tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * L-2: TokenStore::touch deferred-write semantics.
+ *
+ * Audit (2026-04-27) flagged the synchronous `UPDATE wp_kl_oauth_tokens
+ * SET last_used_at = ... WHERE token_hash = ?` on every authenticated MCP
+ * request as a hot row under burst load. This test pins the post-fix
+ * contract:
+ *   - `touch()` does not issue a DB write itself.
+ *   - Multiple `touch()` calls for the same token within one request
+ *     coalesce into a single UPDATE on flush.
+ *   - Distinct token_hashes flush as N UPDATEs.
+ *   - Empty buffer flush is a no-op.
+ *   - Empty token_hash is a no-op.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\TokenStore;
+
+final class TokenStoreTouchDeferredTest extends TestCase {
+
+	private object $original_wpdb;
+
+	protected function setUp(): void {
+		$this->original_wpdb = $GLOBALS['wpdb'];
+		$this->install_capturing_wpdb();
+		TokenStore::reset_pending_touches_for_tests();
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+		TokenStore::reset_pending_touches_for_tests();
+	}
+
+	/**
+	 * $wpdb stub that records every update() call so tests can assert on the
+	 * exact (table, data, where) arguments passed.
+	 */
+	private function install_capturing_wpdb(): void {
+		$GLOBALS['wpdb'] = new class {
+			public string $prefix = 'wp_';
+			/** @var array<int, array{table:string, data:array, where:array}> */
+			public array $update_calls = array();
+
+			public function prepare( $q, ...$a ) { return $q; }
+			public function get_row( $q )         { return null; }
+			public function get_var( $q )         { return null; }
+			public function get_results( $q )     { return array(); }
+			public function insert( $t, $d, $f = null ) { return 1; }
+			public function query( $sql )         { return true; }
+
+			public function update( $table, $data, $where, $format = null, $where_format = null ) {
+				$this->update_calls[] = array(
+					'table' => (string) $table,
+					'data'  => (array) $data,
+					'where' => (array) $where,
+				);
+				return 1;
+			}
+		};
+	}
+
+	// ─── touch() does not write synchronously ───────────────────────────────────
+
+	public function test_touch_does_not_issue_immediate_db_write(): void {
+		TokenStore::touch( 'hash-a' );
+
+		$this->assertSame( array(), $GLOBALS['wpdb']->update_calls,
+			'touch() must defer the wpdb->update; no write before shutdown flush'
+		);
+	}
+
+	// ─── flush coalesces same-token touches ─────────────────────────────────────
+
+	public function test_repeat_touch_for_same_token_flushes_one_update(): void {
+		TokenStore::touch( 'hash-a' );
+		TokenStore::touch( 'hash-a' );
+		TokenStore::touch( 'hash-a' );
+
+		TokenStore::flush_pending_touches();
+
+		$this->assertCount( 1, $GLOBALS['wpdb']->update_calls,
+			'Three touches for the same token must coalesce into one UPDATE'
+		);
+		$call = $GLOBALS['wpdb']->update_calls[0];
+		$this->assertSame( 'hash-a', $call['where']['token_hash'] );
+		$this->assertArrayHasKey( 'last_used_at', $call['data'] );
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+			(string) $call['data']['last_used_at']
+		);
+	}
+
+	// ─── flush issues one update per distinct token ─────────────────────────────
+
+	public function test_touches_for_distinct_tokens_flush_separately(): void {
+		TokenStore::touch( 'hash-a' );
+		TokenStore::touch( 'hash-b' );
+		TokenStore::touch( 'hash-c' );
+
+		TokenStore::flush_pending_touches();
+
+		$this->assertCount( 3, $GLOBALS['wpdb']->update_calls );
+
+		$hashes = array_map(
+			static fn( $c ) => $c['where']['token_hash'],
+			$GLOBALS['wpdb']->update_calls
+		);
+		sort( $hashes );
+		$this->assertSame( array( 'hash-a', 'hash-b', 'hash-c' ), $hashes );
+	}
+
+	// ─── flush is idempotent / clears the buffer ────────────────────────────────
+
+	public function test_flush_is_idempotent_after_buffer_drained(): void {
+		TokenStore::touch( 'hash-a' );
+		TokenStore::flush_pending_touches();
+		TokenStore::flush_pending_touches();
+
+		$this->assertCount( 1, $GLOBALS['wpdb']->update_calls,
+			'A second flush with an empty buffer must be a no-op'
+		);
+	}
+
+	public function test_flush_with_empty_buffer_is_noop(): void {
+		TokenStore::flush_pending_touches();
+
+		$this->assertSame( array(), $GLOBALS['wpdb']->update_calls );
+	}
+
+	// ─── empty token_hash guard ─────────────────────────────────────────────────
+
+	public function test_empty_token_hash_is_noop(): void {
+		TokenStore::touch( '' );
+		TokenStore::flush_pending_touches();
+
+		$this->assertSame( array(), $GLOBALS['wpdb']->update_calls,
+			'touch("") must not enqueue a write'
+		);
+	}
+
+	// ─── post-flush touches re-buffer correctly (sequential FPM-style use) ──────
+
+	public function test_touch_after_flush_buffers_the_next_request_window(): void {
+		// First "request": one touch then flush.
+		TokenStore::touch( 'hash-a' );
+		TokenStore::flush_pending_touches();
+
+		// Second "request" within the same process: another touch then flush.
+		// Even though the shutdown flag stays sticky in this single PHP process
+		// (PHPUnit doesn't reset statics between tests), the buffer must still
+		// accept new entries and the next flush must drain them.
+		TokenStore::touch( 'hash-a' );
+		TokenStore::flush_pending_touches();
+
+		$this->assertCount( 2, $GLOBALS['wpdb']->update_calls,
+			'Subsequent touch+flush cycles must continue to write'
+		);
+	}
+}


### PR DESCRIPTION
Closes #67.

## Summary

- `TokenStore::touch()` no longer issues a synchronous `wpdb->update` per call. It stamps an in-memory buffer keyed by `token_hash` and registers a `register_shutdown_function` flush on first use within the request.
- New `TokenStore::flush_pending_touches()` drains the buffer with one `UPDATE` per distinct `token_hash`. Multiple touches for the same token within one request coalesce into one UPDATE; distinct tokens flush as N UPDATEs after the response is sent.
- New `TokenStore::reset_pending_touches_for_tests()` test hook (PHPUnit shares process state across tests; production must not call it).
- Sole production caller (`AuthorizationServer::authenticate_bearer` line 440) is unchanged — `touch()`'s public signature and fire-and-forget contract are preserved.
- 7 new tests in `TokenStoreTouchDeferredTest` cover: no-immediate-write, same-token coalesce, distinct-token flush, idempotent flush, empty-buffer no-op, empty-token-hash no-op, sequential touch+flush cycles.

## Effects

- **Coalesce within request:** N `touch()` calls for the same token in one request → 1 UPDATE.
- **Off-critical-path:** the UPDATE happens at PHP shutdown — after the response has been sent — so authenticated MCP requests no longer block on `last_used_at` write latency.
- **Cross-request hot row:** PHP's shared-nothing per-request lifecycle resets the buffer between requests. Distinct requests for the same token in different FPM workers still produce one UPDATE per request. Cross-request batching (issue body's Option A — transient + cron flush) is intentionally not introduced; see Deviations.
- `last_used_at` resolution: still effectively per-request granularity; data lag is bounded by PHP shutdown timing, not by a cron interval.

## Test plan

- [x] `composer test` green locally on PHP 8.5 (855 tests, 2229 assertions; +7 new in `TokenStoreTouchDeferredTest`).
- [ ] CI matrix green on PHP 8.2 + 8.3.

## Deviations

**Implementation choice (per sprint plan §4 D.3 — required to document either way):**

I went with **per-request coalesce + `register_shutdown_function` flush**, not Option A (transient + cron flush). Rationale:

1. The issue body explicitly says "Option A is the right shape for production scale. Don't fix until traffic justifies it." We are not at that scale.
2. Sprint plan §4 D.3 instructs "Choose the simpler option in PR body's Deviations section" — the shutdown-flush approach is materially simpler than introducing a new transient schema, cron handler, flush logic, and stale-data drift handling.
3. Strictly better than the prior synchronous behavior on every relevant axis — coalesces redundant writes, moves the write off the response critical path — without giving up `last_used_at` per-request granularity that the audit notes is "fine at minute-granularity" but is currently better than that.
4. The `touch()` API is unchanged, so an upgrade to Option A later (transient + cron flush) is a drop-in inside `TokenStore` without touching any caller.

The sprint plan listed `register_shutdown_function` and "transient batch + cron flush" as the two acceptable shapes; this PR ships the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)