### PR TITLE
fix(oauth): subsite authorize endpoint accepts path-style prefix (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.4.5] - Unreleased
+
+Public Alpha Hardening release — fixes from the GPT 5.5 codebase review (2026-05-04).
+
+### Known limitation
+
+- **Path-style multisite is not yet end-to-end verified.** Subdomain-style multisite is the binding alpha gate. Code paths for path-style subsites are exercised by unit tests, but a full discovery → consent → code → token flow on a path-style network has not been run because no path-style multisite test environment is currently available. Building/locating one is a follow-up infrastructure task; subdomain-style multisite is unaffected.
+
+### Bug — High
+
+- **#90: Subsite authorize endpoint now dispatches under any path-style prefix.** `AuthorizationServer::intercept_pre_wp_routes()` previously only matched the exact root path `/oauth/authorize`, so a path-style subsite client following its own discovery metadata (which advertises `https://example.com/<prefix>/oauth/authorize`) fell through to WP/404 before consent. The interceptor now matches any path ending in `/oauth/authorize` and threads the leading prefix into `AuthorizeEndpoint::dispatch()` → `handle_get` / `handle_post`. The self-post URL, `wp_login_url()` redirect target, and resource indicator now all carry the same prefix, so the URLs match what the subsite's discovery metadata advertised. Single-site and subdomain-style multisite are unchanged. M-5 (#60) addressed the same gap on the `.well-known/*` discovery paths but did not extend the fix to `/oauth/authorize`; #90 closes the remaining half. (#90)
+
 ## [1.4.4] - 2026-05-02
 
 ### Test infra

--- a/src/Auth/OAuth/AuthorizationServer.php
+++ b/src/Auth/OAuth/AuthorizationServer.php
@@ -213,8 +213,13 @@ final class AuthorizationServer {
 		} elseif ( str_starts_with( $path, '/.well-known/openid-configuration' ) ) {
 			$prefix = self::extract_path_prefix( $path, '/.well-known/openid-configuration' );
 			DiscoveryEndpoints::serve_oidc_configuration( $prefix );
-		} elseif ( $path === '/oauth/authorize' ) {
-			AuthorizeEndpoint::dispatch();
+		} elseif ( str_ends_with( $path, '/oauth/authorize' ) ) {
+			// Path-style multisite: discovery metadata for /sub2 advertises
+			// https://example.com/sub2/oauth/authorize. Match any path ending
+			// in /oauth/authorize and pass the leading prefix (or null for
+			// root) into the authorize handler so self-post / login-redirect
+			// / resource-indicator URLs match what discovery promised.
+			AuthorizeEndpoint::dispatch( self::extract_authorize_path_prefix( $path ) );
 		}
 	}
 
@@ -241,6 +246,41 @@ final class AuthorizationServer {
 			return null;
 		}
 		return $tail;
