### PR TITLE
docs(README): rewrite for OAuth resource server + Connected Bridges + layered-permissions surface coverage (v1.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.4.7] - 2026-05-08
+
+Documentation update — README rewrite for OAuth resource server + Connected Bridges + layered-permissions surface coverage. Code unchanged from v1.4.6.
+
+### Documentation
+
+- README rewritten end-to-end:
+  - OAuth 2.1 resource server + authorization server endpoints documented (RFC 9728 / 8414 discovery, RFC 7591 DCR, `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`, scope enforcement at every dispatch path, selected-role enforcement)
+  - Connected Bridges admin UI section added — operators manage OAuth client registrations through *WP Admin → Settings → MCP Adapter → Connected Bridges*
+  - Settings → Permissions UI section added (the layered-permissions enforcement layer the adapter contributes to)
+  - PHP version requirement corrected from 8.0+ to 8.2+ (matches `composer.json` `require.php` and plugin header `Requires PHP`)
+  - Boundary event log emit section added — names the v0.1 events the adapter emits (`boundary.session.init`, `boundary.session.terminated`, `boundary.auth.denied`, `boundary.transport.error`, `boundary.rate_limit_hit`)
+  - "Usage with the Abilities MCP bridge" section rewritten to reflect recommended install paths (`.mcpb` install for Claude Desktop + `npm install -g @wickedevolutions/abilities-mcp` for terminal MCP clients) — replaces the obsolete `node /path/to/...` example
+  - New Notes section: four-layer permissions model, paired ability classes, discovery-vs-authorization distinction (`mcp-adapter-discover-abilities` is registration manifest; `suite/get-status` is authorization gate), selected-consent-role-on-refresh tracked on [#94](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/94)
+- Welcome block at top with verbatim *"Welcome, Wordpressnaut"* spaceship paragraph + 3 URL pointers (knowledge.wickedevolutions.com, wickedevolutions.com, abilitiesforai.io)
+- Disclaimer block from J at the very top
+- Pointer to [PRINCIPLES.md](PRINCIPLES.md) as the *Official WordPress Compatibility Contract* binding all four suite repos
+- Existing bottom *Disclaimer* section retired (replaced by J's at top)
+
+Closes [#111](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/111).
+
 ## [1.4.6] - 2026-05-07
 
 Alpha Release Gate hotfix bundle — Phase B.1 of the Alpha Release Gate + Issue Reconciliation 2026-05-07 sprint plan. Three coordinated fixes in a single release: PII redaction tightening, schema-printer correctness, and OAuth scope coverage with a drift test that prevents the same class of bug from re-opening.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # Abilities MCP Adapter
 
-Converts WordPress abilities into MCP (Model Context Protocol) tools, resources, and prompts. Any ability registered via `wp_register_ability()` automatically becomes accessible to AI agents — zero configuration required.
+> **A word from J, the director of this creation.**
+>
+> Everything you see here is built by a single human who does not read or write code and is written by AI. Everything is in constant motion and by observing that movement we create the illusion of being still. Change happens at any given moment. It is simply a law of evolution. Stillness is an act of conscious awareness, not a reality of life.
+
+## Welcome, Wordpressnaut
+
+Here is the spaceship, now you'll have to learn how to fly and please do remember, humans make mistakes, humans created AI so AI makes mistakes. Learning to fly is your job and to do that you'll need structure, systems, checklists, principles and understanding you stand before a magical leap of a steep and wonderful learning curve. Be patient and do backup things.
+
+→ Knowledge layer (deeper traversal): [https://knowledge.wickedevolutions.com](https://knowledge.wickedevolutions.com)
+→ [https://wickedevolutions.com](https://wickedevolutions.com)
+→ [https://abilitiesforai.io](https://abilitiesforai.io)
+
+Our development aim is the *Official WordPress Compatibility Contract* — see [PRINCIPLES.md](PRINCIPLES.md) for the full binding principles across the four-repo suite.
+
+---
+
+Converts WordPress abilities into MCP (Model Context Protocol) tools, resources, and prompts. Any ability registered via `wp_register_ability()` automatically becomes accessible to AI agents — zero configuration required. Runs the OAuth 2.1 resource server + authorization server for the suite, ships the Settings → Permissions UI that gates per-module execution, and contributes the runtime layer of the four-layer permissions model.
 
 ## Features
 
@@ -11,28 +27,50 @@ Converts WordPress abilities into MCP (Model Context Protocol) tools, resources,
 - **Permission metadata** — abilities carry `permission` (read/write/delete) and `enabled` state in MCP annotations
 - **MCP annotations** — readonly, destructive, idempotent hints flow through to tool definitions
 - **Schema transformation** — JSON Schema to MCP-compatible format with automatic wrapping
-- **Error mapping** — WP_Error objects map cleanly to MCP error codes
+- **Error mapping** — `WP_Error` objects map cleanly to MCP error codes
 - **HTTP transport** — REST API endpoint with session management, plus minimal Server-Sent Events stub
+
+### OAuth 2.1 resource server + authorization server (since v1.4.0)
+
+- **RFC 9728 + RFC 8414 discovery** — `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` advertise the OAuth surface; HTTPS-only, `.well-known/*` refuses redirects
+- **RFC 7591 Dynamic Client Registration** — `/oauth/register` mints a fresh client_id per bridge; rate-limited per-IP with atomic counters (Memcached/Redis when available, transient fallback)
+- **`/oauth/authorize`** — authorization endpoint with PKCE S256 verifier validation, role-selector consent screen, host allowlist gate, trusted-proxy-aware rate limiting; supports both root and path-style WordPress installs
+- **`/oauth/token`** — token endpoint with auth-code grant + refresh-token grant; refresh rotation uses encrypt-at-rest grace-window retry (HKDF-SHA256 key derived from old refresh + `AUTH_KEY`)
+- **`/oauth/revoke`** — RFC 7009 revocation with `client_id` proof of possession; cascades through the refresh-token family
+- **Scope enforcement (`OAuthScopeEnforcer`)** — wired at every dispatch path (`ToolsHandler`, `ResourcesHandler`, `PromptsHandler`, `ExecuteAbilityAbility`); scopes are derived from registered ability categories per Principle 9 (Scope Coverage Is Derived Or Coverage-Tested), with a CI drift test pinning the contract
+- **Selected role enforcement** — operator's selected role at consent time persists through the auth-code → access-token → refresh-token chain; `SelectedRoleEnforcer` replaces `$allcaps` for OAuth-bound users only
+
+### Connected Bridges admin UI
+
+Operators manage OAuth client registrations through **WP Admin → Settings → MCP Adapter → Connected Bridges**:
+
+- One row per registered bridge with `client_id`, redirect URI, requested + sensitive scopes, last activity, and revoke action
+- DCR registration response carries `sensitive_scopes_requested` so the admin UI can show *"X sensitive scopes requested — will require explicit consent"* without inventing the classification client-side
+- AuthHeaderProbe diagnostic surfaces whether the `Authorization` header survives end-to-end against MCP-resource paths
+
+### Settings → Permissions UI (the layered-permissions enforcement layer)
+
+Operators control which modules and which tiers (read/write/delete) the bridge can execute through:
+
+- **WP Admin → Settings → MCP Abilities** — per-ability enable/disable controls with permission tier overrides
+- **WP Admin → Settings → MCP Safety** — master redaction toggle (with warning checkbox), keyword editor per bucket, per-ability exemption list, trusted-proxy configuration
+
+Per-module read/write/delete state is the *Abilities for AI module* layer in the [four-layer permissions model](#four-layer-permissions-model). When an ability is denied at this layer, the runtime returns `[ability_disabled]` with the module name and the WP Admin path to fix it.
 
 ### Safety surface (v1.4.x)
 
-- **Three-bucket response redaction** — secrets always filtered (passwords, API keys, tokens, hashes); payment / regulated identifiers and contact PII filtered by default with operator-controlled overrides; type-aware markers preserve schema shape
-- **Per-ability exemptions** — operators unlock contact PII visibility on specific abilities (e.g. CRM workflows that legitimately need email) without weakening defaults globally
+- **Three-bucket response redaction** — secrets always filtered (passwords, API keys, tokens, hashes); payment / regulated identifiers and contact PII filtered by default with operator-controlled overrides; type-aware markers preserve schema shape; prefixed/suffixed email field variants covered as of v1.4.6 (#103)
+- **Per-ability exemptions** — operators unlock contact PII visibility on specific abilities (e.g. CRM workflows that legitimately need email) without weakening defaults globally; weakening default safety requires in-chat 1/2 confirmation; Bucket 2 (payment/regulated) cannot be weakened through chat at any granularity
 - **Origin allowlist + scoped CORS** — defense-in-depth against DNS rebinding; CORS scoped to MCP routes only, no global REST API side effects
 - **Rate limiting at /mcp boundary** — per-IP and per-user windows, with Cloudflare and custom-allowlist trusted-proxy presets
 - **Boundary event log** — structured events for session lifecycle, auth denials, transport errors, rate-limit hits, and settings audit changes (consumed by [Abilities for AI](https://github.com/Wicked-Evolutions/abilities-for-ai)'s `kl_boundary` writer when present)
 - **Sanitized event hooks** — third-party listeners receive sanitized metadata only; raw API keys are hashed before any listener fires
-
-### Operator UI
-
-- **Settings → MCP Abilities** — per-ability enable/disable controls, permission tier overrides
-- **Settings → MCP Safety** — master redaction toggle (with warning checkbox), keyword editor per bucket, per-ability exemption list, trusted-proxy configuration
-- **AI-callable safety configuration** — operators can ask their AI to read or strengthen safety settings; weakening default safety requires in-chat 1/2 confirmation; Bucket 2 (payment/regulated) cannot be weakened through chat at any granularity
+- **AI-callable safety configuration** — operators can ask their AI to read or strengthen safety settings via the dedicated `settings/*` ability namespace below
 
 ## Requirements
 
 - WordPress 6.9+ (Abilities API)
-- PHP 8.0+
+- PHP 8.2+
 
 ## Installation
 
@@ -57,10 +95,17 @@ You also need **[Abilities for AI](https://community.wickedevolutions.com/item/a
 
 | Tool | Description |
 |------|-------------|
-| `mcp-adapter-discover-abilities` | List all available abilities with category and tier |
+| `mcp-adapter-discover-abilities` | List all available abilities with category and tier (registration manifest at ability-name resolution) |
 | `mcp-adapter-get-ability-info` | Get schema and metadata for a specific ability |
 | `mcp-adapter-execute-ability` | Execute an ability with input parameters |
-| `mcp-adapter-batch-execute` | Execute multiple abilities in a single request (max 20) |
+| `mcp-adapter-batch-execute` | Execute multiple abilities in a single request (max 20). Reach for compact-class abilities when the batch is broad — see [Notes — Paired ability classes](#paired-ability-classes) |
+| `mcp-adapter/get-started` | Operator orientation entry point (`recommended_first_steps` available for ability plugins to populate) |
+
+### Suite + status
+
+| Tool | Description |
+|------|-------------|
+| `suite/get-status` | Return per-module category × tier permission state — the authorization gate at category resolution. Pair with `mcp-adapter-discover-abilities` for the registration manifest at ability resolution |
 
 ### Safety configuration (require `manage_options`)
 
@@ -74,46 +119,34 @@ You also need **[Abilities for AI](https://community.wickedevolutions.com/item/a
 | `settings/exempt-ability-from-bucket3` | Per-ability Bucket 3 unlock — in-chat 1/2 confirmation required |
 | `settings/unexempt-ability-from-bucket3` | Re-lock an exemption |
 
-## Permission Metadata
-
-Each ability carries permission metadata in its MCP annotations:
-
-- **`permission`** — `read`, `write`, or `delete`, derived from ability annotations
-- **`enabled`** — boolean, controlled via Settings → MCP Abilities
-
-When a disabled ability is called, the adapter returns a structured error:
-
-```json
-{
-  "error": "permission_required",
-  "permission": "write",
-  "ability": "content/create",
-  "enabled": false
-}
-```
-
 ## How Abilities Become MCP Tools
 
 Abilities are exposed as MCP tools when either:
+
 1. `show_in_rest` is set to `true` on the ability (WordPress 6.9+ standard)
 2. `meta.mcp.public` is `true` (fallback for older registrations)
 
-The adapter reads `input_schema` and `output_schema` to generate MCP-compatible definitions, and maps annotations like `readonly`, `destructive`, and `idempotent` to MCP hint fields.
+The adapter reads `input_schema` and `output_schema` to generate MCP-compatible definitions, and maps annotations like `readonly`, `destructive`, and `idempotent` to MCP hint fields. Per [PRINCIPLES.md](PRINCIPLES.md) Principle 3 (Adapter Is A Projection), the adapter projects the WordPress registry — it filters, redacts, annotates, scopes, and rate-limits, but it does not redefine schemas or invent alternate versions of business-domain abilities.
 
-## Usage with MCP Bridge
+## Boundary event log (events the adapter emits)
 
-For remote access from any MCP-compatible AI client or IDE, use the [Abilities MCP](https://github.com/Wicked-Evolutions/abilities-mcp) bridge:
+The adapter emits structured boundary events through the `mcp_adapter_boundary_event` action hook for any third-party listener (the canonical consumer is [Abilities for AI](https://github.com/Wicked-Evolutions/abilities-for-ai)'s `BoundaryEventLogger`, which writes them to the `kl_boundary` table). Events emitted:
 
-```json
-{
-  "mcpServers": {
-    "wordpress": {
-      "command": "node",
-      "args": ["/path/to/abilities-mcp/abilities-mcp.js"]
-    }
-  }
-}
-```
+- `boundary.session.init` — MCP session created
+- `boundary.session.terminated` — MCP session ended
+- `boundary.auth.denied` — Bearer auth or scope check rejected a request
+- `boundary.transport.error` — transport-layer failure
+- `boundary.rate_limit_hit` — per-IP or per-user rate window exceeded
+
+Events are sanitized at the boundary — third-party listeners never see raw secrets. Metadata-only allowlist applied as defense-in-depth on top.
+
+## Usage with the Abilities MCP bridge
+
+For remote access from any MCP-compatible AI client, install the [Abilities MCP](https://github.com/Wicked-Evolutions/abilities-mcp) bridge:
+
+- **Claude Desktop:** download `abilities-mcp.mcpb` from the [bridge's latest GitHub Release](https://github.com/Wicked-Evolutions/abilities-mcp/releases/latest), drag into Claude Desktop, then upgrade to OAuth via `abilities-mcp upgrade-auth <site>` from terminal
+- **Terminal MCP clients (Claude Code, Cursor, Codex, etc.):** `npm install -g @wickedevolutions/abilities-mcp`, then `abilities-mcp add-site <url>` — OAuth by default, with PKCE consent in your browser
+- **Power-user `wp-sites.json` config:** see the [bridge README](https://github.com/Wicked-Evolutions/abilities-mcp#readme) for hand-curated multi-site configuration
 
 ## Creating Custom MCP Servers
 
@@ -133,9 +166,34 @@ add_action( 'mcp_adapter_init', function( $adapter ) {
 });
 ```
 
+## Notes
+
+### Four-layer permissions model
+
+When an ability is denied, the rejection comes from one of four independent layers. The runtime error names the layer:
+
+1. **Abilities for AI module permission** — per-blog read/write/delete toggle in *WP Admin → Abilities for AI → Permissions* (and on the adapter side, *WP Admin → Settings → MCP Abilities*). The runtime returns `[ability_disabled]` with the module name and where to fix it.
+2. **WordPress capability** — the WordPress user the request authenticates as lacks the relevant capability. WordPress core REST returns `rest_forbidden` / `rest_cannot_*` codes.
+3. **OAuth scope** — the bearer token does not include the scope the ability requires. The adapter's `OAuthScopeEnforcer::check()` returns an `insufficient_scope` rejection at dispatch time.
+4. **Unclear** — generic 500, timeout, or malformed response. Check server logs.
+
+The four gates apply together by design (see [PRINCIPLES.md](PRINCIPLES.md), Principle 5 — *Permissions Stay Layered*). The runtime error tells you which gate fired so you can act at the right layer.
+
+### Paired ability classes
+
+The product ships compact-vs-full pairs across the API by design. Each ability description names its payload tradeoff. Pick the pair member that matches the traversal you intend — compact for bulk discovery, full for targeted inspection. The pattern recurs across categories beyond `content/*`.
+
+### Discovery vs authorization (two separate inspection surfaces)
+
+`mcp-adapter-discover-abilities` returns the registration manifest — every ability that exists in the system, regardless of whether the current category × tier permissions allow it to execute. `suite/get-status` returns the authorization gate state at category × tier resolution. Both are valid surfaces; each answers a different question; neither substitutes for the other.
+
+### Selected consent role on token refresh
+
+The role-downgrade fix (#88, v1.4.5) persists the operator's selected role on the auth-code → access-token → refresh-token chain for tokens minted from the interactive consent screen. Auto-approve refresh / silent reauth does not currently carry the prior consent's role choice. Mitigation: explicit reauth (`abilities-mcp reauth <site> --scope=...` on the bridge CLI, or revoke + re-consent) renders a fresh consent screen and resets the chain to the chosen role. Tracked on [#94](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/94).
+
 ## Naming Lineage
 
-This plugin was originally a thin wrapper around `wordpress/mcp-adapter` (Composer package). It has been fully decoupled and is now a standalone codebase under the `WickedEvolutions\McpAdapter` namespace. The upstream package is credited but no longer a dependency.
+This plugin was originally a thin wrapper around `wordpress/mcp-adapter` (Composer package). It has been fully decoupled and is now a standalone codebase under the `WickedEvolutions\McpAdapter` namespace. The upstream package is credited but no longer a dependency. Per [PRINCIPLES.md](PRINCIPLES.md), we monitor `wordpress/mcp-adapter` as a reference implementation, but our adapter may differ where product requirements demand it, provided we preserve WordPress-native ability semantics.
 
 ## `wpab__` Resolver vs MCP Adapter
 
@@ -148,12 +206,6 @@ We continuously add knowledge docs, skills, and agent patterns to [knowledge.wic
 ## Version
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
-
-## Disclaimer
-
-Humans make mistakes — as we know from the present day and history. Humans trained AI. AI acts accordingly. AI predicts probability based on the context window it holds. It is trained to sound certain, as if everything is truth, and to "fix" everything so the human becomes satisfied.
-
-Learn how to communicate with AI. You are fully responsible for using AI in your life, business, and projects. Using these products is your personal responsibility to learn and own.
 
 ## Author
 

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: Abilities MCP Adapter
  * Plugin URI:  https://github.com/Wicked-Evolutions/abilities-mcp-adapter
  * Description: Exposes WordPress abilities as MCP tools, resources, and prompts. Upload, activate, and your WordPress abilities become MCP tools.
- * Version:     1.4.6
+ * Version:     1.4.7
  * Author:      Wicked Evolutions
  * Author URI:  https://wickedevolutions.com
  * Copyright:   Copyright (C) 2026 Wicked Evolutions
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Plugin constants.
-define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.6' );
+define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.7' );
 define( 'ABILITIES_MCP_ADAPTER_PATH', plugin_dir_path( __FILE__ ) );
 
 // License manager — FluentCart license for auto-update delivery.


### PR DESCRIPTION
## Summary

Closes #111. Documentation update — code unchanged from v1.4.6. Bumps plugin header `Version:` and `ABILITIES_MCP_ADAPTER_VERSION` constant to 1.4.7 so the corrected README ships inside the next plugin .zip artifact.

## What changed

- README rewritten end-to-end:
  - **OAuth 2.1 resource server + authorization server** documented (RFC 9728 / 8414 discovery, RFC 7591 DCR, `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`, scope enforcement at every dispatch path, selected-role enforcement). OAuth was invisible in the v1.4.6 README despite being available since v1.4.0.
  - **Connected Bridges admin UI** section added
  - **Settings → Permissions UI** section added (the layered-permissions enforcement layer the adapter contributes to)
  - **PHP version requirement** corrected from 8.0+ to 8.2+ (matches `composer.json` `require.php` and plugin header `Requires PHP`)
  - **Boundary event log emit** section added — names the v0.1 events the adapter emits (`boundary.session.init`, `boundary.session.terminated`, `boundary.auth.denied`, `boundary.transport.error`, `boundary.rate_limit_hit`)
  - **Usage with the Abilities MCP bridge** rewritten to reflect recommended install paths (`.mcpb` + `npm install -g @wickedevolutions/abilities-mcp`)
  - **New Notes section:** four-layer permissions model, paired ability classes, discovery-vs-authorization distinction, selected-consent-role-on-refresh
  - **Welcome block** at top with Wordpressnaut spaceship paragraph + 3 URL pointers
  - **Disclaimer** from J at the very top
  - **Pointer to PRINCIPLES.md** as the Official WordPress Compatibility Contract
  - Old bottom Disclaimer section retired
- Version bumps: plugin header `Version:` + `ABILITIES_MCP_ADAPTER_VERSION` constant 1.4.6 → 1.4.7
- New `[1.4.7]` CHANGELOG entry

## Language rules verified

- **Rule 1 — no "wrong" framing:** `grep -ni '\\bwrong\\b' README.md` → no matches
- **Rule 2 — no "limitation" framing:** `grep -ni 'limitation' README.md` → no matches

## Test plan

- [ ] CI green (test.yml runs PHPUnit — no code changes, expected to pass cleanly)
- [ ] On merge: build v1.4.7 .zip + create v1.4.7 GitHub Release with the new artifact (orchestrator-dispatched per J's authorization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)