### PR TITLE
fix(get-ability-info): move show_in_rest into meta block (#133)

### DIFF
--- a/src/Abilities/GetAbilityInfoAbility.php
+++ b/src/Abilities/GetAbilityInfoAbility.php
@@ -36,7 +36,6 @@ final class GetAbilityInfoAbility {
 		wp_register_ability(
 			'mcp-adapter/get-ability-info',
 			array(
-				'show_in_rest'        => true,
 				'label'               => 'Get Ability Info',
 				'description'         => 'Get detailed information about a specific WordPress ability including its input/output schema, description, and usage examples.',
 				'category'            => 'mcp-adapter',
@@ -76,7 +75,9 @@ final class GetAbilityInfoAbility {
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'execute_callback'    => array( self::class, 'execute' ),
 				'meta'                => array(
-					'annotations' => array(
+					'mcp'          => array( 'public' => true ),
+					'show_in_rest' => true,
+					'annotations'  => array(
 						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,


### PR DESCRIPTION
## What changed

`GetAbilityInfoAbility::register()` previously passed `'show_in_rest' => true` as a top-level argument to `wp_register_ability()`. WP core's `WP_Ability::__construct` does not recognise `show_in_rest` as a valid top-level property and emits `_doing_it_wrong` every time the ability is constructed — captured on dev2.helenawillow.com 2026-05-21. The ability still registered and worked (the top-level value was silently ignored), but debug logs filled on every request. Moved the flag into the `meta` block per WP core convention, and added `'mcp' => array( 'public' => true )` alongside it to match the canonical pattern used by every other adapter ability (`DiscoverAbilitiesAbility`, `GetStartedAbility`, `SettingsAbilities`). `GetAbilityInfoAbility` was the only adapter ability missing this pattern.

## How it satisfies the acceptance gate

Three-line change in `src/Abilities/GetAbilityInfoAbility.php`: the top-level `'show_in_rest' => true` line is removed, and inside the existing `meta` block two new entries are added — `'mcp' => array( 'public' => true )` and `'show_in_rest' => true` — matching the canonical placement used by the other four adapter abilities. The discovery path (`McpAbilityHelperTrait::is_ability_mcp_public()`) reads the meta block in this exact order: `meta.show_in_rest` (WordPress core standard) takes precedence over `meta.mcp.public` (proprietary fallback); both flags coexist throughout the codebase, so this PR matches convention rather than removing. No code in the adapter reads top-level `show_in_rest` — verified by grep across `src/` (`grep -rn "show_in_rest\|mcp.*public" src/Abilities/`). After install, the `_doing_it_wrong` warning for this ability is gone, and the ability also gains explicit self-introspection visibility under the discovery gate (previously absent in meta).

## Tests run

- `vendor/bin/phpunit` (full suite): **`OK (1036 tests, 2590 assertions)`**, 0.703s, 32.50 MB.
- `composer validate --strict`: **`./composer.json is valid`**.
- `git diff src/Abilities/GetAbilityInfoAbility.php`:

  ```diff
  -				'show_in_rest'        => true,
   				'label'               => 'Get Ability Info',
  ...
   				'meta'                => array(
  -					'annotations' => array(
  +					'mcp'          => array( 'public' => true ),
  +					'show_in_rest' => true,
  +					'annotations'  => array(
  ```

## Sprint Plan Gate (Principles v1)

Official WordPress Compatibility Review:
- Registry / source-of-truth impact: None on semantics — the ability's name, schema, callback, and permission semantics are unchanged. The `show_in_rest` flag moves from a top-level position WP core was rejecting to the meta location WP core honours; this is a placement correction, not a contract change (Principle 10 preserved).
- Adapter / product-layer impact: Adapter stops emitting `_doing_it_wrong` for this ability on every request; the ability is now correctly discoverable via the documented discovery gate priority (`meta.show_in_rest` + `meta.mcp.public`), matching the canonical pattern across the other adapter abilities.

## Issue / Project / phase linkage

- Fixes #133

## Deviations

None. (Chose the "move into meta" path over the "remove if redundant" path after a quick discovery-path read: `McpAbilityHelperTrait::is_ability_mcp_public()` documents `meta.show_in_rest` and `meta.mcp.public` as distinct gates with the former taking precedence — they are not strictly redundant, and every other adapter ability sets both. Matching convention is the smallest, safest correct change.)