### PR TITLE
refactor: lift MCP route to McpResourcePath constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Tech-debt
+- **MCP route lifted to a single source of truth.** Previously the path `mcp/mcp-adapter-default-server` was hard-coded across `AuthorizationServer`, `AuthorizeEndpoint`, `DiscoveryEndpoints`, and `helpers.php` (six callsites across four files). Drift between callsites would silently narrow Bearer auth or break resource validation. New `McpResourcePath` value class exposes `REST_NAMESPACE`, `ROUTE`, `PATH` (no leading slash, for `rest_url()`), and `LEADING_SLASH_PATH` (for REQUEST_URI / rest_route compares). All production callsites now consume the constants; a future rename touches one file. Behavior-preserving refactor — all 855 existing tests stay green; 4 new tests pin the constant values. (#54)
+
 ### Performance / tech-debt
 - **L-2: `TokenStore::touch()` no longer issues a synchronous `UPDATE` per request.** Previously every authenticated MCP request blocked on a `wpdb->update` of `last_used_at` on the access-token table — a hot row under burst load. `touch()` now stamps a per-request in-memory buffer keyed by `token_hash` and registers a `register_shutdown_function` flush on first use. Multiple touches for the same token within one request coalesce into one UPDATE; distinct tokens flush as N UPDATEs after the response is sent. Cross-request batching (transient + cron flush, issue body's Option A) is intentionally not introduced — the simpler shutdown-flush refactor is sufficient at current scale and leaves Option A as a future move without changing the `touch()` API. (#67)
 

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -419,7 +419,7 @@ final class AuthorizationServer {
 		}
 
 		// Resource indicator validation (H.1.2) — token must be bound to this site's MCP endpoint.
-		$current_resource = rest_url( 'mcp/mcp-adapter-default-server' );
+		$current_resource = rest_url( McpResourcePath::PATH );
 		if ( ! hash_equals( (string) $row->resource, $current_resource ) ) {
 			self::schedule_www_authenticate( 'invalid_token', 'The access token is invalid.' );
 			\oauth_log_boundary( 'boundary.oauth_invalid_token', [ 'client_id' => $row->client_id, 'reason' => 'resource_mismatch' ] );

--- a/src/Auth/OAuth/DiscoveryEndpoints.php
+++ b/src/Auth/OAuth/DiscoveryEndpoints.php
@@ -20,10 +20,12 @@ namespace WickedEvolutions\McpAdapter\Auth\OAuth;
  */
 final class DiscoveryEndpoints {
 
-	/** REST namespace used by the MCP adapter. */
-	private const MCP_NAMESPACE = 'mcp';
-	private const MCP_ROUTE     = 'mcp-adapter-default-server';
-	private const OAUTH_REST_NS = 'mcp'; // OAuth endpoints under same namespace as MCP.
+	/**
+	 * OAuth REST namespace. Currently coincident with the MCP namespace
+	 * (see {@see McpResourcePath::REST_NAMESPACE}) but kept independent so
+	 * OAuth endpoints can move without dragging the MCP route name.
+	 */
+	private const OAUTH_REST_NS = 'mcp';
 
 	/**
 	 * Compute the issuer URL from HTTP_HOST (timing-safe, avoids home_url() at init priority 0).
@@ -55,7 +57,7 @@ final class DiscoveryEndpoints {
 	 * @param string|null $path_prefix Path-style multisite prefix (see issuer()).
 	 */
 	public static function resource_url( ?string $path_prefix = null ): string {
-		return self::issuer( $path_prefix ) . '/wp-json/' . self::MCP_NAMESPACE . '/' . self::MCP_ROUTE;
+		return self::issuer( $path_prefix ) . '/wp-json/' . McpResourcePath::PATH;
 	}
 
 	/**

--- a/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
@@ -46,6 +46,7 @@ use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\PriorGrantLookup;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RenderedScopeNonce;
 use WickedEvolutions\McpAdapter\Auth\OAuth\Consent\RoleSelector;
 use WickedEvolutions\McpAdapter\Auth\OAuth\DiscoveryEndpoints;
+use WickedEvolutions\McpAdapter\Auth\OAuth\McpResourcePath;
 
 /**
  * Top-level dispatcher for /oauth/authorize. Pre-WP — exits with `never`.
@@ -406,7 +407,7 @@ final class AuthorizeEndpoint {
 	/** This site's resource indicator URL (mirrors AuthorizationServer::authenticate_bearer's binding). */
 	private static function resource_indicator(): string {
 		return function_exists( 'rest_url' )
-			? rest_url( 'mcp/mcp-adapter-default-server' )
+			? rest_url( McpResourcePath::PATH )
 			: DiscoveryEndpoints::resource_url();
 	}
 }

--- a/src/Auth/OAuth/McpResourcePath.php
+++ b/src/Auth/OAuth/McpResourcePath.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Canonical MCP resource path constants — single source of truth (#54).
+ *
+ * The MCP REST endpoint path was previously hard-coded across four files
+ * (AuthorizationServer, AuthorizeEndpoint, DiscoveryEndpoints, helpers.php).
+ * Drift between callsites would silently narrow Bearer auth or break
+ * resource validation. All callsites now consume this class so a future
+ * route rename is a one-line change.
+ *
+ * Copyright (C) 2026 Wicked Evolutions
+ * License: GPL-2.0-or-later
+ *
+ * @package WickedEvolutions\McpAdapter\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Auth\OAuth;
+
+/**
+ * Constants only. Never instantiated.
+ */
+final class McpResourcePath {
+
+	/** REST namespace under /wp-json/. */
+	public const REST_NAMESPACE = 'mcp';
+
+	/** Route name within the namespace. */
+	public const ROUTE = 'mcp-adapter-default-server';
+
+	/** REST path for `rest_url()` — no leading slash. */
+	public const PATH = self::REST_NAMESPACE . '/' . self::ROUTE;
+
+	/** REST path with leading slash — for REQUEST_URI / rest_route compares. */
+	public const LEADING_SLASH_PATH = '/' . self::REST_NAMESPACE . '/' . self::ROUTE;
+}

--- a/src/Auth/OAuth/helpers.php
+++ b/src/Auth/OAuth/helpers.php
@@ -106,12 +106,12 @@ if ( ! function_exists( 'oauth_is_mcp_resource_request' ) ) {
 			return false;
 		}
 
-		$rest_route = '/mcp/mcp-adapter-default-server';
+		$rest_route = \WickedEvolutions\McpAdapter\Auth\OAuth\McpResourcePath::LEADING_SLASH_PATH;
 
 		// Pretty permalinks. Derive the path from rest_url() so subdir / multisite
 		// installs (e.g. /wp/wp-json/...) are matched against their actual prefix.
 		if ( function_exists( 'rest_url' ) ) {
-			$resource_url  = (string) rest_url( 'mcp/mcp-adapter-default-server' );
+			$resource_url  = (string) rest_url( \WickedEvolutions\McpAdapter\Auth\OAuth\McpResourcePath::PATH );
 			$resource_path = (string) parse_url( $resource_url, PHP_URL_PATH );
 			if ( $resource_path !== '' && str_starts_with( $uri, $resource_path ) ) {
 				$tail = substr( $uri, strlen( $resource_path ) );

--- a/tests/Unit/Auth/OAuth/McpResourcePathTest.php
+++ b/tests/Unit/Auth/OAuth/McpResourcePathTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Pin McpResourcePath constant values (#54).
+ *
+ * The whole point of the lift is that all callsites read the same value.
+ * If the canonical constants change, the tests that pin downstream URLs
+ * (PathStyleMultisiteDiscoveryTest, AuthenticateBearerNarrowsToMcpResourceTest,
+ * etc.) will fail in lockstep — and so will this test, surfacing the rename
+ * intent at exactly one place.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\McpResourcePath;
+
+final class McpResourcePathTest extends TestCase {
+
+	public function test_rest_namespace_is_mcp(): void {
+		$this->assertSame( 'mcp', McpResourcePath::REST_NAMESPACE );
+	}
+
+	public function test_route_is_mcp_adapter_default_server(): void {
+		$this->assertSame( 'mcp-adapter-default-server', McpResourcePath::ROUTE );
+	}
+
+	public function test_path_is_namespace_slash_route_with_no_leading_slash(): void {
+		$this->assertSame( 'mcp/mcp-adapter-default-server', McpResourcePath::PATH );
+	}
+
+	public function test_leading_slash_path_has_leading_slash(): void {
+		$this->assertSame( '/mcp/mcp-adapter-default-server', McpResourcePath::LEADING_SLASH_PATH );
+		$this->assertSame( '/' . McpResourcePath::PATH, McpResourcePath::LEADING_SLASH_PATH );
+	}
+}


### PR DESCRIPTION
Closes #54.

## Summary

- New `WickedEvolutions\McpAdapter\Auth\OAuth\McpResourcePath` value class — constants only, never instantiated.
  - `REST_NAMESPACE` = `'mcp'`
  - `ROUTE` = `'mcp-adapter-default-server'`
  - `PATH` = `'mcp/mcp-adapter-default-server'` (for `rest_url()`)
  - `LEADING_SLASH_PATH` = `'/mcp/mcp-adapter-default-server'` (for REQUEST_URI / rest_route compares)
- Refactored all six production callsites across the four files cited in the issue body + sprint plan §4 D.4:
  - `DiscoveryEndpoints.php` — dropped private `MCP_NAMESPACE` / `MCP_ROUTE`; `resource_url()` now uses `McpResourcePath::PATH`. `OAUTH_REST_NS` retained as a deliberately separate constant (see Deviations).
  - `helpers.php` — `oauth_is_mcp_resource_request()` uses `McpResourcePath::LEADING_SLASH_PATH` and `McpResourcePath::PATH` (FQN since the file lives in the global namespace).
  - `AuthorizationServer.php` line 422 — uses `McpResourcePath::PATH`.
  - `AuthorizeEndpoint.php` — added `use` import; `resource_indicator()` uses `McpResourcePath::PATH`.
- Behavior-preserving refactor. All 855 pre-existing tests stay green; 4 new tests in `McpResourcePathTest` pin the constant values so a future rename surfaces in one place.

## Test plan

- [x] `composer test` green locally on PHP 8.5 (859 tests, 2234 assertions; +4 new in `McpResourcePathTest`).
- [ ] CI matrix green on PHP 8.2 + 8.3.

## Deviations

1. **Canonical home:** picked a new `McpResourcePath` value class (issue body's preferred suggestion) over `OAuthHostAllowlist` (also suggested). Rationale: the constant is consumed by resource validation, REQUEST_URI matching, and discovery URL construction — none of which are host-allowlist concerns. A single-purpose constants class is the simpler, less-cross-cutting home.
2. **`DiscoveryEndpoints::OAUTH_REST_NS` left in place.** It happens to equal `'mcp'` today and shares the value with `McpResourcePath::REST_NAMESPACE`, but the existing comment ("OAuth endpoints under same namespace as MCP") frames the equivalence as a current choice, not a binding rule. Aliasing it to the new constant would couple two independently-renameable values; an updated comment now captures that intent. Issue scope is explicitly the *MCP route*, not the OAuth namespace, so this is faithful to the contract.
3. **Test fixtures unchanged.** Many test files contain the literal `mcp/mcp-adapter-default-server` as fixture URI strings. Lifting them to `McpResourcePath::*` is plausible but is scope creep beyond the issue's "6 callsites across 4 files" production count — and useful: tests asserting against a known-good fixture string would be tautological if they read from the same constant the code under test uses. They stay literal on purpose; if `McpResourcePath::ROUTE` changes, the tests will fail loudly until updated, which is the intended forcing function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)