### PR TITLE
docs(readme.txt): close #124 — Stable tag + Requires PHP + changelog backfill

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wickedevolutions
 Tags: mcp, ai, abilities, model-context-protocol, automation
 Requires at least: 6.9
 Tested up to: 6.9.1
-Requires PHP: 8.0
-Stable tag: 1.0.0
+Requires PHP: 8.2
+Stable tag: 1.4.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,32 @@ Yes. Network activate to make MCP tools available on all sites.
 
 == Changelog ==
 
+See [CHANGELOG.md](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/blob/main/CHANGELOG.md) for the full version history. Recent versions:
+
+= 1.4.9 =
+* Fixed: McpToolValidator no longer rejects JSON-spec-correct stdClass empty-object schemas (#125) — adapter aligned with WordPress Abilities API contract per Principle 3 + Principle 4.
+* Added: FluentPlayer ability category in OAuth scope registry — abilities grantable + executable under OAuth (#118).
+* Fixed: Documented boot entrypoint mcp-adapter/get-started now registered with default server (#87 S3 via #119).
+* Chore: ABILITIES_MCP_ADAPTER_VERSION constant aligned with plugin header.
+* Docs: readme.txt Stable tag + Requires PHP corrected; changelog backfilled (#124).
+
+= 1.4.8 =
+* Fixed: tools/list + tools/list/all schema-metadata exemption extended to method-level paths (#113) — completes the per-ability exemption shipped in 1.4.6.
+
+= 1.4.7 =
+* Documentation: README rewrite for OAuth 2.1 resource server, Connected Bridges admin UI, layered-permissions surface coverage.
+* Corrected: PHP requirement 8.0+ → 8.2+ (matches composer.json + plugin header).
+
+= 1.4.6 =
+* Security: Bucket 3 redaction extended to prefixed email field variants (#103).
+* Fixed: mcp-adapter/get-ability-info schemas no longer corrupted by redaction (#105).
+* Fixed: OAuth scope coverage for site + surecart-ecommerce categories, with CI drift test pinning the contract (#101, #102).
+
+= 1.4.5 =
+* Fixed: Subsite authorize endpoint dispatches under path-style prefix (#90).
+* Known limitation: role downgrade applies on interactive consent only — auto-approve refresh issues full-caps tokens (#94).
+* Known limitation: mcp-adapter/batch-execute deferred to post-alpha (#104).
+
 = 1.0.0 =
 * Initial public release under Wicked Evolutions
 * Batch execute tool (max 20 abilities per request)
@@ -80,6 +106,9 @@ Yes. Network activate to make MCP tools available on all sites.
 * Requires PHP 8.0+
 
 == Upgrade Notice ==
+
+= 1.4.9 =
+Hotfix for Astra-pattern stdClass schema rejection (#125) plus FluentPlayer OAuth scope (#118), boot-tool allowlist fix (#87 S3), and readme.txt metadata corrections. Drop-in replacement for v1.4.8.
 
 = 1.0.0 =
 First public release. Install and activate to expose WordPress abilities as MCP tools.


### PR DESCRIPTION
## What changed

`readme.txt` had three drifts identified during the v1.4.9 release-prep audit:

| Line | Before | After |
|---|---|---|
| `Stable tag:` | `1.0.0` | `1.4.9` |
| `Requires PHP:` | `8.0` | `8.2` (corrected in v1.4.7 in `composer.json` + plugin header; `readme.txt` missed) |
| `== Changelog ==` section | Only `= 1.0.0 =` entry | Added `= 1.4.5 =` through `= 1.4.9 =` entries (one-line summaries; pointer to `CHANGELOG.md` for full history) |

Also added `= 1.4.9 =` `== Upgrade Notice ==` entry.

Doc-only. No code shipping. No permission, schema, or runtime behavior change.

## Why now

J-authorized release-prep scope expansion 2026-05-21 (Scope B). The original v1.4.9 sprint plan had this deliberately out-of-scope (#124 marked roadmap). J flagged at pre-release audit that shipping with `Stable tag: 1.0.0` when the plugin is `1.4.9` was straightforwardly wrong — the WP.org plugin directory contract / auto-updater contract was lying. Same rebuild cost (zip needs new build either way), so the elegant-minimal-sustainable answer was to close all three readme.txt drifts in one shot rather than leave a follow-up patch.

## How it satisfies the acceptance gate

This is a release-prep companion PR, not the validator sprint itself. The "acceptance gate" here is:

1. `Stable tag` now matches plugin header + constant (`1.4.9` everywhere).
2. `Requires PHP` matches `composer.json` (`8.2+`) and plugin header (`Requires PHP: 8.2`).
3. Changelog section accurately represents v1.4.5 → v1.4.9 release history.
4. No code paths touched.
5. Closes [#124](https://github.com/Wicked-Evolutions/abilities-mcp-adapter/issues/124).

## Sprint Plan Gate (Principles v1)

Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema, callback, or permission semantics changed.
- Adapter / product-layer impact: None. Docs-only.

## Issue / Project / phase linkage

- Fixes #124
- Sprint plan: [[Adapter Validator stdClass Hotfix Sprint 2026-05-20]] (release-prep companion to the validator hotfix; scope-expansion authorized by J 2026-05-21)
- Release: lands before the v1.4.9 tag

## Deviations

None — change is exactly the three-drift fix authorized in J's "B" scope ratification. No code touched outside `readme.txt`.

## Post-merge work (orchestrator-owned)

After this merges, the v1.4.9 zip needs:
1. Rebuild from updated `main`
2. New SHA-256 (current `a5fe3d24…` becomes stale)
3. Light dev2 smoke (doc-only, low risk)
4. Re-run Reviewer round-3 release-candidate against new zip
5. Tag + GitHub Release v1.4.9