### PR TITLE
fix(redaction): extend schema-metadata exemption to tools/list method paths (#113)

### DIFF
--- a/src/Infrastructure/Redaction/ResponseRedactionGate.php
+++ b/src/Infrastructure/Redaction/ResponseRedactionGate.php
@@ -70,7 +70,7 @@ final class ResponseRedactionGate {
 		$ability_name = self::extract_ability_name( $method, $params );
 
 		try {
-			$redactor = new ResponseRedactor( $ability_name );
+			$redactor = new ResponseRedactor( $ability_name, $method );
 			$redacted = $redactor->redact( $result );
 			$counts   = $redactor->get_counts();
 		} catch ( RedactionLimitExceeded $e ) {

--- a/src/Infrastructure/Redaction/ResponseRedactor.php
+++ b/src/Infrastructure/Redaction/ResponseRedactor.php
@@ -14,11 +14,14 @@
  *     redacted — `admin_email`, `author_email`, `billingEmail`, `to_email`, etc.
  *     The substring rule is intentionally scoped to the `email` family only;
  *     phone / address generalisation is contract-polish work.
- *   - Schema-metadata paths (`input_schema`, `output_schema`) are exempt from
- *     redaction (issue #105). Their subtrees describe ability shape, not data,
- *     so running keyword/substring matching over property names like `email`,
- *     `username`, `password` would corrupt the cold-AI contract. The exemption
- *     is path-aware — only the literal `input_schema`/`output_schema` keys
+ *   - Schema-metadata paths (`input_schema`/`output_schema` in the WP REST
+ *     shape, `inputSchema`/`outputSchema` in the MCP wire shape) are exempt
+ *     from redaction (issue #105 for the per-ability meta-tool path,
+ *     completed by issue #113 for the method-level `tools/list` and
+ *     `tools/list/all` paths). Their subtrees describe ability shape, not
+ *     data, so running keyword/substring matching over property names like
+ *     `email`, `username`, `password` would corrupt the cold-AI contract.
+ *     The exemption is path-aware — only the literal schema-metadata keys
  *     trigger pass-through; field-name matching resumes below them only when
  *     the same names appear OUTSIDE a schema subtree.
  *   - When a field name matches, the ENTIRE value at that key is replaced (recursively
@@ -110,10 +113,14 @@ final class ResponseRedactor {
 	private int $node_count = 0;
 
 	/**
-	 * Whether the schema-metadata path exemption (issue #105) is active for
-	 * this redactor instance. Set when the ability that produced the response
-	 * is one of the dispatcher meta-tools that returns ability schemas as
-	 * structural metadata rather than runtime data.
+	 * Whether the schema-metadata path exemption (issues #105 + #113) is
+	 * active for this redactor instance. Set when either:
+	 *   - the ability that produced the response is one of the dispatcher
+	 *     meta-tools that returns ability schemas as structural metadata
+	 *     (per {@see SCHEMA_METADATA_ABILITIES}, issue #105); or
+	 *   - the JSON-RPC method is one of the schema-emit metadata methods
+	 *     that lists tool schemas as the response payload itself (per
+	 *     {@see SCHEMA_METADATA_METHODS}, issue #113).
 	 *
 	 * @var bool
 	 */
@@ -138,11 +145,31 @@ final class ResponseRedactor {
 	);
 
 	/**
+	 * JSON-RPC methods whose response body IS the tool-schema catalog —
+	 * the MCP protocol's tool-discovery surface. Each tool entry carries
+	 * `inputSchema` / `outputSchema` (camelCase, MCP wire shape) describing
+	 * the registered ability's WordPress-native schema. Walking redaction
+	 * across these keys corrupts the schemas Anthropic / OpenAI / generic
+	 * draft-2020-12 validators check at tool-load time (issue #113 —
+	 * completes the #105 exemption pattern for the method-level path).
+	 *
+	 * Audit pattern: any future MCP method that emits schemas as its
+	 * response payload (e.g. a hypothetical `tools/get-info`, or new
+	 * MCP protocol additions) registers itself here explicitly rather
+	 * than relying on a blanket method-level pass-through.
+	 */
+	private const SCHEMA_METADATA_METHODS = array(
+		'tools/list',
+		'tools/list/all',
+	);
+
+	/**
 	 * Build a redactor configured for the given ability call.
 	 *
 	 * @param string|null $ability_name Ability name (e.g. `users/list`), or null when method has no ability.
+	 * @param string|null $method       JSON-RPC method (e.g. `tools/list`), or null when unknown / unit-test contexts.
 	 */
-	public function __construct( ?string $ability_name = null ) {
+	public function __construct( ?string $ability_name = null, ?string $method = null ) {
 		$this->bucket1_set = self::flip_lower( RedactionConfig::bucket1_keywords() );
 		$this->bucket2_set = self::flip_lower( RedactionConfig::bucket2_keywords() );
 		$this->bucket3_set = self::flip_lower( RedactionConfig::bucket3_keywords() );
@@ -151,8 +178,12 @@ final class ResponseRedactor {
 		$this->bucket2_active  = $master && ! RedactionConfig::is_ability_exempt( $ability_name, RedactionConfig::BUCKET_PAYMENT );
 		$this->bucket3_active  = $master && ! RedactionConfig::is_ability_exempt( $ability_name, RedactionConfig::BUCKET_CONTACT );
 
-		$this->schema_metadata_exempt = null !== $ability_name
+		$ability_is_schema_meta = null !== $ability_name
 			&& in_array( $ability_name, self::SCHEMA_METADATA_ABILITIES, true );
+		$method_is_schema_meta  = null !== $method
+			&& in_array( $method, self::SCHEMA_METADATA_METHODS, true );
+
+		$this->schema_metadata_exempt = $ability_is_schema_meta || $method_is_schema_meta;
 	}
 
 	/**
@@ -280,14 +311,31 @@ final class ResponseRedactor {
 
 	/**
 	 * Whether the lower-cased key denotes a schema-metadata subtree exempt
-	 * from redaction (issue #105).
+	 * from redaction (issues #105 + #113).
 	 *
-	 * Scoped tightly to the two WordPress Abilities API schema fields. Broader
-	 * dispatcher-metadata exemption (e.g. `properties.<*>.description`,
+	 * Scoped tightly to the WordPress Abilities API schema fields in BOTH
+	 * naming conventions the suite traverses: snake_case (`input_schema` /
+	 * `output_schema`) as emitted by the WP-REST shape — meta-ability
+	 * responses like `mcp-adapter/get-ability-info` — AND camelCase
+	 * (`inputSchema` / `outputSchema`) as emitted by the MCP wire shape —
+	 * the `tools/list` / `tools/list/all` JSON-RPC method payloads in
+	 * {@see \WickedEvolutions\McpAdapter\Handlers\Tools\ToolsHandler}. Both
+	 * forms describe the same registered ability schema; treating them
+	 * symmetrically is the projection-layer contract.
+	 *
+	 * The key-name check fires only when the redactor was constructed in a
+	 * schema-metadata context (see {@see SCHEMA_METADATA_ABILITIES} /
+	 * {@see SCHEMA_METADATA_METHODS}). Outside those contexts a runtime
+	 * payload happening to use one of these key names still redacts.
+	 *
+	 * Broader dispatcher-metadata exemption (e.g. `properties.<*>.description`,
 	 * `properties.<*>.example`) is contract-polish work.
 	 */
 	private static function is_schema_metadata_key( string $lower_key ): bool {
-		return 'input_schema' === $lower_key || 'output_schema' === $lower_key;
+		return 'input_schema' === $lower_key
+			|| 'output_schema' === $lower_key
+			|| 'inputschema' === $lower_key
+			|| 'outputschema' === $lower_key;
 	}
 
 	/**

--- a/tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php
+++ b/tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * Regression coverage for issue #113 — `tools/list` and `tools/list/all`
+ * JSON-RPC responses must NOT have their per-tool `inputSchema` /
+ * `outputSchema` subtrees corrupted by the redaction pipeline.
+ *
+ * Completes the schema-metadata exemption pattern shipped by issue #105
+ * for the per-ability meta-tool path. The same defect surfaces on the
+ * method-level path: `tools/list` carries the same JSON Schema objects as
+ * `mcp-adapter/get-ability-info` but under MCP wire keys (`inputSchema`,
+ * `outputSchema`, camelCase) and with no per-ability name to key the
+ * existing #105 exemption against.
+ *
+ * Source: live capture from helenawillow.com 2026-05-10 — 40 of 789 tools
+ * had property schemas replaced by `["[redacted:bucket_3]"]`, breaking
+ * Anthropic API draft 2020-12 validation and yielding zero loaded tools.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Infrastructure\Redaction;
+
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\RedactionLimitExceeded;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactionGate;
+use WickedEvolutions\McpAdapter\Infrastructure\Redaction\ResponseRedactor;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class ToolsListSchemaExemptionTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+		$GLOBALS['wp_test_options']   = array();
+		$GLOBALS['wp_test_abilities'] = array();
+		ResponseRedactionGate::reset_name_cache_for_testing();
+	}
+
+	/**
+	 * Build a `tools/list` response shape (mirrors
+	 * {@see \WickedEvolutions\McpAdapter\Handlers\Tools\ToolsHandler::list_tools()}).
+	 * One entry per `$tools` row — each row is `[ name, inputSchemaProps,
+	 * outputSchemaProps ]`. `_metadata` is stripped by the gate before
+	 * redaction; we mirror that strip so direct-redactor tests see the same
+	 * shape as the gate-fed redactor.
+	 *
+	 * @param array<int,array{0:string,1:array<string,mixed>,2:array<string,mixed>}> $tools
+	 */
+	private function tools_list_response( array $tools ): array {
+		$entries = array();
+		foreach ( $tools as $row ) {
+			[ $name, $input_props, $output_props ] = $row;
+			$entries[] = array(
+				'name'         => $name,
+				'description'  => 'desc for ' . $name,
+				'type'         => 'action',
+				'inputSchema'  => array(
+					'type'                 => 'object',
+					'properties'           => $input_props,
+					'required'             => array_keys( $input_props ),
+					'additionalProperties' => false,
+				),
+				'outputSchema' => array(
+					'type'       => 'object',
+					'properties' => $output_props,
+				),
+			);
+		}
+
+		return array( 'tools' => $entries );
+	}
+
+	// ── Pin the live-captured bug shape (the array-sentinel replacement) ───
+
+	public function test_tools_list_pii_keyed_property_schema_passes_through(): void {
+		// Live capture shape: presto-player-create-email-collection had its
+		// `email_provider` property schema replaced by `["[redacted:bucket_3]"]`.
+		$response = $this->tools_list_response(
+			array(
+				array(
+					'presto-player-create-email-collection',
+					array(
+						'enabled'        => array( 'type' => 'boolean' ),
+						'email_provider' => array( 'type' => 'string', 'description' => 'Provider key' ),
+					),
+					array(
+						'id' => array( 'type' => 'integer' ),
+					),
+				),
+			)
+		);
+
+		$out = ResponseRedactionGate::apply( $response, 'tools/list', array(), 1 );
+
+		$this->assertSame(
+			array( 'type' => 'string', 'description' => 'Provider key' ),
+			$out['tools'][0]['inputSchema']['properties']['email_provider'],
+			'#113: inputSchema property whose name matches Bucket 3 must pass through verbatim on tools/list.'
+		);
+		$this->assertNotSame(
+			array( '[redacted:bucket_3]' ),
+			$out['tools'][0]['inputSchema']['properties']['email_provider'],
+			'#113: the array-sentinel marker must NOT appear inside a tools/list schema.'
+		);
+	}
+
+	public function test_tools_list_input_and_output_schema_pass_through_for_all_known_pii_property_families(): void {
+		// Covers the 40-tool failure surface from #113 — email family,
+		// password, address, ip — across both schemas on a single tool.
+		$response = $this->tools_list_response(
+			array(
+				array(
+					'users-create',
+					array(
+						'username' => array( 'type' => 'string', 'description' => 'WordPress login' ),
+						'email'    => array( 'type' => 'string', 'format' => 'email' ),
+						'password' => array( 'type' => 'string', 'minLength' => 8 ),
+						'phone'    => array( 'type' => 'string' ),
+					),
+					array(
+						'id'             => array( 'type' => 'integer' ),
+						'email'          => array( 'type' => 'string', 'format' => 'email' ),
+						'admin_email'    => array( 'type' => 'string', 'format' => 'email' ),
+						'address_line_1' => array( 'type' => 'string' ),
+						'ip'             => array( 'type' => 'string' ),
+					),
+				),
+			)
+		);
+
+		$out = ResponseRedactionGate::apply( $response, 'tools/list', array(), 1 );
+
+		$input_props  = $out['tools'][0]['inputSchema']['properties'];
+		$output_props = $out['tools'][0]['outputSchema']['properties'];
+
+		$this->assertSame( array( 'type' => 'string', 'description' => 'WordPress login' ), $input_props['username'] );
+		$this->assertSame( array( 'type' => 'string', 'format' => 'email' ),                $input_props['email'] );
+		$this->assertSame( array( 'type' => 'string', 'minLength' => 8 ),                   $input_props['password'] );
+		$this->assertSame( array( 'type' => 'string' ),                                      $input_props['phone'] );
+
+		$this->assertSame( array( 'type' => 'integer' ),                $output_props['id'] );
+		$this->assertSame( array( 'type' => 'string', 'format' => 'email' ), $output_props['email'] );
+		$this->assertSame( array( 'type' => 'string', 'format' => 'email' ), $output_props['admin_email'] );
+		$this->assertSame( array( 'type' => 'string' ),                  $output_props['address_line_1'] );
+		$this->assertSame( array( 'type' => 'string' ),                  $output_props['ip'] );
+	}
+
+	public function test_tools_list_all_variant_also_passes_schemas_through(): void {
+		// `tools/list/all` shape mirrors `tools/list` (per
+		// ToolsHandler::list_all_tools()) with an extra `available` bool.
+		// Both methods route through the same redaction gate.
+		$response = $this->tools_list_response(
+			array(
+				array(
+					'fluent-crm-create-contact',
+					array(
+						'email'          => array( 'type' => 'string', 'format' => 'email' ),
+						'phone'          => array( 'type' => 'string' ),
+						'address_line_1' => array( 'type' => 'string' ),
+					),
+					array(
+						'id'    => array( 'type' => 'integer' ),
+						'email' => array( 'type' => 'string', 'format' => 'email' ),
+					),
+				),
+			)
+		);
+		$response['tools'][0]['available'] = true;
+
+		$out = ResponseRedactionGate::apply( $response, 'tools/list/all', array(), 1 );
+
+		$this->assertSame(
+			array( 'type' => 'string', 'format' => 'email' ),
+			$out['tools'][0]['inputSchema']['properties']['email']
+		);
+		$this->assertSame(
+			array( 'type' => 'string', 'format' => 'email' ),
+			$out['tools'][0]['outputSchema']['properties']['email']
+		);
+		$this->assertTrue( $out['tools'][0]['available'] );
+	}
+
+	public function test_tools_list_clean_payload_remains_clean(): void {
+		// No-false-positive case: a tool whose schemas contain no
+		// PII-keyword-matching property names must survive the redaction
+		// pass unchanged. Pin the full schema by equality so any silent
+		// mutation regresses the test.
+		$response = $this->tools_list_response(
+			array(
+				array(
+					'posts-list',
+					array(
+						'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100 ),
+						'status'   => array( 'type' => 'string', 'default' => 'publish' ),
+					),
+					array(
+						'posts' => array( 'type' => 'array' ),
+					),
+				),
+			)
+		);
+
+		$out = ResponseRedactionGate::apply( $response, 'tools/list', array(), 1 );
+
+		$this->assertSame( $response['tools'][0]['inputSchema'],  $out['tools'][0]['inputSchema'] );
+		$this->assertSame( $response['tools'][0]['outputSchema'], $out['tools'][0]['outputSchema'] );
+	}
+
+	public function test_tools_list_redaction_counts_stay_zero_on_schema_payload(): void {
+		// Counter pin: traversing the exempt schema subtree must NOT
+		// increment any bucket counter. Mirrors
+		// SchemaPathExemptionTest::test_schema_subtree_does_not_increment_redaction_counters
+		// for the method-level path.
+		$response = $this->tools_list_response(
+			array(
+				array(
+					'users-create',
+					array(
+						'username' => array( 'type' => 'string' ),
+						'email'    => array( 'type' => 'string', 'format' => 'email' ),
+						'password' => array( 'type' => 'string' ),
+					),
+					array(
+						'id' => array( 'type' => 'integer' ),
+					),
+				),
+			)
+		);
+
+		$redactor = new ResponseRedactor( null, 'tools/list' );
+		$redactor->redact( $response );
+		$counts = $redactor->get_counts();
+
+		$this->assertSame( 0, $counts[1], 'Schema subtree must not increment Bucket 1 counter on tools/list.' );
+		$this->assertSame( 0, $counts[2] );
+		$this->assertSame( 0, $counts[3], 'Schema subtree must not increment Bucket 3 counter on tools/list.' );
+	}
+
+	// ── Negative-control: runtime-value redaction on tools/call still fires ──
+
+	public function test_negative_control_tools_call_users_list_still_redacts_email(): void {
+		// Proves the exemption is method-scoped: a `tools/call` response
+		// against a PII-returning ability still redacts the runtime values.
+		// `users-list` is reachable on any WordPress site with at least one
+		// user — the always-available negative-control target named in
+		// the sprint plan acceptance gate.
+		$tools_call_response = array(
+			'content'           => array(
+				array(
+					'type' => 'text',
+					'text' => '{"users":[{"id":1,"email":"jacob@willow.se"}]}',
+				),
+			),
+			'structuredContent' => array(
+				'users' => array(
+					array(
+						'id'    => 1,
+						'email' => 'jacob@willow.se',
+					),
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$tools_call_response,
+			'tools/call',
+			array( 'name' => 'users-list', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['structuredContent']['users'][0]['email'] );
+		$this->assertStringContainsString( '[redacted:bucket_3]', $out['content'][0]['text'], 'Dual-channel text snapshot must be regenerated from redacted structuredContent.' );
+		$this->assertStringNotContainsString( 'jacob@willow.se', $out['content'][0]['text'] );
+	}
+
+	public function test_negative_control_other_method_does_not_inherit_exemption(): void {
+		// `resources/list` or any other method outside SCHEMA_METADATA_METHODS
+		// must NOT inherit the exemption — runtime PII in a hypothetical
+		// resource listing would still redact. Pins the method allowlist as
+		// an allowlist, not a blanket pass-through.
+		$response = array(
+			'resources' => array(
+				array(
+					'name'  => 'user-record',
+					'email' => 'jacob@willow.se',
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply( $response, 'resources/list', array(), 1 );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['resources'][0]['email'] );
+	}
+
+	public function test_negative_control_runtime_payload_with_inputSchema_named_key_does_not_bypass(): void {
+		// Smuggling defence: when the method is OUTSIDE the allowlist, a
+		// runtime payload that happens to contain a key literally named
+		// `inputSchema` must still redact downstream PII. Mirrors
+		// SchemaPathExemptionTest::test_meta_list_post_meta_with_input_schema_named_meta_value_does_not_bypass_redaction
+		// for the method-level path.
+		$response = array(
+			'meta' => array(
+				'inputSchema' => array(
+					'admin_email' => 'admin@example.com',
+				),
+			),
+		);
+
+		$out = ResponseRedactionGate::apply(
+			$response,
+			'tools/call',
+			array( 'name' => 'meta-get-post-meta', 'arguments' => array() ),
+			1
+		);
+
+		$this->assertSame( '[redacted:bucket_3]', $out['meta']['inputSchema']['admin_email'] );
+	}
+
+	// ── Direct redactor unit-level coverage ────────────────────────────────
+
+	public function test_redactor_constructed_with_tools_list_method_activates_exemption(): void {
+		$response = array(
+			'tools' => array(
+				array(
+					'name'        => 'users-create',
+					'inputSchema' => array(
+						'properties' => array(
+							'email' => array( 'type' => 'string', 'format' => 'email' ),
+						),
+					),
+				),
+			),
+		);
+
+		$out = ( new ResponseRedactor( null, 'tools/list' ) )->redact( $response );
+
+		$this->assertSame(
+			array( 'type' => 'string', 'format' => 'email' ),
+			$out['tools'][0]['inputSchema']['properties']['email']
+		);
+	}
+
+	public function test_redactor_constructed_with_unrelated_method_does_not_activate_exemption(): void {
+		// Defensive: passing a non-allowlisted method must not bypass the
+		// per-key field-name check. A key literally named `inputSchema`
+		// at runtime still redacts PII underneath.
+		$response = array(
+			'inputSchema' => array(
+				'admin_email' => 'admin@example.com',
+			),
+		);
+
+		$out = ( new ResponseRedactor( null, 'initialize' ) )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['inputSchema']['admin_email'] );
+	}
+
+	public function test_redactor_with_null_method_preserves_pre_113_behaviour(): void {
+		// Backward-compat pin: callers that don't pass a method (the
+		// pre-#113 constructor signature) still see the redactor behave
+		// exactly as before. Mirrors the existing
+		// SchemaPathExemptionTest::test_no_ability_name_disables_schema_exemption
+		// assertion shape.
+		$response = array(
+			'inputSchema' => array(
+				'admin_email' => 'admin@example.com',
+			),
+		);
+
+		$out = ( new ResponseRedactor( null ) )->redact( $response );
+
+		$this->assertSame( '[redacted:bucket_3]', $out['inputSchema']['admin_email'] );
+	}
+
+	// ── Limits still enforced through method-path exemption ───────────────
+
+	public function test_max_nodes_guard_still_fires_on_oversized_tools_list_payload(): void {
+		$big = array();
+		for ( $i = 0; $i < ResponseRedactor::MAX_NODES + 10; $i++ ) {
+			$big[ 'k' . $i ] = $i;
+		}
+		$response = array(
+			'tools' => array(
+				array(
+					'inputSchema' => $big,
+				),
+			),
+		);
+
+		$this->expectException( RedactionLimitExceeded::class );
+		( new ResponseRedactor( null, 'tools/list' ) )->redact( $response );
+	}
+}


### PR DESCRIPTION
## Summary

Extends the schema-metadata exemption shipped by [#105](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/105) (v1.4.6) to fire for the `tools/list` and `tools/list/all` JSON-RPC method paths — the case [#113](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/113) captured live on `helenawillow.com` 2026-05-10 where the Bucket 3 PII-keyword/email-family matcher replaced per-tool `inputSchema` property definitions with the array-shaped redaction sentinel `["[redacted:bucket_3]"]`, breaking Anthropic API draft 2020-12 validation across 40 of 789 tools and rejecting the whole tools catalog on first invalid entry.

Per dispatch brief Phase B framing (i) — "least invasive code change that fully addresses the failure mode", preserving the explicit-allowlist audit pattern from the prior partial coverage shipped at adapter issue 105:

- `ResponseRedactor::__construct( ?string $ability_name = null, ?string $method = null )` — new optional `$method` arg, backward-compatible with all existing callers.
- `SCHEMA_METADATA_METHODS = ['tools/list', 'tools/list/all']` const — new class-level allowlist. Schema-metadata exemption activates when either the ability is in `SCHEMA_METADATA_ABILITIES` (the existing #105 pattern) OR the method is in `SCHEMA_METADATA_METHODS` (the new #113 pattern).
- `is_schema_metadata_key()` now recognises both `input_schema` / `output_schema` (WP-REST snake_case, as emitted by `mcp-adapter/get-ability-info` and `mcp-adapter/discover-abilities`) AND `inputSchema` / `outputSchema` (MCP wire camelCase, as emitted by `ToolsHandler::list_tools()` / `list_all_tools()`). Both forms describe the same registered ability schema — the projection-layer contract treats them symmetrically.
- `ResponseRedactionGate::apply()` forwards the resolved JSON-RPC method to the redactor constructor; otherwise untouched.

The exemption remains path-scoped (only schema-metadata key names trigger pass-through) AND audit-traceable (both `SCHEMA_METADATA_ABILITIES` and `SCHEMA_METADATA_METHODS` are explicit allowlists with documented rationale). Future schema-emit methods register themselves to the allowlist explicitly rather than silently inheriting a blanket pass-through. Runtime-value redaction on `tools/call` responses is structurally untouched and pinned by negative-control tests.

Closes #113.

## How it satisfies the acceptance gate

**Positive case** — for `tools/list` and `tools/list/all` JSON-RPC method paths, every tool entry's `inputSchema` and `outputSchema` subtree passes through the redaction gate verbatim. Property names matching the Bucket 3 keyword list or the email-family token matcher (`email`, `password`, `admin_email`, `author_email`, `customer_email`, `phone`, `address_line_1`, `ip`, etc.) retain their full schema-object shape (`{ "type": "string", "format": "email", ... }`) rather than being replaced by the array sentinel `["[redacted:bucket_3]"]`.

**Negative-control case** — `tools/call` is NOT in `SCHEMA_METADATA_METHODS`, so the schema-metadata exemption never fires on runtime data. Bucket 1 secrets, Bucket 2 payment, and Bucket 3 contact-PII redaction all continue to fire on `tools/call` response payloads.

**Path-scope discipline** — `is_schema_metadata_key()` only matches when `schema_metadata_exempt` is already true (i.e. the response originated from an allowlisted ability or method). A runtime payload from outside the allowlist that happens to carry a key literally named `inputSchema` / `input_schema` still redacts downstream PII — pinned by the smuggling-defence test.

## Tests run

```
composer validate --strict                                    → ./composer.json is valid
./vendor/bin/phpunit                                          → 1033 tests, 2580 assertions, all green
./vendor/bin/phpunit --filter ToolsListSchemaExemptionTest    → 12 tests, 28 assertions, all green
```

**Phase 4 behavior-reversal pin (dev-tier, captured pre-PR):** reverted `ResponseRedactor.php` to `git show HEAD:…` (md5 `9f0cb133ee7f07b03e130e6a8fb514ef`) → re-ran `ToolsListSchemaExemptionTest` → 5 of 12 tests failed with the exact live-captured bug shape from #113 (`inputSchema` property definitions replaced by `[0 => '[redacted:bucket_3]']` arrays, schema-subtree counter pin tripped to 1). Restored fix (md5 `925e78a6f6023e44be11cd7efcc5c6b9`) → 12/12 green. Proves the regression-guard tests are not vacuously passing.

WPCS / phpcs is not configured in this repo's CI matrix or local dev deps — PRINCIPLES.md §11 ("WPCS Is CI Hygiene") references CI runs that the workflow at `.github/workflows/test.yml` does not currently exercise. The touched files follow the same brace/spacing/array-syntax conventions as the surrounding redaction code. Treating CI re-enablement as out-of-scope per dispatch brief anti-bundling.

### Unit-test evidence — what `ToolsListSchemaExemptionTest` pins

12 test methods, 28 assertions. The full file lives at `tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php`.

| Pin | Test |
|---|---|
| Live-captured bug shape (`presto-player-create-email-collection` `email_provider`) `inputSchema` passes through | `test_tools_list_pii_keyed_property_schema_passes_through` |
| Full PII property family coverage (`email`, `password`, `phone`, `username`, `admin_email`, `address_line_1`, `ip`) on a single tool — both `inputSchema` AND `outputSchema` | `test_tools_list_input_and_output_schema_pass_through_for_all_known_pii_property_families` |
| `tools/list/all` variant parity (`available` extra field included) | `test_tools_list_all_variant_also_passes_schemas_through` |
| No-false-positive — clean schemas byte-identical pre/post redaction | `test_tools_list_clean_payload_remains_clean` |
| Counter pin — schema subtree increments zero buckets | `test_tools_list_redaction_counts_stay_zero_on_schema_payload` |
| Negative control — `tools/call users-list` still redacts `email` + regenerates dual-channel text snapshot | `test_negative_control_tools_call_users_list_still_redacts_email` |
| Allowlist-not-blanket — unrelated method (`resources/list`) does NOT inherit the exemption | `test_negative_control_other_method_does_not_inherit_exemption` |
| Smuggling defence — runtime payload with literal `inputSchema`-named key outside the allowlist still redacts | `test_negative_control_runtime_payload_with_inputSchema_named_key_does_not_bypass` |
| Direct redactor unit — method-based exemption activates correctly | `test_redactor_constructed_with_tools_list_method_activates_exemption` |
| Direct redactor unit — unrelated method does NOT activate exemption | `test_redactor_constructed_with_unrelated_method_does_not_activate_exemption` |
| Backward-compat — null `$method` preserves pre-#113 behaviour | `test_redactor_with_null_method_preserves_pre_113_behaviour` |
| MAX_NODES limit still enforced inside method-path exemption | `test_max_nodes_guard_still_fires_on_oversized_tools_list_payload` |

Reviewer round-2A confirmed: `./vendor/bin/phpunit --filter ToolsListSchemaExemptionTest` → 12 tests, 28 assertions, all green.

## Live verification evidence

### Operator-install artifact (Reviewer round-2A)

- **Artifact:** `~/my-agent/wordpress-plugins-temp/_releases/abilities-mcp-adapter-1.4.8-pre113.zip`
- **SHA-256:** `80b8477e7d1a2085b8aaab4c55e770cf105ecec2be21203b74d7143ed4161006`
- **Size:** 336K
- Packaged source matches the branch fix; `vendor/autoload.php` present; zero dev-dep leaks; no `tests/`, `.verification/`, `.git/`, `.DS_Store`, `__MACOSX`.
- Plugin header retained at `Version: 1.4.7` — **the v1.4.8 version bump is deliberately deferred to Phase C release time, not in this PR**.

### Empirical post-bridge `tools/list` capture (Reviewer round-2B)

Capture path: local `abilities-mcp` bridge stdio against `helenawillow.com` with the v1.4.8-pre113 build deployed.

- 789-tool catalog captured (the degraded-mode floor cleared).
- Redaction sentinel detection on `/tmp/tools-list-bridge.json` — `[redacted:bucket_3]` is **absent** across literal `grep`, `jq` scalar walk, AND `jq` array walk. **Zero hits in any form.**
- Canonical #113 bug-shape targets validated clean in the post-bridge payload:
  - `presto-player-list-email-collections` (index 23)
  - `presto-player-get-email-collection` (index 24)
  - `presto-player-create-email-collection` (index 25)
  - `presto-player-update-email-collection` (index 26)
- Triangulation across the other failure families: `users-create` (index 81), `users-update` (index 82), `comments-create` (index 90) — all clean.

**Conclusion:** #113's redaction-leak class is empirically cleared on the post-bridge `inputSchema` surface that Anthropic's draft 2020-12 validator inspects.

## Out-of-#113-scope finding (separate sprint dispatched)

788 of 789 captured tools validate clean under draft 2020-12. One unrelated failure remains: `surecart-get-store-info` at `result.tools[237]` has `inputSchema.properties: []` — a JS-array shape where draft 2020-12 requires an object. This is **not** a redaction-leak (no sentinel anywhere in the capture). It is a separate source-side registration bug being handled by a parallel sprint (SureCart schema-validity hotfix, different repo).

#113 post-bridge `inputSchema` path is clean; the separate `surecart-get-store-info` invalid-schema blocker remains at tool index 237 and routes to a separate sprint. The marketing-launch Anthropic-API-accepts-full-payload moment therefore unblocks on the paired release of this hotfix + the SureCart sprint's release, not on this PR alone — this PR's binding scope (#113's redaction-leak class) is empirically met.

## Phase C release coupling

Per J's Decision 1B (2026-05-11): the v1.4.8 tag + GitHub Release is **held** until the parallel SureCart hotfix sprint also ships its release. The two releases ship as a coordinated wave to unblock the alpha gate in a single deployable moment.

**Implication for merge custody:** merge to `main` after Reviewer round-2 Source-check clears + J authorization. Do **not** tag v1.4.8 or open the GitHub Release on merge. Tag-and-release happens later, paired with the SureCart release event.

## Sprint Plan Gate

```
Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability changes. Schemas registered via wp_register_ability() remain unmodified. The fix restores adapter-boundary conformance with JSON Schema draft 2020-12 — the same standard WordPress's own Abilities API validator uses at registration time. The contract becomes consistent across registration (WP), MCP protocol layer (tools/list wire format), and AI-provider tool catalogs.
- Adapter / product-layer impact: Single repo (abilities-mcp-adapter). Method-level schema-metadata exemption added to the redaction gate + redactor for tools/list + tools/list/all JSON-RPC methods. Exemption remains path-aware + schema-aware (not blanket pass-through). Runtime-value redaction on tools/call responses is untouched and verified by negative-control test.
```

## Issue / Project / phase linkage

- Closes #113.
- Project: [Wicked-Evolutions/projects/8 — Abilities Suite Alpha & Roadmap](https://github.com/orgs/Wicked-Evolutions/projects/8)
- Phase: Adapter Schema Exemption Hotfix Sprint 2026-05-11 Phase B
- Milestone: Adapter v1.4.8 hotfix — schema exemption completion
- Completes prior partial coverage tracked at adapter issue 105 (v1.4.6) — same exemption pattern, now extended to the method-level path

## Deviations

Deviations: None. Brief was fully scoped at dispatch; framing (i) chosen per the "default if equidistant on simplicity" rule and Reviewer round-2A/2B both cleared without scope amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
