### PR TITLE
fix: drop dead /wp-json/abilities-mcp-adapter/ branch in AuthHeaderProbe gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Tech-debt
+- **AuthHeaderProbe namespace gate cleaned up (H.2.6 diagnostic now actually fires).** `AuthorizationServer::authenticate_bearer` was matching both `/wp-json/mcp/` and the stale `/wp-json/abilities-mcp-adapter/` namespace before recording an observation. The latter is left over from a pre-rename branch — no REST routes are registered there, so the probe was silently dead on requests that hit it (and harmlessly recording-on-noise on requests that didn't, which means the rolling counter never reflected real traffic). Dropped the dead OR branch; probe now records only on `/wp-json/mcp/` traffic, restoring the H.2.6 diagnostic. (#53)
 - **MCP route lifted to a single source of truth.** Previously the path `mcp/mcp-adapter-default-server` was hard-coded across `AuthorizationServer`, `AuthorizeEndpoint`, `DiscoveryEndpoints`, and `helpers.php` (six callsites across four files). Drift between callsites would silently narrow Bearer auth or break resource validation. New `McpResourcePath` value class exposes `REST_NAMESPACE`, `ROUTE`, `PATH` (no leading slash, for `rest_url()`), and `LEADING_SLASH_PATH` (for REQUEST_URI / rest_route compares). All production callsites now consume the constants; a future rename touches one file. Behavior-preserving refactor — all 855 existing tests stay green; 4 new tests pin the constant values. (#54)
 
 ### Performance / tech-debt

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -358,9 +358,11 @@ final class AuthorizationServer {
 
 		// Phase 3 (H.2.6): record header presence/absence for the diagnostic.
 		// Only count requests that actually look like MCP traffic so the rolling
-		// counter reflects bridge calls, not unrelated REST hits.
+		// counter reflects bridge calls, not unrelated REST hits. The stale
+		// `/wp-json/abilities-mcp-adapter/` namespace from a pre-rename branch
+		// has no routes registered — matching it was silently dead (#53).
 		$path = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
-		if ( str_contains( $path, '/wp-json/mcp/' ) || str_contains( $path, '/wp-json/abilities-mcp-adapter/' ) ) {
+		if ( str_contains( $path, '/wp-json/mcp/' ) ) {
 			AuthHeaderProbe::record( null !== $auth_header && '' !== $auth_header );
 		}
 

--- a/tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php
+++ b/tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Regression for #53: `AuthorizationServer::authenticate_bearer()`'s
+ * Authorization-header probe must record only when the request hits the
+ * MCP namespace `/wp-json/mcp/`. The stale `/wp-json/abilities-mcp-adapter/`
+ * namespace has no routes registered and matching it was silently dead —
+ * the diagnostic seam recorded zero data despite firing on every REST hit
+ * to that prefix.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Admin\Bridges\AuthHeaderProbe;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\OAuthRequestContext;
+
+if ( ! defined( 'REST_REQUEST' ) ) {
+	define( 'REST_REQUEST', true );
+}
+
+final class AuthHeaderProbeNamespaceGateTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		AuthHeaderProbe::clear();
+		OAuthRequestContext::reset();
+	}
+
+	protected function tearDown(): void {
+		AuthHeaderProbe::clear();
+		OAuthRequestContext::reset();
+		unset( $_SERVER['REQUEST_URI'] );
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		parent::tearDown();
+	}
+
+	public function test_probe_records_on_mcp_namespace_request(): void {
+		$_SERVER['REQUEST_URI']        = '/wp-json/mcp/mcp-adapter-default-server';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-token';
+
+		AuthorizationServer::authenticate_bearer( false );
+
+		$state = get_option( AuthHeaderProbe::OPTION );
+		$this->assertIsArray( $state, 'Probe must record an observation on /wp-json/mcp/ requests' );
+		$this->assertCount( 1, $state['observations'] ?? array() );
+		$this->assertSame( 1, $state['observations'][0], 'Bearer header presence must be recorded as 1' );
+	}
+
+	public function test_probe_does_not_record_on_stale_abilities_mcp_adapter_namespace(): void {
+		// The whole point of #53: pre-fix, this URI matched the OR branch and
+		// the probe recorded against a namespace that holds no real routes.
+		// Post-fix, the OR branch is gone and the probe stays silent here.
+		$_SERVER['REQUEST_URI']        = '/wp-json/abilities-mcp-adapter/anything';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-token';
+
+		AuthorizationServer::authenticate_bearer( false );
+
+		$this->assertFalse(
+			get_option( AuthHeaderProbe::OPTION, false ),
+			'Probe must not record on the stale /wp-json/abilities-mcp-adapter/ namespace'
+		);
+	}
+
+	public function test_probe_does_not_record_on_unrelated_rest_routes(): void {
+		$_SERVER['REQUEST_URI']        = '/wp-json/wp/v2/users';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer some-token';
+
+		AuthorizationServer::authenticate_bearer( false );
+
+		$this->assertFalse(
+			get_option( AuthHeaderProbe::OPTION, false ),
+			'Probe must not record on unrelated REST routes'
+		);
+	}
+
+	public function test_probe_records_zero_when_authorization_header_absent(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-json/mcp/mcp-adapter-default-server';
+		// No HTTP_AUTHORIZATION set.
+
+		AuthorizationServer::authenticate_bearer( false );
+
+		$state = get_option( AuthHeaderProbe::OPTION );
+		$this->assertIsArray( $state );
+		$this->assertSame( 0, $state['observations'][0] ?? null,
+			'Missing Authorization header must be recorded as 0'
+		);
+	}
+}


### PR DESCRIPTION
Closes #53.

## Summary

- Dropped the `str_contains( \$path, '/wp-json/abilities-mcp-adapter/' )` OR branch in `AuthorizationServer::authenticate_bearer` — that namespace has no routes registered anywhere in `src/`, so the probe was silently dead on requests hitting it. Probe now records only on `/wp-json/mcp/` traffic, restoring the H.2.6 diagnostic to its intended data source.
- Updated the inline comment to spell out why the OR branch is gone (left over from a pre-rename branch) so it doesn't get re-added in a future cleanup.
- Added regression test `AuthHeaderProbeNamespaceGateTest` with 4 assertions:
  - Probe records `1` observation on `/wp-json/mcp/mcp-adapter-default-server`.
  - Probe does **not** record on `/wp-json/abilities-mcp-adapter/anything` (the regression assertion that pins this fix).
  - Probe does not record on `/wp-json/wp/v2/users` (unrelated REST routes).
  - Absent Authorization header records as `0` (existing behavior, pinned for completeness).

## Test plan

- [x] `composer test` green locally on PHP 8.5 (863 tests, 2241 assertions; +4 new in `AuthHeaderProbeNamespaceGateTest`).
- [ ] CI matrix green on PHP 8.2 + 8.3.

## Deviations

The literal `'/wp-json/mcp/'` could be lifted to `'/wp-json/' . McpResourcePath::REST_NAMESPACE . '/'` per #54's "single source of truth" intent — issue #53 even invokes that follow-on ("update the path match to /wp-json/mcp/ or wherever the canonical MCP resource sits — see issue #54"). I held it back: the orchestrator's brief framed this as a one-line drop-the-OR-branch fix, not a constant-lift; and the literal here matches the *namespace prefix*, which is conceptually distinct from the resource path lifted in #54. Flag if a follow-up lift is wanted; otherwise this stays a clean #54-independent fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)