### PR TITLE
fix(validator): accept stdClass empty-object schemas (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [1.4.9] - 2026-05-17
+## [1.4.9] - 2026-05-20
 
 ### Added
 
@@ -11,6 +11,12 @@
 ### Fixed
 
 - **Documented boot entrypoint `mcp-adapter/get-started` is now registered with the default server (Issue [#87](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/87) S3).** `DefaultServerFactory` advertises `server_description.boot_sequence.first_tool = "mcp-adapter/get-started"` (added in the "Boot nudge" change, commit `6b51d24`) but the server's `tools` allowlist was never updated to include it — only `discover-abilities`, `get-ability-info`, `execute-ability`, `batch-execute`. The `GetStartedAbility` registered correctly as a public WordPress ability, but the default MCP server never exposed it, so `tools/call mcp-adapter-get-started` resolved to `-32003 Tool not found` — the documented first boot step was unreachable for every client. `src/Servers/DefaultServerFactory.php` now includes `'mcp-adapter/get-started'` in the `tools` array. Purely additive — exposes an already-registered, already-advertised ability; no schema, name, or permission-semantics change (Principle 10). Regression-guarded by `tests/Unit/Servers/DefaultServerFactoryBootContractTest.php`, which pins the advertised boot `first_tool` and the `tools` allowlist in sync via static source parse so this cannot silently drift again. Full PHPUnit suite green.
+
+- **`McpToolValidator` no longer rejects JSON-spec-correct `stdClass` empty-object schemas (Issue [#125](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/125)).** `McpToolValidator::get_schema_validation_errors()` previously checked `! is_array( $schema['properties'] )` at the root and `! is_array( $property )` at each sub-property, rejecting `new \stdClass()` even though it is the JSON Schema-spec-correct PHP encoding of the empty object literal `{}`. Astra's `Astra_Abstract_Ability::get_final_input_schema()` normalizes no-arg input to `[ 'type' => 'object', 'properties' => new \stdClass() ]` and the top-level `stdClass → array` cast at line 152 is non-recursive, so the nested `stdClass` slipped through and failed validation. The error logged per ability per request — on a site with ~10 Astra no-arg abilities running on a 32MB-`memory_limit` shared host, the resulting log cascade contributed to fatal `Allowed memory size exhausted` PHP errors on legitimate admin endpoints (`/wp-json/wp/v2/users/me`, application-passwords, update-core), captured live on thinknicenow.com 2026-05-20. The fix accepts `stdClass` alongside `array` at both checked lines (root-level `properties` and per-property values). Per Principle 3 (Adapter Is A Projection) and Principle 4 (Schemas Stay WordPress-Native): the adapter validator stops being stricter than the JSON Schema spec for WordPress-native ability registrations. Regression-guarded by two new tests in `tests/Unit/Domain/Tools/McpToolValidatorTest.php` covering both the top-level and the sub-property `stdClass` cases. Closes [#125](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/125).
+
+### Chore
+
+- **`ABILITIES_MCP_ADAPTER_VERSION` constant aligned with plugin header (`'1.4.8'` → `'1.4.9'`).** PR [#123](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/pull/123) bumped the plugin header to `Version: 1.4.9` but missed the matching `define()` in `abilities-mcp-adapter.php`. Same class of drift as the `abilities-for-ai` v1.9.4 constant drift caught at release prep. The constant is used by `Abilities_MCP_Adapter_Plugin_Updater` and any code that reads `ABILITIES_MCP_ADAPTER_VERSION` for diagnostic / update-channel comparison. No functional behavior change beyond reporting the correct version.
 
 ## [1.4.8] - 2026-05-12
 

--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Plugin constants.
-define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.8' );
+define( 'ABILITIES_MCP_ADAPTER_VERSION', '1.4.9' );
 define( 'ABILITIES_MCP_ADAPTER_PATH', plugin_dir_path( __FILE__ ) );
 
 // License manager — FluentCart license for auto-update delivery.

--- a/src/Domain/Tools/McpToolValidator.php
+++ b/src/Domain/Tools/McpToolValidator.php
@@ -176,8 +176,13 @@ class McpToolValidator {
 			);
 		}
 
-		// If properties exist, they must be an array/object.
-		if ( isset( $schema['properties'] ) && ! is_array( $schema['properties'] ) ) {
+		// If properties exist, they must be an array/object. stdClass is the JSON-spec-correct
+		// PHP encoding of an empty JSON object (`{}`) and must be accepted alongside arrays
+		// (Astra and other vendors register no-arg ability schemas as `new \stdClass()` per
+		// the JSON Schema spec for empty objects).
+		if ( isset( $schema['properties'] )
+			&& ! is_array( $schema['properties'] )
+			&& ! ( $schema['properties'] instanceof stdClass ) ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
 				__( 'Tool %s properties must be an object/array', 'mcp-adapter' ),
@@ -194,10 +199,12 @@ class McpToolValidator {
 			);
 		}
 
-		// If properties are provided, validate their basic structure.
-		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
-			foreach ( $schema['properties'] as $property_name => $property ) {
-				if ( ! is_array( $property ) ) {
+		// If properties are provided, validate their basic structure. Accept stdClass alongside
+		// array at the per-property level too — a sub-schema may be `new \stdClass()` for the
+		// same JSON Schema empty-object reason as the top-level case above.
+		if ( isset( $schema['properties'] ) && ( is_array( $schema['properties'] ) || $schema['properties'] instanceof stdClass ) ) {
+			foreach ( (array) $schema['properties'] as $property_name => $property ) {
+				if ( ! is_array( $property ) && ! ( $property instanceof stdClass ) ) {
 					$errors[] = sprintf(
 					/* translators: %1$s: field name, %2$s: property name */
 						__( 'Tool %1$s property \'%2$s\' must be an object', 'mcp-adapter' ),
@@ -205,6 +212,11 @@ class McpToolValidator {
 						$property_name
 					);
 					continue;
+				}
+
+				// Normalize stdClass to array for the remaining per-property checks.
+				if ( $property instanceof stdClass ) {
+					$property = (array) $property;
 				}
 
 				// Each property should have a type (though not strictly required by JSON Schema).

--- a/tests/Unit/Domain/Tools/McpToolValidatorTest.php
+++ b/tests/Unit/Domain/Tools/McpToolValidatorTest.php
@@ -220,4 +220,50 @@ class McpToolValidatorTest extends TestCase {
 		$errors = McpToolValidator::get_validation_errors( $data );
 		$this->assertNotEmpty( $errors );
 	}
+
+	// ── stdClass empty-object schemas (Issue #125) ──
+
+	/**
+	 * Astra's `Astra_Abstract_Ability::get_final_input_schema()` normalizes empty input
+	 * to `[ 'type' => 'object', 'properties' => new \stdClass() ]` — the JSON Schema spec
+	 * encoding for `{}` in PHP. The validator must accept this shape for no-arg abilities.
+	 *
+	 * Issue: https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/125
+	 */
+	public function test_stdclass_properties_at_schema_root_is_valid(): void {
+		$data                = $this->valid_tool_data();
+		$data['inputSchema'] = array(
+			'type'       => 'object',
+			'properties' => new \stdClass(),
+		);
+
+		$result = McpToolValidator::validate_tool_data( $data );
+		$this->assertTrue( $result );
+
+		$errors = McpToolValidator::get_validation_errors( $data );
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Per JSON Schema, an individual property value may itself be an empty object (`{}`),
+	 * which PHP encodes as `new \stdClass()`. The validator must accept stdClass at the
+	 * per-property level alongside arrays.
+	 *
+	 * Issue: https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/125
+	 */
+	public function test_stdclass_sub_property_value_is_valid(): void {
+		$data                = $this->valid_tool_data();
+		$data['inputSchema'] = array(
+			'type'       => 'object',
+			'properties' => array(
+				'metadata' => new \stdClass(),
+			),
+		);
+
+		$result = McpToolValidator::validate_tool_data( $data );
+		$this->assertTrue( $result );
+
+		$errors = McpToolValidator::get_validation_errors( $data );
+		$this->assertEmpty( $errors );
+	}
 }


### PR DESCRIPTION
## What changed

`McpToolValidator::get_schema_validation_errors()` now accepts `stdClass` alongside `array` at the two checked locations: the schema-root `properties` check (formerly line 180) and the per-property structure check (formerly line 200). The previous `is_array()`-only checks rejected the JSON-Schema-spec-correct PHP encoding of an empty JSON object (`{}`) — which Astra's `Astra_Abstract_Ability::get_final_input_schema()` emits for every no-arg Astra ability — and the resulting per-ability-per-request error cascade contributed to fatal PHP `memory_limit` exhaustion on legitimate wp-admin endpoints on low-memory shared hosts (live evidence captured 2026-05-20 from thinknicenow.com on Cloudways Flexible Basic, 32MB `memory_limit`). The fix also corrects the `ABILITIES_MCP_ADAPTER_VERSION` constant drift (`'1.4.8'` → `'1.4.9'`) missed by PR #123, and appends both entries into the existing `## [1.4.9]` CHANGELOG section (no new heading introduced; section date updated to 2026-05-20).

## How it satisfies the acceptance gate

Validator fix is minimal at the two binding lines (180 + 200) with the `instanceof stdClass` carve-out plus a local `(array) $property` cast that keeps the existing downstream per-property type checks operating against arrays — equivalent-shape per the dispatch brief's explicit allowance. Two new tests in `tests/Unit/Domain/Tools/McpToolValidatorTest.php` cover both the top-level (`inputSchema.properties = new \stdClass()`) and per-property (`properties.metadata = new \stdClass()`) cases; both fail against unfixed `main` and pass on this branch. `vendor/bin/phpunit` is green (1036 tests, 2590 assertions). `composer validate --strict` passes. The canonical version grep returns zero hits. The existing `## [1.4.9]` section is the only `1.4.9` heading in `CHANGELOG.md`; #125 and the constant-drift correction are appended into its `### Fixed` and `### Chore` subsections respectively. PR linkage is `Fixes #125` only — #118 and #119 remain release-custody closures.

## Tests run

- `vendor/bin/phpunit` (full suite): **`OK (1036 tests, 2590 assertions)`**, 0.737s, 32.50 MB.
- `composer validate --strict`: **`./composer.json is valid`**.
- Acceptance gate item 5 version grep (run from plugin root):

  ```bash
  grep -rn "1\.4\.8" . \
    --include="*.php" --include="*.txt" --include="*.json" \
    --exclude-dir=vendor --exclude-dir=tests --exclude-dir=.git \
    --exclude=CHANGELOG.md
  ```

  Result: **0 hits** (exit code 1, no output).
- The two new tests against unfixed `main` (validator stashed to its pre-fix state, tests left in place):

  ```
  FF                                                                  2 / 2 (100%)

  1) McpToolValidatorTest::test_stdclass_properties_at_schema_root_is_valid
  Failed asserting that WP_Error Object (
      'code' => 'tool_validation_failed'
      'message' => 'Tool validation failed: Tool inputSchema properties must be an object/array'
      'data' => ''
  ) is true.

  2) McpToolValidatorTest::test_stdclass_sub_property_value_is_valid
  Failed asserting that WP_Error Object (
      'code' => 'tool_validation_failed'
      'message' => "Tool validation failed: Tool inputSchema property 'metadata' must be an object"
      'data' => ''
  ) is true.

  FAILURES! Tests: 2, Assertions: 2, Failures: 2.
  ```

- The same two tests against the fix on this branch: pass cleanly inside the full-suite green run above.

## Sprint Plan Gate (Principles v1)

Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema definition, callback, or permission semantics changed.
- Adapter / product-layer impact: Validator stops wrongly rejecting WordPress-native `stdClass` empty-object schemas; the projection-time stricter-than-spec drift that violated Principles 3 + 4 is removed.

## Issue / Project / phase linkage

- Fixes #125
- Sprint plan: [[Adapter Validator stdClass Hotfix Sprint 2026-05-20]] (key: `adapter_validator_stdclass_hotfix_2026_05_20`), Phase C
- References (descriptive, not closing): #118, #119 — both already documented in the existing `## [1.4.9]` CHANGELOG section; close at release-custody phase against tag + auto-updater evidence per the sprint plan.

## Deviations

Two notes, neither code-shipping beyond brief:

1. **Equivalent-shape applied at line 200 (per dispatch brief allowance).** The per-property fix accepts `stdClass` via `! ( $property instanceof stdClass )` and then normalizes the property to `array` via `(array) $property` inside the loop so the existing downstream `$property['type']` array-offset checks continue to work unchanged. The dispatch brief explicitly allows "Equivalent shapes are fine (e.g. a small helper); the binding constraint is that no `stdClass` empty-object schema is rejected" — this is the smallest local normalization that satisfies that constraint without restructuring. No behavior change for the array branch.
2. **Noticed during work — NOT fixed, surfaced for Orchestrator follow-up (per sprint plan stop condition).** `get_schema_validation_errors()` line 250 (now ~262) uses `isset( $schema['properties'][ $required_field ] )` for required-field membership lookup. With the new fix, `$schema['properties']` may now be a `stdClass`, and PHP array-style offset access on `stdClass` is unreliable. The Astra reproducer does not exercise this code path (Astra no-arg abilities don't carry `required`), and the binding scope explicitly excludes broader validator audit, so per the sprint plan's "If you notice something concerning while implementing, surface to Orchestrator via PR `Deviations` line or a separate 'noticed during work' note; do NOT fix" — surfacing here for the Orchestrator to triage as a separate follow-up issue if warranted.