### PR TITLE
chore: release v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.4.4] - 2026-05-02
 
 ### Test infra
 - **#27: Rate-limit burst harness shipped.** New CLI tool `bin/rate-limit-burst.php` and `RateLimit\BurstHarness` helper class — session-aware harness that exercises the live `/wp-json/mcp/mcp-adapter-default-server` endpoint past its IP and initialize windows and verifies the wire response (429 + Retry-After + boundary log entry) matches the limiter contract. Pairs with `RateLimiter`'s 33 unit cases, which pin the in-memory math; this harness pins the wire behavior. Two cases (`threshold-trip`, `initialize-window`) automated; the multi-source per-IP separation and trusted-proxy header trust matrix are documented in the script header for operator-run coverage. 15 unit tests cover header parsing, session merge (defensive vs future per-request token rotation), and result classification. (#27)

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: Abilities MCP Adapter
  * Plugin URI:  https://github.com/Wicked-Evolutions/abilities-mcp-adapter
  * Description: Exposes WordPress abilities as MCP tools, resources, and prompts. Upload, activate, and your WordPress abilities become MCP tools.
- * Version:     1.4.3
+ * Version:     1.4.4
  * Author:      Wicked Evolutions
  * Author URI:  https://wickedevolutions.com
  * Copyright:   Copyright (C) 2026 Wicked Evolutions
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Plugin constants.
-define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.3' );
+define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.4' );
 define( 'ABILITIES_MCP_ADAPTER_PATH', plugin_dir_path( __FILE__ ) );
 
 // License manager — FluentCart license for auto-update delivery.


### PR DESCRIPTION
Phase F release-prep PR for the v1.4.4 — Stretch to Stable milestone.

## Summary

- Plugin header `Version: 1.4.3` → `1.4.4` in `abilities-mcp-adapter.php`.
- `ABILITIES_MCP_ADAPTER_VERSION` constant `'1.4.3'` → `'1.4.4'` in the same file (kept in sync with the plugin header — leaving them divergent would drift the runtime version-of-record from the WP plugin metadata; matches the v1.4.3 bump precedent in 5cc12da).
- `CHANGELOG.md`: `## [Unreleased]` → `## [1.4.4] - 2026-05-02`. Content unchanged.

No code changes. No new tests.

## Milestone closure

The v1.4.4 [Unreleased] section already covers the 9 PRs that landed for this milestone, in chronological merge order:

- #75 — M-8 LastConsentLookup explicit fail-closed
- #76 — M-9 AuthorizationCodeStore wpdb->insert return check
- #77 — L-2 TokenStore::touch deferred-write
- #78 — MCP route lifted to McpResourcePath constants
- #79 — AuthHeaderProbe namespace gate cleanup
- #80 — M-3 has_scope → oauth_has_scope strict-false
- #81 — Fluent suite scopes added to ScopeRegistry (#74)
- #82 — L-3 DCR sensitive_scopes_requested flag
- #84 — #27 rate-limit burst harness

Plus #83 filed for v1.4.5 (UI follow-up to #68's data layer).

The v1.4.4 milestone is already closed on GitHub, so this PR is intentionally not attached to it (closed milestones reject new PR attachments). The CHANGELOG section header is the canonical milestone-closure record.

## Test plan

- [ ] CI matrix green on PHP 8.2 + 8.3 (no code changes; full suite stays at 893 tests).
- [ ] After merge: tag v1.4.4, draft GitHub Release with notes from the new `[1.4.4]` section, build adapter zip, .mcpb pack (per Phase F coordinated release sequence).

## Deviations

The orchestrator brief specified the plugin header bump only. I additionally bumped the `ABILITIES_MCP_ADAPTER_VERSION` constant on line 19 to keep the runtime version-of-record in sync with the WP plugin header. The previous release commit (5cc12da, "chore: bump version to 1.4.3") changed both lines together, so this matches established precedent — flag if you wanted only the header bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)