+	}
+
+	/**
+	 * Extract the subsite path prefix from an authorize-endpoint request path.
+	 *
+	 * Mirrors {@see extract_path_prefix()} but anchored at the suffix
+	 * '/oauth/authorize' rather than a known leading prefix:
+	 *   '/oauth/authorize'        → null     (root site)
+	 *   '/sub2/oauth/authorize'   → '/sub2'  (path-style subsite)
+	 *   '/team/blog/oauth/authorize' → '/team/blog'
+	 *
+	 * Caller must already have confirmed the path ends in '/oauth/authorize'
+	 * (the interceptor uses str_ends_with as the guard before calling this).
+	 *
+	 * Prefix validation matches the discovery side: any non-empty leading
+	 * segment that begins with '/' is accepted. Whether the prefix maps to
+	 * an actual subsite is a downstream concern (WP resolves blog ID from
+	 * host+path); this helper is a URL-construction aid only.
+	 *
+	 * @param string $full_path The full request path (no query string).
+	 * @return string|null The leading path segment(s), or null for root sites.
+	 */
+	public static function extract_authorize_path_prefix( string $full_path ): ?string {
+		$suffix = '/oauth/authorize';
+		if ( ! str_ends_with( $full_path, $suffix ) ) {
+			return null;
+		}
+		$head = substr( $full_path, 0, -strlen( $suffix ) );
+		if ( $head === '' ) {
+			return null;
+		}
+		if ( ! str_starts_with( $head, '/' ) ) {
+			return null;
+		}
+		return $head;
 	}
 
 	public static function is_well_known_or_oauth_path(): bool {

--- a/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
+++ b/src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php
@@ -56,12 +56,22 @@ final class AuthorizeEndpoint {
 	/** Lifetime of an issued authorization code (seconds). */
 	private const CODE_TTL = 600;
 
-	/** Dispatch by request method. */
-	public static function dispatch(): never {
+	/**
+	 * Dispatch by request method.
+	 *
+	 * @param string|null $path_prefix Path-style multisite prefix extracted by
+	 *                                 the pre-WP interceptor (e.g. '/sub2');
+	 *                                 null for single-site or subdomain-style
+	 *                                 multisite. Threaded through self-post,
+	 *                                 login-redirect, and resource-indicator
+	 *                                 URLs so they match the URL the client
+	 *                                 followed from discovery metadata.
+	 */
+	public static function dispatch( ?string $path_prefix = null ): never {
 		$method = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? 'GET' ) );
 		match ( $method ) {
-			'GET'  => self::handle_get( $_GET ),
-			'POST' => self::handle_post( $_POST ),
+			'GET'  => self::handle_get( $_GET, $path_prefix ),
+			'POST' => self::handle_post( $_POST, $path_prefix ),
 			default => self::reject_method(),
 		};
 	}
@@ -80,10 +90,11 @@ final class AuthorizeEndpoint {
 	 * GET handler — validates per H.3.6, then dispatches to login redirect,
 	 * auto-approve, or consent screen.
 	 *
-	 * @param array $params Raw query string.
+	 * @param array       $params      Raw query string.
+	 * @param string|null $path_prefix Path-style multisite prefix; see dispatch().
 	 */
-	public static function handle_get( array $params ): never {
-		$resource_indicator = self::resource_indicator();
+	public static function handle_get( array $params, ?string $path_prefix = null ): never {
+		$resource_indicator = self::resource_indicator( $path_prefix );
 		$validation         = AuthorizeRequestValidator::validate( $params, $resource_indicator );
 
 		if ( $validation->is_pre_redirect_error() ) {
@@ -110,7 +121,7 @@ final class AuthorizeEndpoint {
 		// Validation passed. From here, the request can be redirected to wp-login safely
 		// (the redirect_uri itself is now known good — H.3.6 line 7 reached).
 		if ( ! is_user_logged_in() ) {
-			self::redirect_to_login();
+			self::redirect_to_login( $path_prefix );
 		}
 
 		$user_id = (int) get_current_user_id();
@@ -133,7 +144,7 @@ final class AuthorizeEndpoint {
 		}
 
 		// Render full or incremental consent.
-		self::render_consent( $validation, $decision, $user_id, $last_interactive );
+		self::render_consent( $validation, $decision, $user_id, $last_interactive, $path_prefix );
 	}
 
 	/**
@@ -198,7 +209,8 @@ final class AuthorizeEndpoint {
 		AuthorizeValidationResult $validation,
 		ConsentDecision $decision,
 		int $user_id,
-		?int $last_interactive_unix
+		?int $last_interactive_unix,
+		?string $path_prefix = null
 	): never {
 		$client = $validation->client;
 		$user   = function_exists( 'get_userdata' ) ? get_userdata( $user_id ) : null;
@@ -208,7 +220,7 @@ final class AuthorizeEndpoint {
 
 		$available_roles = RoleSelector::roles_for_user_id( $user_id );
 
-		$action_url = self::self_url();
+		$action_url = self::self_url( $path_prefix );
 
 		ConsentScreenRenderer::render( array(
 			'client_id'                  => (string) $client->client_id,
@@ -238,15 +250,16 @@ final class AuthorizeEndpoint {
 	 * Re-checks scope subset against the server-issued nonce (H.4.5).
 	 * Re-checks role membership against the user's actual roles (H.4.5).
 	 *
-	 * @param array $params Raw $_POST.
+	 * @param array       $params      Raw $_POST.
+	 * @param string|null $path_prefix Path-style multisite prefix; see dispatch().
 	 */
-	public static function handle_post( array $params ): never {
+	public static function handle_post( array $params, ?string $path_prefix = null ): never {
 		// Operator must be logged in to post the consent form.
 		if ( ! is_user_logged_in() ) {
-			self::redirect_to_login();
+			self::redirect_to_login( $path_prefix );
 		}
 
-		$resource_indicator = self::resource_indicator();
+		$resource_indicator = self::resource_indicator( $path_prefix );
 		$validation         = AuthorizeRequestValidator::validate( $params, $resource_indicator );
 
 		if ( $validation->is_pre_redirect_error() ) {
@@ -364,13 +377,13 @@ final class AuthorizeEndpoint {
 	// ─── Redirect helpers ────────────────────────────────────────────────────────
 
 	/** Redirect to wp-login.php with `redirect_to` set back to this exact authorize URL (H.3.6 same-origin note). */
-	private static function redirect_to_login(): never {
-		$self = self::self_url() . ( isset( $_SERVER['QUERY_STRING'] ) && '' !== (string) $_SERVER['QUERY_STRING']
+	private static function redirect_to_login( ?string $path_prefix = null ): never {
+		$self = self::self_url( $path_prefix ) . ( isset( $_SERVER['QUERY_STRING'] ) && '' !== (string) $_SERVER['QUERY_STRING']
 			? '?' . (string) $_SERVER['QUERY_STRING']
 			: '' );
 		$login_url = function_exists( 'wp_login_url' )
 			? wp_login_url( $self )
-			: ( DiscoveryEndpoints::issuer() . '/wp-login.php?redirect_to=' . rawurlencode( $self ) );
+			: ( DiscoveryEndpoints::issuer( $path_prefix ) . '/wp-login.php?redirect_to=' . rawurlencode( $self ) );
 
 		status_header( 302 );
 		header( 'Location: ' . $login_url );
@@ -412,13 +425,30 @@ final class AuthorizeEndpoint {
 		exit;
 	}
 
-	/** The canonical /oauth/authorize URL on this site, for self-posting + redirect_to. */
-	private static function self_url(): string {
-		return DiscoveryEndpoints::issuer() . '/oauth/authorize';
+	/**
+	 * The canonical /oauth/authorize URL on this site, for self-posting + redirect_to.
+	 *
+	 * Path-style multisite: when the request arrived at /<prefix>/oauth/authorize,
+	 * the self-post URL must include the same prefix so the consent form posts
+	 * back to the same subsite-scoped URL the client followed from discovery.
+	 */
+	private static function self_url( ?string $path_prefix = null ): string {
+		return DiscoveryEndpoints::issuer( $path_prefix ) . '/oauth/authorize';
 	}
 
-	/** This site's resource indicator URL (mirrors AuthorizationServer::authenticate_bearer's binding). */
-	private static function resource_indicator(): string {
+	/**
+	 * This site's resource indicator URL (mirrors AuthorizationServer::authenticate_bearer's binding).
+	 *
+	 * Path-style multisite: rest_url() runs pre-WP and may not yet have resolved
+	 * the subsite from the request path, so it can return the network-root URL
+	 * even when the request is for a path-style subsite. When a prefix is
+	 * supplied, build the resource URL explicitly via DiscoveryEndpoints so it
+	 * matches what the subsite's discovery metadata advertised.
+	 */
+	private static function resource_indicator( ?string $path_prefix = null ): string {
+		if ( null !== $path_prefix && '' !== $path_prefix ) {
+			return DiscoveryEndpoints::resource_url( $path_prefix );
+		}
 		return function_exists( 'rest_url' )
 			? rest_url( McpResourcePath::PATH )
 			: DiscoveryEndpoints::resource_url();

--- a/tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php
+++ b/tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * #90: Path-style multisite authorize-endpoint routing.
+ *
+ * Pre-fix: AuthorizationServer::intercept_pre_wp_routes() only dispatched the
+ * exact root path '/oauth/authorize'. Discovery metadata for a path-style
+ * subsite (e.g. /sub2) advertises https://example.com/sub2/oauth/authorize, so
+ * any client following discovery fell through to WordPress and 404'd before
+ * consent could render. The authorize-endpoint helpers (self-post URL, login
+ * redirect, resource indicator) also lacked subsite-prefix awareness.
+ *
+ * After fix:
+ *   1. The interceptor matches any path ending in '/oauth/authorize' and
+ *      passes the leading prefix (or null for root) into AuthorizeEndpoint.
+ *   2. AuthorizeEndpoint::self_url($prefix) and resource_indicator($prefix)
+ *      build URLs that match what discovery advertised for the same subsite.
+ *
+ * Tests here pin:
+ *   - AuthorizationServer::extract_authorize_path_prefix() boundary cases
+ *   - AuthorizeEndpoint::self_url() with and without prefix
+ *   - AuthorizeEndpoint::resource_indicator() with and without prefix
+ *
+ * End-to-end path-style multisite verification is NOT a release gate per the
+ * Public Alpha Hardening sprint plan §3 alpha-scope lock — alpha is
+ * subdomain-style only. Path-style is named as a known limitation in the
+ * v1.4.5 CHANGELOG; building a path-style multisite test environment is a
+ * follow-up infrastructure task. This file's coverage is the intentional
+ * release gate for #90.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Auth\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use WickedEvolutions\McpAdapter\Auth\OAuth\AuthorizationServer;
+use WickedEvolutions\McpAdapter\Auth\OAuth\Endpoints\AuthorizeEndpoint;
+
+final class PathStyleMultisiteAuthorizeRoutingTest extends TestCase {
+
+	protected function setUp(): void {
+		unset( $_SERVER['HTTP_HOST'], $_SERVER['HTTPS'], $_SERVER['HTTP_X_FORWARDED_PROTO'] );
+		$GLOBALS['wp_test_home_url'] = 'https://example.com';
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wp_test_home_url'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// extract_authorize_path_prefix() — boundary cases
+	// -------------------------------------------------------------------------
+
+	/** Exact root path → null prefix (single-site / subdomain-style multisite). */
+	public function test_extract_authorize_prefix_root_path_yields_null(): void {
+		$this->assertNull(
+			AuthorizationServer::extract_authorize_path_prefix( '/oauth/authorize' )
+		);
+	}
+
+	/** Single-segment subsite path → prefix '/sub2'. */
+	public function test_extract_authorize_prefix_single_segment(): void {
+		$this->assertSame(
+			'/sub2',
+			AuthorizationServer::extract_authorize_path_prefix( '/sub2/oauth/authorize' )
+		);
+	}
+
+	/** Multi-segment subsite path → prefix '/team/blog' (consistent with discovery side). */
+	public function test_extract_authorize_prefix_multi_segment(): void {
+		$this->assertSame(
+			'/team/blog',
+			AuthorizationServer::extract_authorize_path_prefix( '/team/blog/oauth/authorize' )
+		);
+	}
+
+	/**
+	 * '/oauth/authorizeextra' must NOT match — str_ends_with anchor is
+	 * '/oauth/authorize' (with leading slash), so suffix-substring tricks
+	 * can't widen the dispatch surface.
+	 */
+	public function test_extract_authorize_prefix_suffix_substring_does_not_match(): void {
+		$this->assertNull(
+			AuthorizationServer::extract_authorize_path_prefix( '/oauth/authorizeextra' )
+		);
+	}
+
+	/**
+	 * Trailing slash form ('/oauth/authorize/') is NOT matched — discovery
+	 * metadata advertises no trailing slash, and the interceptor doesn't
+	 * normalize. Pinned so any future normalization change surfaces here.
+	 */
+	public function test_extract_authorize_prefix_trailing_slash_does_not_match(): void {
+		$this->assertNull(
+			AuthorizationServer::extract_authorize_path_prefix( '/oauth/authorize/' )
+		);
+	}
+
+	/**
+	 * Path missing the leading slash ('oauth/authorize') is malformed; head
+	 * before the suffix is empty so it normalizes to root → null. Either
+	 * "null (no match)" or "null (root match)" is acceptable here; pinned to
+	 * the actual current behavior so changes are visible.
+	 */
+	public function test_extract_authorize_prefix_no_leading_slash_yields_null(): void {
+		$this->assertNull(
+			AuthorizationServer::extract_authorize_path_prefix( 'oauth/authorize' )
+		);
+	}
+
+	/** Unrelated paths return null. */
+	public function test_extract_authorize_prefix_unrelated_path_yields_null(): void {
+		$this->assertNull(
+			AuthorizationServer::extract_authorize_path_prefix( '/some-other-path' )
+		);
+	}
+
+	/**
+	 * Prefix that itself contains '/oauth' is accepted — the helper's
+	 * contract is purely structural ("split on the last '/oauth/authorize'
+	 * suffix"). Whether the prefix actually maps to a real subsite is a
+	 * downstream concern (WP resolves blog ID from host+path). Pinned so the
+	 * security boundary is explicit.
+	 */
+	public function test_extract_authorize_prefix_prefix_containing_oauth_segment(): void {
+		$this->assertSame(
+			'/oauth',
+			AuthorizationServer::extract_authorize_path_prefix( '/oauth/oauth/authorize' )
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// AuthorizeEndpoint::self_url() — must include the prefix when supplied
+	// -------------------------------------------------------------------------
+
+	public function test_self_url_without_prefix_returns_root_authorize_url(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$self_url = $this->call_self_url( null );
+		$this->assertSame( 'http://example.com/oauth/authorize', $self_url );
+	}
+
+	public function test_self_url_with_path_prefix_includes_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$self_url = $this->call_self_url( '/sub2' );
+		$this->assertSame( 'http://example.com/sub2/oauth/authorize', $self_url );
+	}
+
+	public function test_self_url_with_multi_segment_prefix(): void {
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$self_url = $this->call_self_url( '/team/blog' );
+		$this->assertSame( 'http://example.com/team/blog/oauth/authorize', $self_url );
+	}
+
+	// -------------------------------------------------------------------------
+	// AuthorizeEndpoint::resource_indicator() — must mirror discovery URL
+	// when a prefix is supplied; preserve rest_url() fallback when null.
+	// -------------------------------------------------------------------------
+
+	public function test_resource_indicator_without_prefix_uses_rest_url(): void {
+		// rest_url() stub returns wp_test_home_url . '/wp-json/' . path.
+		$indicator = $this->call_resource_indicator( null );
+		$this->assertSame(
+			'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			$indicator
+		);
+	}
+
+	public function test_resource_indicator_with_path_prefix_uses_discovery_resource_url(): void {
+		// DiscoveryEndpoints::resource_url('/sub2') derives from HTTP_HOST,
+		// not wp_test_home_url, because pre-WP it can't trust rest_url().
+		$_SERVER['HTTP_HOST'] = 'example.com';
+		$indicator = $this->call_resource_indicator( '/sub2' );
+		$this->assertSame(
+			'http://example.com/sub2/wp-json/mcp/mcp-adapter-default-server',
+			$indicator
+		);
+	}
+
+	public function test_resource_indicator_empty_prefix_treated_as_no_prefix(): void {
+		// Empty string is treated the same as null — falls back to rest_url().
+		$indicator = $this->call_resource_indicator( '' );
+		$this->assertSame(
+			'https://example.com/wp-json/mcp/mcp-adapter-default-server',
+			$indicator
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Reflection helpers — self_url and resource_indicator are private.
+	// -------------------------------------------------------------------------
+
+	private function call_self_url( ?string $path_prefix ): string {
+		$ref = new \ReflectionClass( AuthorizeEndpoint::class );
+		$m   = $ref->getMethod( 'self_url' );
+		return (string) $m->invoke( null, $path_prefix );
+	}
+
+	private function call_resource_indicator( ?string $path_prefix ): string {
+		$ref = new \ReflectionClass( AuthorizeEndpoint::class );
+		$m   = $ref->getMethod( 'resource_indicator' );
+		return (string) $m->invoke( null, $path_prefix );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #90 — Phase B.1 of the Public Alpha Hardening sprint.

Pre-fix, `AuthorizationServer::intercept_pre_wp_routes()` only matched the exact root path `/oauth/authorize`. A path-style multisite client following its own discovery metadata (which advertises `https://example.com/<prefix>/oauth/authorize`) fell through to WordPress and 404'd before consent could render. M-5 (#60) addressed the same gap on the `.well-known/*` discovery paths but did not extend the fix to `/oauth/authorize`; this PR closes the remaining half.

## Fix shape

Two parts, matching the §4 B.1 plan recommendation.

**1. Interceptor accepts `(/<prefix>)?/oauth/authorize`.**

`AuthorizationServer::intercept_pre_wp_routes()` now branches on `str_ends_with($path, '/oauth/authorize')` and extracts the leading prefix via a new `AuthorizationServer::extract_authorize_path_prefix()` helper. Mirrors `extract_path_prefix()` but anchored at the suffix instead of a known leading prefix. Returns `null` for root, `/<prefix>` for subsite paths.

Per orchestrator confirmation, the helper is structurally consistent with the discovery-side prefix extraction: any non-empty leading segment that begins with `/` is accepted. **Whether the prefix maps to an actual subsite is a downstream concern** — WordPress resolves blog ID from host+path during its own routing. This helper is a URL-construction aid only; the security boundary is explicit.

**2. `?string $path_prefix` threaded through `AuthorizeEndpoint`.**

- `dispatch(?string $path_prefix = null)` → `handle_get` / `handle_post` → `redirect_to_login` / `render_consent`
- `self_url($prefix)` → `DiscoveryEndpoints::issuer($prefix) . '/oauth/authorize'` — used for the consent form `action` and the `redirect_to` argument to `wp_login_url()`
- `resource_indicator($prefix)` → `DiscoveryEndpoints::resource_url($prefix)` when prefix is non-null/non-empty; `rest_url()` fallback retained for null prefix

The reason `resource_indicator()` doesn't always use `rest_url()`: pre-WP, `rest_url()` may not yet have resolved the subsite from the request path and can return the network-root URL even on a subsite request. For path-style we build the URL explicitly via `DiscoveryEndpoints::resource_url($prefix)` so it matches what the subsite's discovery metadata advertised — which is what `AuthorizeRequestValidator` validates the bridge's `resource` parameter against.

## Files

- [src/Auth/OAuth/AuthorizationServer.php](src/Auth/OAuth/AuthorizationServer.php) — interceptor branch + new `extract_authorize_path_prefix()` helper
- [src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php](src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php) — `dispatch`, `handle_get`, `handle_post`, `redirect_to_login`, `render_consent`, `self_url`, `resource_indicator`
- [tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php](tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php) — new test file, 14 cases
- [CHANGELOG.md](CHANGELOG.md) — opens `[1.4.5] - Unreleased` section with the fix and the alpha-scope known-limitation note

## Test plan

- [x] `composer test` — 907 tests pass (893 baseline + 14 new)
- [x] `composer validate --strict` — `composer.json` valid
- [x] Subdomain-style multisite path unchanged (`self_url(null)` returns `/oauth/authorize`, no prefix)
- [x] Single-site adapter unchanged (null-prefix path is the existing behavior)
- [x] `extract_authorize_path_prefix()` boundary cases pinned: root, single-segment, multi-segment, suffix-substring (`/oauth/authorizeextra`), trailing slash, no leading slash, prefix containing `/oauth` segment
- [x] `self_url()` and `resource_indicator()` exercised with `null` / `/sub2` / `/team/blog` / `''` via reflection

End-to-end path-style verification on a real path-style multisite is **not** a release gate per the Public Alpha Hardening sprint plan §3 alpha-scope lock — alpha is subdomain-style only. The unit-level coverage in this PR is the intentional release gate; building/locating a path-style test environment is a follow-up infrastructure task tracked separately.

## Deviations

- **None from the §4 B.1 plan.** The fix shape is exactly what the sprint plan recommended. Critical files match the plan ([`AuthorizationServer.php:216-218`](src/Auth/OAuth/AuthorizationServer.php) and the authorize helpers).
- **Unit-level coverage is the release gate, by design.** Per §3 alpha-scope lock, path-style multisite end-to-end testing is explicitly carved out as a follow-up infrastructure task. This is not a corner cut — the alpha is subdomain-style only, and path-style is named as a documented known limitation in the v1.4.5 CHANGELOG. A future "path-style multisite alpha" expansion will gate on the end-to-end environment being available.
- **`extract_authorize_path_prefix()` is a separate helper from `extract_path_prefix()`** rather than a generalized shared helper. The suffix-anchored case is structurally different from the prefix-anchored case (head vs. tail extraction, different malformed-input guards), and a single-purpose helper keeps each call site readable. If a future change introduces a third anchor mode, refactoring to a shared helper at that point is the cheaper path.
- **Behavior expansion on a niche edge case:** any request whose path *ends* in `/oauth/authorize` will now be intercepted, even if a non-multisite operator happens to have a custom rewrite rule mapping e.g. `/something/oauth/authorize` to a real page. Pre-fix that request fell through to WP and rendered the page; post-fix it gets dispatched to `AuthorizeEndpoint` and returns 400 for missing OAuth params. This mirrors the discovery side, which has accepted arbitrary leading prefixes since M-5 (#60). The same operator would already be unable to host their own discovery metadata at that subsite without conflict, so the practical surface is vanishingly small.
- **Out of scope: `is_well_known_or_oauth_path()`** still uses `str_starts_with($path, '/oauth/')`, so a path-style authorize request from a *disallowed host* would silently return without logging a `boundary.oauth_host_rejected` event. This code path is not reachable in path-style multisite (the host is the network host, which is in the allowlist), so this is not a #90 regression — but flagging it here in case a follow-up wants symmetry with the `.well-known/*` host-rejection logging.

## Sprint context

PR-1 of 5 in the Phase B queue (adapter v1.4.5). Sprint plan: [Sprint Plan — Public Alpha Hardening 2026-05-04](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/milestone/3). Workflow law applies: orchestrator merges, dev does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)