### PR TITLE
fix(bootstrap): hook McpAdapter::instance() on plugins_loaded (#131)

### DIFF
--- a/abilities-mcp-adapter.php
+++ b/abilities-mcp-adapter.php
@@ -108,12 +108,12 @@ add_filter( 'mcp_adapter_default_server_config', function( $config ) {
 }, 10 );
 
 // Initialize the MCP Adapter.
-add_action( 'init', function() {
+add_action( 'plugins_loaded', function() {
 	if ( ! class_exists( McpAdapter::class ) ) {
 		return;
 	}
 	McpAdapter::instance();
-}, 5 );
+} );
 
 // Register custom cron intervals.
 add_filter( 'cron_schedules', static function ( $schedules ) {


### PR DESCRIPTION
## What changed

Two-character change in `abilities-mcp-adapter.php` around line 111: the `add_action()` wiring for `McpAdapter::instance()` moves from `'init'` (priority 5) to `'plugins_loaded'` (default priority). WordPress 6.9.4 fires `wp_abilities_api_init` very early in the request bootstrap — before `init` priority 5 runs — so the previous wiring missed the registration window on every real HTTP request. The `McpAdapter` singleton constructor is what calls `add_action('wp_abilities_api_init', ...)`; by the time our `init`-priority-5 callback fired the singleton, the abilities-registration hook had already fired and completed, and our 5 `mcp-adapter/*` abilities never registered during real REST/frontend/admin requests. WP-CLI bootstrap fires events in a different order (and re-fires the hook later), which is why WP-CLI-based testing historically masked the bug. `plugins_loaded` is the same hook the standalone `wordpress/mcp-adapter` plugin and FluentKit's bundled copy use, and it fires before both `init` and `wp_abilities_api_init`.

## How it satisfies the acceptance gate

Code change is exactly the two characters the issue calls for (`'init'` → `'plugins_loaded'` + remove `, 5`); diff is 2 insertions + 2 deletions on a single function call. Existing test suite is green. Live verification on dev2.helenawillow.com (per Issue #131's "Verified on dev2 with direct edit" section) showed all 5 `mcp-adapter/*` abilities now register under `WickedEvolutions\McpAdapter\*` and the total ability count moves from 1636 to 1638.

## Tests run

- `vendor/bin/phpunit` (full suite): **`OK (1036 tests, 2590 assertions)`**, 0.686s, 32.50 MB.
- `composer validate --strict`: **`./composer.json is valid`**.
- `git diff abilities-mcp-adapter.php`:

  ```diff
  -add_action( 'init', function() {
  +add_action( 'plugins_loaded', function() {
   	if ( ! class_exists( McpAdapter::class ) ) {
   		return;
   	}
   	McpAdapter::instance();
  -}, 5 );
  +} );
  ```

- Live behavior on dev2 (per Issue #131, captured 2026-05-21 with the same patch applied directly):

  | Measure | Before | After |
  |---|---|---|
  | Our callback in `wp_abilities_api_init` list | absent | present at priority 10 |
  | Total `mcp-adapter/*` abilities | 3 | 5 |
  | Owner of all 5 `mcp-adapter/*` abilities | `WP\MCP\Abilities\*` (FluentKit's bundle) | `WickedEvolutions\McpAdapter\Abilities\*` |

## Sprint Plan Gate (Principles v1)

Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None. No ability registration, schema, callback, or permission semantics changed — only the wiring hook our singleton instantiates on, so that our existing `add_action('wp_abilities_api_init', ...)` registrations land before the platform fires the registration event.
- Adapter / product-layer impact: Adapter abilities (`get-started`, `discover-abilities`, `get-ability-info`, `execute-ability`, `batch-execute`) now actually register under our namespace during real HTTP requests, restoring Principle 1 (Registry First) and Principle 8 (Official Interface Parity) on sites where another `wordpress/mcp-adapter`-shaped registrant was previously winning the registration race.

## Issue / Project / phase linkage

- Fixes #131

## Deviations

None.