### PR TITLE
fix(#87 S3): register advertised boot tool mcp-adapter/get-started in default-server tools allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Documented boot entrypoint `mcp-adapter/get-started` is now registered with the default server (Issue [#87](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/87) S3).** `DefaultServerFactory` advertises `server_description.boot_sequence.first_tool = "mcp-adapter/get-started"` (added in the "Boot nudge" change, commit `6b51d24`) but the server's `tools` allowlist was never updated to include it — only `discover-abilities`, `get-ability-info`, `execute-ability`, `batch-execute`. The `GetStartedAbility` registered correctly as a public WordPress ability, but the default MCP server never exposed it, so `tools/call mcp-adapter-get-started` resolved to `-32003 Tool not found` — the documented first boot step was unreachable for every client. `src/Servers/DefaultServerFactory.php` now includes `'mcp-adapter/get-started'` in the `tools` array. Purely additive — exposes an already-registered, already-advertised ability; no schema, name, or permission-semantics change (Principle 10). Regression-guarded by `tests/Unit/Servers/DefaultServerFactoryBootContractTest.php`, which pins the advertised boot `first_tool` and the `tools` allowlist in sync via static source parse so this cannot silently drift again. Full PHPUnit suite green.
+
 ## [1.4.8] - 2026-05-12
 
 Hotfix completion of the schema-metadata exemption pattern shipped in [1.4.6] — extends the [#105](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/105) per-ability path to cover the JSON-RPC method-level `tools/list` and `tools/list/all` paths. Marketing-launch-coupled fix: the gap broke AI-client tool catalog loading on any site whose registered abilities include PII-keyword-named properties (`email`, `password`, `phone`, `address`, `ip` and prefix/suffix variants).

--- a/src/Servers/DefaultServerFactory.php
+++ b/src/Servers/DefaultServerFactory.php
@@ -56,6 +56,12 @@ class DefaultServerFactory {
 			'error_handler'          => ErrorLogMcpErrorHandler::class,
 			'observability_handler'  => NullMcpObservabilityHandler::class,
 			'tools'                  => array(
+				// Issue #87 (S3): get-started is the documented boot entrypoint
+				// advertised in server_description.boot_sequence.first_tool
+				// above. It must be in this allowlist or tools/call resolves to
+				// -32003 Tool not found — advertised-but-unregistered. Additive,
+				// no contract change (Principle 10).
+				'mcp-adapter/get-started',
 				'mcp-adapter/discover-abilities',
 				'mcp-adapter/get-ability-info',
 				'mcp-adapter/execute-ability',

--- a/tests/Unit/Servers/DefaultServerFactoryBootContractTest.php
+++ b/tests/Unit/Servers/DefaultServerFactoryBootContractTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Boot-contract regression guard for the default server (Issue #87 S3).
+ *
+ * The default server's `server_description` advertises a boot_sequence whose
+ * `first_tool` is the documented onboarding entrypoint. If that tool name is
+ * not also present in the server's `tools` allowlist, tools/call resolves to
+ * `-32003 Tool not found` — an advertised-but-unregistered boot path (the #87
+ * S3 regression). This test pins the two in sync via a static source parse so
+ * it cannot silently drift again.
+ *
+ * @package WickedEvolutions\McpAdapter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WickedEvolutions\McpAdapter\Tests\Unit\Servers;
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class DefaultServerFactoryBootContractTest extends TestCase {
+
+	private function factory_source(): string {
+		return (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/src/Servers/DefaultServerFactory.php'
+		);
+	}
+
+	public function test_advertised_boot_first_tool_is_in_the_tools_allowlist(): void {
+		$src = $this->factory_source();
+
+		$this->assertSame(
+			1,
+			preg_match( '/"first_tool":"([^"]+)"/', $src, $boot ),
+			'server_description must advertise a boot_sequence.first_tool'
+		);
+		$advertised = $boot[1];
+
+		$this->assertSame(
+			1,
+			preg_match( "/'tools'\\s*=>\\s*array\\((.*?)\\n\\s*\\),/s", $src, $tools ),
+			'DefaultServerFactory must declare a tools allowlist'
+		);
+		preg_match_all( "/'([^']+)'/", $tools[1], $registered );
+		$registered_tools = $registered[1];
+
+		$this->assertContains(
+			$advertised,
+			$registered_tools,
+			sprintf(
+				'Advertised boot tool "%s" must be in the default server tools allowlist [%s] — '
+				. 'otherwise tools/call returns -32003 Tool not found (Issue #87 S3).',
+				$advertised,
+				implode( ', ', $registered_tools )
+			)
+		);
+	}
+}


### PR DESCRIPTION
Closes part of Wicked-Evolutions/abilities-mcp#87 (Workstream B). Addresses **S3** (documented boot entrypoint not found). S1/S2 is the paired bridge PR (Wicked-Evolutions/abilities-mcp#88).

## Root cause
`DefaultServerFactory` advertises `server_description.boot_sequence.first_tool = "mcp-adapter/get-started"` (added in the "Boot nudge" change, commit `6b51d24`) but the server's `tools` allowlist was never updated to include it — only `discover-abilities`, `get-ability-info`, `execute-ability`, `batch-execute`. `GetStartedAbility` registered correctly as a public WP ability, but the default MCP server never projected it, so `tools/call mcp-adapter-get-started` resolved to `-32003 Tool not found`. The documented first boot step was unreachable for every client.

## Fix
Add `'mcp-adapter/get-started'` to the `tools` array in `src/Servers/DefaultServerFactory.php`. Purely additive — exposes an already-registered, already-advertised ability; no schema, name, or permission-semantics change (Principle 10). One-line behavior fix; no adjacent refactor.

## Verification
- New `tests/Unit/Servers/DefaultServerFactoryBootContractTest.php` — static source-parse guard pinning the advertised boot `first_tool` and the `tools` allowlist in sync so this cannot silently drift again.
- Full PHPUnit suite: **1034/1034 green** (1033 prior + 1 new guard).
- `php -l` clean on touched files. WPCS runs in CI (Principle 11); change matches surrounding file style.

⚠️ **Do not merge.** Holding for B-orchestrator + reviewer gate-check.