### PR TITLE
Add Understand-Anything knowledge graph + GitHub Pages dashboard

### DIFF
--- a/.github/workflows/understand-dashboard.yml
+++ b/.github/workflows/understand-dashboard.yml
@@ -1,0 +1,64 @@
+name: Publish Understand-Anything Dashboard
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".understand-anything/knowledge-graph.json"
+      - ".understand-anything/meta.json"
+      - ".github/workflows/understand-dashboard.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repo (graph data)
+        uses: actions/checkout@v4
+      - name: Checkout Understand-Anything dashboard (pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: Lum1104/Understand-Anything
+          ref: 5c1e35f90be029efb012a41e1122b08abef5cbb2
+          path: .ua
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .ua/pnpm-lock.yaml
+      - name: Install deps
+        working-directory: .ua
+        run: pnpm install --frozen-lockfile
+      - name: Build core
+        working-directory: .ua
+        run: pnpm --filter @understand-anything/core build
+      - name: Build static dashboard
+        working-directory: .ua/packages/dashboard
+        env:
+          VITE_GRAPH_URL: ./knowledge-graph.json
+          VITE_META_URL: ./meta.json
+        run: npx vite build --config vite.config.demo.ts --base=./ --outDir dist --emptyOutDir
+      - name: Inject knowledge graph
+        run: |
+          cp .understand-anything/knowledge-graph.json .ua/packages/dashboard/dist/knowledge-graph.json
+          cp .understand-anything/meta.json .ua/packages/dashboard/dist/meta.json
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .ua/packages/dashboard/dist
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ Thumbs.db
 
 # Claude Code agent worktrees / local metadata (never committed)
 .claude/
+
+# Understand-Anything — commit graph data (knowledge-graph.json, meta.json,
+# fingerprints.json, .understandignore); ignore scratch + local static build.
+.understand-anything/intermediate/
+.understand-anything/tmp/
+.understand-anything/.trash-*/
+.understand-anything/dashboard-static/

--- a/.understand-anything/.understandignore
+++ b/.understand-anything/.understandignore
@@ -1,0 +1,1 @@
+# .understandignore — defaults only (full-scope analysis)

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,0 +1,24068 @@
+{
+  "version": "1.0.0",
+  "gitCommitHash": "05fcd5a13d4da9cf0ba1eae81860f81c24fb38e8",
+  "generatedAt": "2026-06-07T12:36:42.390Z",
+  "files": {
+    ".distignore": {
+      "filePath": ".distignore",
+      "contentHash": "ad8506da4021dcf6455752e065800b73f6a4ac17b3cbe12c14b1418cd98f5f20",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 12,
+      "hasStructuralAnalysis": false
+    },
+    ".github/ISSUE_TEMPLATE/ability-gap.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/ability-gap.yml",
+      "contentHash": "7d51652a4f2285e257cadd3720ebde7831e188634448be2b884a84c4daa027e6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 50,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/bug-report.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/bug-report.yml",
+      "contentHash": "cbac9299e494ee95e23a12b21b7da13d7413975ac318cba081581c53776e25a5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 64,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/dev-brief.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/dev-brief.yml",
+      "contentHash": "3387d620ae4e17660cd7fc9f0e23f8a4f6c183b84334d8676b3a43b2c7e65bd3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 46,
+      "hasStructuralAnalysis": true
+    },
+    ".github/PULL_REQUEST_TEMPLATE.md": {
+      "filePath": ".github/PULL_REQUEST_TEMPLATE.md",
+      "contentHash": "df80a9caa0b0d94fc8b436d80335078c98409cd6918d5a69f1b256ca695cfb3a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/test.yml": {
+      "filePath": ".github/workflows/test.yml",
+      "contentHash": "36ea84848d88ae93e6333648f69e60be26c823e891efbad73a6a9e75d10a20b0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    ".ijfw/.dream-state-v2.json": {
+      "filePath": ".ijfw/.dream-state-v2.json",
+      "contentHash": "81d328bd24d98b699bcd58e22c26233a19aacd92d26ea0134184368d622e2576",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 32,
+      "hasStructuralAnalysis": true
+    },
+    ".ijfw/.dream-state.json": {
+      "filePath": ".ijfw/.dream-state.json",
+      "contentHash": "cc1c82c8378acf55a328e2b1ef80ddc67fe135c2bc7843c096c7b1beb6053536",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": true
+    },
+    ".ijfw/.session-counter": {
+      "filePath": ".ijfw/.session-counter",
+      "contentHash": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    ".ijfw/memory/project-journal.md": {
+      "filePath": ".ijfw/memory/project-journal.md",
+      "contentHash": "e627827cd54bdf816a460831fd487f9968261e85e55bb31bb52e8dd0f087dd2d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    ".ijfw/metrics/sessions.jsonl": {
+      "filePath": ".ijfw/metrics/sessions.jsonl",
+      "contentHash": "0411130f4b43577926ac424e5e375e970a4884ddb6ad597c74490e19197fbab4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 3,
+      "hasStructuralAnalysis": false
+    },
+    ".ijfw/sessions/session_2026-06-03_15-41-08.md": {
+      "filePath": ".ijfw/sessions/session_2026-06-03_15-41-08.md",
+      "contentHash": "e1b076cd7990c7f69c409617e393a415f982976d7a8f693ac81b949b50108896",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    ".ijfw/sessions/session_2026-06-03_15-45-58.md": {
+      "filePath": ".ijfw/sessions/session_2026-06-03_15-45-58.md",
+      "contentHash": "2f57b3890519ee800dcff20891eed7f87f990793d9969295cbfd3a48068b7567",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    ".understand-anything/.understandignore": {
+      "filePath": ".understand-anything/.understandignore",
+      "contentHash": "301f5a3a356dd2388b3a1def3fabce6b8fa9f1860903ab52352892d43594e568",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "abilities-mcp-adapter.php": {
+      "filePath": "abilities-mcp-adapter.php",
+      "contentHash": "1482977868f82416fa7cb4359fbe5ec55922d8b129280482c0913e4cae3ddd4c",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\Settings\\SettingsAbilities",
+          "specifiers": [
+            "SettingsAbilities"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AbilitySettingsPage",
+          "specifiers": [
+            "AbilitySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\SafetySettingsPage",
+          "specifiers": [
+            "SafetySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthCleanup",
+          "specifiers": [
+            "OAuthCleanup"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpAdapter",
+          "specifiers": [
+            "McpAdapter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\TrustedProxyResolver",
+          "specifiers": [
+            "TrustedProxyResolver"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 161,
+      "hasStructuralAnalysis": true
+    },
+    "assets/admin.css": {
+      "filePath": "assets/admin.css",
+      "contentHash": "f9e80c4f7988b5a904806031dbe34d9551eff6583f0dab433f7376d16287cff7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 309,
+      "hasStructuralAnalysis": false
+    },
+    "assets/consent.css": {
+      "filePath": "assets/consent.css",
+      "contentHash": "36385dd896dd9794c45a70b143a42765dca73b9ac7feff7af8dd7270a0b6a730",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 257,
+      "hasStructuralAnalysis": false
+    },
+    "bin/rate-limit-burst.php": {
+      "filePath": "bin/rate-limit-burst.php",
+      "contentHash": "be8b1a0c30a82fe098e51552576c1c712a1214962e229ab31fc165f66f460fc6",
+      "functions": [
+        {
+          "name": "parse_args",
+          "params": [
+            "$argv"
+          ],
+          "returnType": "array",
+          "exported": true,
+          "lineCount": 35
+        },
+        {
+          "name": "usage",
+          "params": [],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "send",
+          "params": [
+            "$url",
+            "$method",
+            "$body",
+            "$headers"
+          ],
+          "returnType": "array",
+          "exported": true,
+          "lineCount": 22
+        },
+        {
+          "name": "compose_headers",
+          "params": [
+            "$session",
+            "$bearer",
+            "$extras"
+          ],
+          "returnType": "array",
+          "exported": true,
+          "lineCount": 19
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\BurstHarness",
+          "specifiers": [
+            "BurstHarness"
+          ]
+        }
+      ],
+      "exports": [
+        "parse_args",
+        "usage",
+        "send",
+        "compose_headers"
+      ],
+      "totalLines": 271,
+      "hasStructuralAnalysis": true
+    },
+    "CHANGELOG.md": {
+      "filePath": "CHANGELOG.md",
+      "contentHash": "9c10be7416813c46b5afb938f3a1b9281e1f70016131ae51813c80ed7cda4780",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 364,
+      "hasStructuralAnalysis": true
+    },
+    "composer.json": {
+      "filePath": "composer.json",
+      "contentHash": "307b9079f1217130529c92e27a488e89e97fb8b61f07e93a88a63376bd6f052b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "CONTRIBUTING.md": {
+      "filePath": "CONTRIBUTING.md",
+      "contentHash": "1e4c733f31239b98bb0e15b9c8b3ee2a6a1815e46a04c8eeadaeec7abb2f4628",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 70,
+      "hasStructuralAnalysis": true
+    },
+    "docs/architecture.md": {
+      "filePath": "docs/architecture.md",
+      "contentHash": "4e9d911e9beab839854488603cabf6a03f7a61543b48919fbe03fcf5d288f93d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 157,
+      "hasStructuralAnalysis": true
+    },
+    "includes/class-license-manager.php": {
+      "filePath": "includes/class-license-manager.php",
+      "contentHash": "7099f87c88c79b66773f4c9c414742057935fc8986530218abfe15d932301345",
+      "functions": [
+        {
+          "name": "get_license_key",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_product_id",
+          "params": [],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "is_active",
+          "params": [],
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "activate",
+          "params": [
+            "$license_key"
+          ],
+          "exported": false,
+          "lineCount": 46
+        },
+        {
+          "name": "deactivate",
+          "params": [],
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "get_status",
+          "params": [],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "is_network_license",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "get_opt",
+          "params": [
+            "$key",
+            "$default"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "update_opt",
+          "params": [
+            "$key",
+            "$value"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "delete_opt",
+          "params": [
+            "$key"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "remote_check",
+          "params": [
+            "$license_key"
+          ],
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "remote_request",
+          "params": [
+            "$action",
+            "$payload"
+          ],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "is_within_grace_period",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "Abilities_MCP_Adapter_License_Manager",
+          "methods": [
+            "get_license_key",
+            "get_product_id",
+            "is_active",
+            "activate",
+            "deactivate",
+            "get_status",
+            "is_network_license",
+            "get_opt",
+            "update_opt",
+            "delete_opt",
+            "remote_check",
+            "remote_request",
+            "is_within_grace_period"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 339
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "Abilities_MCP_Adapter_License_Manager"
+      ],
+      "totalLines": 359,
+      "hasStructuralAnalysis": true
+    },
+    "includes/updater/class-plugin-updater.php": {
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "contentHash": "afa3dcbeb8c93ce702a10d5cbd1f12fa5fbd582a5b52596da40b3961e7a0e220",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$config"
+          ],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "init_hooks",
+          "params": [],
+          "exported": false,
+          "lineCount": 51
+        },
+        {
+          "name": "check_plugin_update",
+          "params": [
+            "$transient_data"
+          ],
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "plugins_api_filter",
+          "params": [
+            "$data",
+            "$action",
+            "$args"
+          ],
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "pre_download",
+          "params": [
+            "$reply",
+            "$package",
+            "$upgrader"
+          ],
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "get_version_info",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "get_cached_version_info",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "set_cached_version_info",
+          "params": [
+            "$value"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "get_remote_version_info",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "get_fluentcart_version_info",
+          "params": [],
+          "exported": false,
+          "lineCount": 48
+        },
+        {
+          "name": "get_github_version_info",
+          "params": [],
+          "exported": false,
+          "lineCount": 51
+        },
+        {
+          "name": "normalize_version_info",
+          "params": [
+            "$version_info"
+          ],
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "Abilities_MCP_Adapter_Plugin_Updater",
+          "methods": [
+            "__construct",
+            "init_hooks",
+            "check_plugin_update",
+            "plugins_api_filter",
+            "pre_download",
+            "get_version_info",
+            "get_cached_version_info",
+            "set_cached_version_info",
+            "get_remote_version_info",
+            "get_fluentcart_version_info",
+            "get_github_version_info",
+            "normalize_version_info"
+          ],
+          "properties": [
+            "cache_key",
+            "config"
+          ],
+          "exported": true,
+          "lineCount": 415
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "Abilities_MCP_Adapter_Plugin_Updater"
+      ],
+      "totalLines": 431,
+      "hasStructuralAnalysis": true
+    },
+    "phpunit.xml": {
+      "filePath": "phpunit.xml",
+      "contentHash": "40dabbb04d89f1e45bbf705464263ab57b89393dd4712528afbee1c1b1b86724",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": false
+    },
+    "PRINCIPLES.md": {
+      "filePath": "PRINCIPLES.md",
+      "contentHash": "7a213435486b28cbacbe0f0b4579b87f5003e72d3f27e45075d8b7fe0f4875e4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 182,
+      "hasStructuralAnalysis": true
+    },
+    "README.md": {
+      "filePath": "README.md",
+      "contentHash": "90fce68806920cff6cae41cec01b9b4eaecfd95f0ee24b5b97b149e8a3d4abff",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 217,
+      "hasStructuralAnalysis": true
+    },
+    "readme.txt": {
+      "filePath": "readme.txt",
+      "contentHash": "b88623ea578f5659fe4b4a83db3388e301b4be8bdd3b3284014e429af6f7639d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 115,
+      "hasStructuralAnalysis": false
+    },
+    "SECURITY.md": {
+      "filePath": "SECURITY.md",
+      "contentHash": "94fd22ddc2b243631a599a4cb20f238efd8da58fec3ed15ba2d7a29fc7f0dff7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 50,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/BatchExecuteAbility.php": {
+      "filePath": "src/Abilities/BatchExecuteAbility.php",
+      "contentHash": "b1a8ca21faefc2083570610b8602ef80130055ed0d1d9187db076d108252ea86",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "execute",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 65
+        }
+      ],
+      "classes": [
+        {
+          "name": "BatchExecuteAbility",
+          "methods": [
+            "register",
+            "check_permission",
+            "execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 150
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpAdapter",
+          "specifiers": [
+            "McpAdapter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "BatchExecuteAbility"
+      ],
+      "totalLines": 175,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/DiscoverAbilitiesAbility.php": {
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "contentHash": "fd422e317896dd42b7a4cfc29dc12b9e259c8525698f7d08a32cbae8219c226e",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 76
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "validate_user_access",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "execute",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 185
+        }
+      ],
+      "classes": [
+        {
+          "name": "DiscoverAbilitiesAbility",
+          "methods": [
+            "register",
+            "check_permission",
+            "validate_user_access",
+            "execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 317
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "DiscoverAbilitiesAbility"
+      ],
+      "totalLines": 346,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/ExecuteAbilityAbility.php": {
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "contentHash": "287eaf76d57dd409f7d9575ed5a0d820006a2d1db2d0dd73afdfeebf4a76ef0e",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 57
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 43
+        },
+        {
+          "name": "validate_user_access",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "execute",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 88
+        }
+      ],
+      "classes": [
+        {
+          "name": "ExecuteAbilityAbility",
+          "methods": [
+            "register",
+            "check_permission",
+            "validate_user_access",
+            "execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 240
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        }
+      ],
+      "exports": [
+        "ExecuteAbilityAbility"
+      ],
+      "totalLines": 272,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/GetAbilityInfoAbility.php": {
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "contentHash": "c058dea3784e3f31014198df48118c820f4e7ed23f53b27136f86a4ea4c6b409",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 54
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "validate_user_access",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "execute",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 47
+        }
+      ],
+      "classes": [
+        {
+          "name": "GetAbilityInfoAbility",
+          "methods": [
+            "register",
+            "check_permission",
+            "validate_user_access",
+            "execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 169
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "GetAbilityInfoAbility"
+      ],
+      "totalLines": 198,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/GetStartedAbility.php": {
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "contentHash": "c06dad5376e0bd8649f44c3e7c9e169636022e527650ceb9ce60d862e63de336",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 59
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "execute",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 136
+        }
+      ],
+      "classes": [
+        {
+          "name": "GetStartedAbility",
+          "methods": [
+            "register",
+            "check_permission",
+            "execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 234
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "GetStartedAbility"
+      ],
+      "totalLines": 257,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/McpAbilityHelperTrait.php": {
+      "filePath": "src/Abilities/McpAbilityHelperTrait.php",
+      "contentHash": "065aa7afcca7df2b1373040d5bd83a7cc6b3fe2a9e8cb6e62e69ab9ee1798459",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 119,
+      "hasStructuralAnalysis": true
+    },
+    "src/Abilities/Settings/SettingsAbilities.php": {
+      "filePath": "src/Abilities/Settings/SettingsAbilities.php",
+      "contentHash": "9b9dbefc0176b75c1109c45935ab92cc169bad4023cf47de1fececb5f59b93d9",
+      "functions": [
+        {
+          "name": "register_all",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$input"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "guard_bucket3_default_keyword",
+          "params": [
+            "$keyword"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 47
+        },
+        {
+          "name": "guard_known_ability_name",
+          "params": [
+            "$ability_name",
+            "$caller_ability"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 43
+        },
+        {
+          "name": "register_get_redaction_list",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 47
+        },
+        {
+          "name": "execute_get_redaction_list",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "register_add_redaction_keyword",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 37
+        },
+        {
+          "name": "execute_add_redaction_keyword",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "register_remove_custom_keyword",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 37
+        },
+        {
+          "name": "execute_remove_custom_keyword",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "register_restore_redaction_defaults",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "execute_restore_redaction_defaults",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "register_remove_default_bucket3_keyword",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "execute_remove_default_bucket3_keyword",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 87
+        },
+        {
+          "name": "register_exempt_ability_from_bucket3",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "execute_exempt_ability_from_bucket3",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 85
+        },
+        {
+          "name": "register_unexempt_ability_from_bucket3",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "execute_unexempt_ability_from_bucket3",
+          "params": [
+            "$input"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 31
+        }
+      ],
+      "classes": [
+        {
+          "name": "SettingsAbilities",
+          "methods": [
+            "register_all",
+            "check_permission",
+            "guard_bucket3_default_keyword",
+            "guard_known_ability_name",
+            "register_get_redaction_list",
+            "execute_get_redaction_list",
+            "register_add_redaction_keyword",
+            "execute_add_redaction_keyword",
+            "register_remove_custom_keyword",
+            "execute_remove_custom_keyword",
+            "register_restore_redaction_defaults",
+            "execute_restore_redaction_defaults",
+            "register_remove_default_bucket3_keyword",
+            "execute_remove_default_bucket3_keyword",
+            "register_exempt_ability_from_bucket3",
+            "execute_exempt_ability_from_bucket3",
+            "register_unexempt_ability_from_bucket3",
+            "execute_unexempt_ability_from_bucket3"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 742
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\ConfirmationTokenStore",
+          "specifiers": [
+            "ConfirmationTokenStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "SettingsAbilities"
+      ],
+      "totalLines": 782,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/AbilitySettingsPage.php": {
+      "filePath": "src/Admin/AbilitySettingsPage.php",
+      "contentHash": "0155c8450fdcdfe92bcd0747313170339b68dc47667c673ff72adc8c93f1e95e",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "maybe_redirect",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        }
+      ],
+      "classes": [
+        {
+          "name": "AbilitySettingsPage",
+          "methods": [
+            "register",
+            "maybe_redirect"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 36
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\AbilitiesTab",
+          "specifiers": [
+            "AbilitiesTab"
+          ]
+        }
+      ],
+      "exports": [
+        "AbilitySettingsPage"
+      ],
+      "totalLines": 64,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/AdapterAdminPage.php": {
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "contentHash": "04191c724d1f3aec396c6ec1d6ca0f70bdd7423d2b125bed45c81e6bb90daaf5",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "add_menu_page",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "page_url",
+          "params": [
+            "$args"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tab_url",
+          "params": [
+            "$tab",
+            "$args"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "active_tab",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tab_ids",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "dispatch_form_submissions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "enqueue_assets",
+          "params": [
+            "$hook_suffix"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "render_page",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 52
+        },
+        {
+          "name": "tab_definitions",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "AdapterAdminPage",
+          "methods": [
+            "register",
+            "add_menu_page",
+            "page_url",
+            "tab_url",
+            "active_tab",
+            "tab_ids",
+            "dispatch_form_submissions",
+            "enqueue_assets",
+            "render_page",
+            "tab_definitions"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 205
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\AbilitiesTab",
+          "specifiers": [
+            "AbilitiesTab"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\ConnectedBridgesTab",
+          "specifiers": [
+            "ConnectedBridgesTab"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\SafetyTab",
+          "specifiers": [
+            "SafetyTab"
+          ]
+        }
+      ],
+      "exports": [
+        "AdapterAdminPage"
+      ],
+      "totalLines": 237,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Bridges/AuthHeaderProbe.php": {
+      "filePath": "src/Admin/Bridges/AuthHeaderProbe.php",
+      "contentHash": "410e8f6203cfe013b55eabb1d2618e280d2c596fba7f5c42ef7f032a2462a63b",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "record",
+          "params": [
+            "$header_present"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "resolve_status",
+          "params": [
+            "$existing"
+          ],
+          "exported": false,
+          "lineCount": 48
+        },
+        {
+          "name": "read_state",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "clear",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthHeaderProbe",
+          "methods": [
+            "register",
+            "record",
+            "resolve_status",
+            "read_state",
+            "clear"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 112
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\ConnectedBridgesTab",
+          "specifiers": [
+            "ConnectedBridgesTab"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthHeaderProbe"
+      ],
+      "totalLines": 145,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Bridges/BoundaryAuditBuffer.php": {
+      "filePath": "src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "contentHash": "f9473bcfa93bae70d4349445b249e70c5fe04ce41cd7f372d15af7018de8faad",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "capture",
+          "params": [
+            "$event",
+            "$tags",
+            "$duration_ms"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "read",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "clear",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "BoundaryAuditBuffer",
+          "methods": [
+            "register",
+            "capture",
+            "read",
+            "clear"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 91
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "BoundaryAuditBuffer"
+      ],
+      "totalLines": 119,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Bridges/BridgeRowProjector.php": {
+      "filePath": "src/Admin/Bridges/BridgeRowProjector.php",
+      "contentHash": "22f804a31fdb57011ddac642577847856610c5d97aef8e151562c431a2c1ddc5",
+      "functions": [
+        {
+          "name": "project",
+          "params": [
+            "$client",
+            "$latest_token",
+            "$last_interactive_unix",
+            "$now_unix",
+            "$silent_cap_days"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 51
+        }
+      ],
+      "classes": [
+        {
+          "name": "BridgeRowProjector",
+          "methods": [
+            "project"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 78
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\PolicyStore",
+          "specifiers": [
+            "PolicyStore"
+          ]
+        }
+      ],
+      "exports": [
+        "BridgeRowProjector"
+      ],
+      "totalLines": 101,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/PermissionManager.php": {
+      "filePath": "src/Admin/PermissionManager.php",
+      "contentHash": "67d93c55f4d6f188e16d31a263446af1700db1abaeb45fddf9862b9ee27781d0",
+      "functions": [
+        {
+          "name": "get_permission",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "is_enabled",
+          "params": [
+            "$ability_name"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "set_enabled",
+          "params": [
+            "$ability_name",
+            "$enabled"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "get_settings",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "save_settings",
+          "params": [
+            "$settings"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "clear_cache",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_valid_permission",
+          "params": [
+            "$permission"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "PermissionManager",
+          "methods": [
+            "get_permission",
+            "is_enabled",
+            "set_enabled",
+            "get_settings",
+            "save_settings",
+            "clear_cache",
+            "is_valid_permission"
+          ],
+          "properties": [
+            "cached_settings"
+          ],
+          "exported": true,
+          "lineCount": 166
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PermissionManager"
+      ],
+      "totalLines": 189,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/SafetySettingsPage.php": {
+      "filePath": "src/Admin/SafetySettingsPage.php",
+      "contentHash": "4ee2adf4c3203bf53a02c382b2f13819baef45e2b205ccdbf7327e3d2835cf54",
+      "functions": [
+        {
+          "name": "register",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "maybe_redirect",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "SafetySettingsPage",
+          "methods": [
+            "register",
+            "maybe_redirect"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 30
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SafetySettingsPage"
+      ],
+      "totalLines": 56,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Tabs/AbilitiesTab.php": {
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "contentHash": "4366770530e0c3a123891103088552f3d2ee5f79d69a5474366faf898ddca85c",
+      "functions": [
+        {
+          "name": "handle_save_abilities",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "handle_license_actions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 39
+        },
+        {
+          "name": "render",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "active_subtab",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "render_abilities_subtab",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 68
+        },
+        {
+          "name": "render_license_subtab",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 79
+        },
+        {
+          "name": "group_abilities_by_permission",
+          "params": [
+            "$abilities"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "is_mcp_exposed",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "AbilitiesTab",
+          "methods": [
+            "handle_save_abilities",
+            "handle_license_actions",
+            "render",
+            "active_subtab",
+            "render_abilities_subtab",
+            "render_license_subtab",
+            "group_abilities_by_permission",
+            "is_mcp_exposed"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 336
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        }
+      ],
+      "exports": [
+        "AbilitiesTab"
+      ],
+      "totalLines": 370,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Tabs/ConnectedBridgesTab.php": {
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "contentHash": "5f59b944188fcec1acb2a60e9b386d008634e758504b1dccc41260658459eb85",
+      "functions": [
+        {
+          "name": "render",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "render_table",
+          "params": [
+            "$clients"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 94
+        },
+        {
+          "name": "render_audit_slice",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 61
+        },
+        {
+          "name": "render_authorization_header_diagnostic",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "handle_action",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 38
+        },
+        {
+          "name": "latest_token_for",
+          "params": [
+            "$client_id"
+          ],
+          "returnType": "?object",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "user_login",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "format_datetime",
+          "params": [
+            "$datetime"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "resolve_status",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "render_flash",
+          "params": [
+            "$flash"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConnectedBridgesTab",
+          "methods": [
+            "render",
+            "render_table",
+            "render_audit_slice",
+            "render_authorization_header_diagnostic",
+            "handle_action",
+            "latest_token_for",
+            "user_login",
+            "format_datetime",
+            "resolve_status",
+            "render_flash"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 391
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\BoundaryAuditBuffer",
+          "specifiers": [
+            "BoundaryAuditBuffer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\BridgeRowProjector",
+          "specifiers": [
+            "BridgeRowProjector"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\LastConsentLookup",
+          "specifiers": [
+            "LastConsentLookup"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\PolicyStore",
+          "specifiers": [
+            "PolicyStore"
+          ]
+        }
+      ],
+      "exports": [
+        "ConnectedBridgesTab"
+      ],
+      "totalLines": 430,
+      "hasStructuralAnalysis": true
+    },
+    "src/Admin/Tabs/SafetyTab.php": {
+      "filePath": "src/Admin/Tabs/SafetyTab.php",
+      "contentHash": "68a3ec512d1986cf6ded6580a77d0bebee40ea604b0e78168c83bc754441725b",
+      "functions": [
+        {
+          "name": "handle_save",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 47
+        },
+        {
+          "name": "render",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "render_master_toggle_section",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 52
+        },
+        {
+          "name": "render_keyword_list_section",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 46
+        },
+        {
+          "name": "render_bucket_table",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 89
+        },
+        {
+          "name": "render_exemptions_section",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 83
+        },
+        {
+          "name": "render_trusted_proxy_section",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 49
+        },
+        {
+          "name": "handle_master_toggle",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "handle_add_keyword",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "handle_remove_custom_keyword",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "handle_remove_default_keyword",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "handle_restore_defaults",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "handle_set_exemption",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "handle_unset_exemption",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "handle_trusted_proxy",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "list_public_abilities",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "is_mcp_public",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "observability_handler",
+          "params": [],
+          "returnType": "?\\WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "SafetyTab",
+          "methods": [
+            "handle_save",
+            "render",
+            "render_master_toggle_section",
+            "render_keyword_list_section",
+            "render_bucket_table",
+            "render_exemptions_section",
+            "render_trusted_proxy_section",
+            "handle_master_toggle",
+            "handle_add_keyword",
+            "handle_remove_custom_keyword",
+            "handle_remove_default_keyword",
+            "handle_restore_defaults",
+            "handle_set_exemption",
+            "handle_unset_exemption",
+            "handle_trusted_proxy",
+            "list_public_abilities",
+            "is_mcp_public",
+            "observability_handler"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 677
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "SafetyTab"
+      ],
+      "totalLines": 715,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/AuthorizationCodeStore.php": {
+      "filePath": "src/Auth/OAuth/AuthorizationCodeStore.php",
+      "contentHash": "23ca13c175f2ac303fc93dac5c050545a3f36a860c574631070b9fabdfe4aa11",
+      "functions": [
+        {
+          "name": "table",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "store",
+          "params": [
+            "$code_hash",
+            "$client_id",
+            "$user_id",
+            "$redirect_uri",
+            "$scope",
+            "$resource",
+            "$code_challenge",
+            "$ttl_seconds",
+            "$selected_role"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 42
+        },
+        {
+          "name": "consume",
+          "params": [
+            "$code",
+            "$client_id",
+            "$redirect_uri",
+            "$code_verifier"
+          ],
+          "returnType": "?object",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "compute_challenge",
+          "params": [
+            "$verifier"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizationCodeStore",
+          "methods": [
+            "table",
+            "store",
+            "consume",
+            "compute_challenge"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 153
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "AuthorizationCodeStore"
+      ],
+      "totalLines": 171,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/AuthorizationServer.php": {
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "contentHash": "dcbf3e634048f910e57855ce16555de912c738ce7d8d74340a7a9eb99e173f59",
+      "functions": [
+        {
+          "name": "boot",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 45
+        },
+        {
+          "name": "maybe_run_migration",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "run_migration",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 82
+        },
+        {
+          "name": "intercept_pre_wp_routes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 41
+        },
+        {
+          "name": "extract_path_prefix",
+          "params": [
+            "$full_path",
+            "$known_prefix"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "extract_authorize_path_prefix",
+          "params": [
+            "$full_path"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "is_well_known_or_oauth_path",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "register_rest_routes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 43
+        },
+        {
+          "name": "rest_host_allowlist_gate",
+          "params": [],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "authenticate_bearer",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "int|false",
+          "exported": false,
+          "lineCount": 107
+        },
+        {
+          "name": "schedule_www_authenticate",
+          "params": [
+            "$error_code",
+            "$description"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizationServer",
+          "methods": [
+            "boot",
+            "maybe_run_migration",
+            "run_migration",
+            "intercept_pre_wp_routes",
+            "extract_path_prefix",
+            "extract_authorize_path_prefix",
+            "is_well_known_or_oauth_path",
+            "register_rest_routes",
+            "rest_host_allowlist_gate",
+            "authenticate_bearer",
+            "schedule_www_authenticate"
+          ],
+          "properties": [
+            "booted"
+          ],
+          "exported": true,
+          "lineCount": 512
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\AuthHeaderProbe",
+          "specifiers": [
+            "AuthHeaderProbe"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\BoundaryAuditBuffer",
+          "specifiers": [
+            "BoundaryAuditBuffer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\AuthorizeEndpoint",
+          "specifiers": [
+            "AuthorizeEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\RegisterEndpoint",
+          "specifiers": [
+            "RegisterEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\TokenEndpoint",
+          "specifiers": [
+            "TokenEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\RevokeEndpoint",
+          "specifiers": [
+            "RevokeEndpoint"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizationServer"
+      ],
+      "totalLines": 554,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/ClientRegistry.php": {
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "contentHash": "de518378a151e6c4cb749659468610451783b43ecb030370cb8ba5620994f51f",
+      "functions": [
+        {
+          "name": "table",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "register",
+          "params": [
+            "$client_name",
+            "$redirect_uris",
+            "$scope",
+            "$software_id",
+            "$software_version",
+            "$registered_ip"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "find",
+          "params": [
+            "$client_id"
+          ],
+          "returnType": "?object",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "redirect_uri_valid",
+          "params": [
+            "$client",
+            "$uri"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 59
+        },
+        {
+          "name": "query_normalize",
+          "params": [
+            "$query"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "revoke",
+          "params": [
+            "$client_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "count_active",
+          "params": [],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "list_active",
+          "params": [
+            "$limit",
+            "$offset"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 14
+        }
+      ],
+      "classes": [
+        {
+          "name": "ClientRegistry",
+          "methods": [
+            "table",
+            "register",
+            "find",
+            "redirect_uri_valid",
+            "query_normalize",
+            "revoke",
+            "count_active",
+            "list_active"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 220
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ClientRegistry"
+      ],
+      "totalLines": 240,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php": {
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "contentHash": "c18552d782bf00dcf9d4ffeeda5067779ea4f32ee2c625656b6f7566b31cb828",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "is_ok",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_pre_redirect_error",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_redirectable_error",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate",
+          "params": [
+            "$params",
+            "$resource_indicator"
+          ],
+          "returnType": "AuthorizeValidationResult",
+          "exported": false,
+          "lineCount": 81
+        },
+        {
+          "name": "str",
+          "params": [
+            "$value"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "pre_redirect_error",
+          "params": [
+            "$code",
+            "$description"
+          ],
+          "returnType": "AuthorizeValidationResult",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "redirectable_error",
+          "params": [
+            "$client",
+            "$redirect_uri",
+            "$state",
+            "$code",
+            "$description"
+          ],
+          "returnType": "AuthorizeValidationResult",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizeValidationResult",
+          "methods": [
+            "__construct",
+            "is_ok",
+            "is_pre_redirect_error",
+            "is_redirectable_error"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 30
+        },
+        {
+          "name": "AuthorizeRequestValidator",
+          "methods": [
+            "validate",
+            "str",
+            "pre_redirect_error",
+            "redirectable_error"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 132
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizeValidationResult",
+        "AuthorizeRequestValidator"
+      ],
+      "totalLines": 202,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/ConsentDecision.php": {
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecision.php",
+      "contentHash": "29bf403ce673309d33315e6e24c305a4bb244dfcfca032e184d8590972ad15e1",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "is_auto_approve",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_render_full",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_render_incremental",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsentDecision",
+          "methods": [
+            "__construct",
+            "is_auto_approve",
+            "is_render_full",
+            "is_render_incremental"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 38
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ConsentDecision"
+      ],
+      "totalLines": 61,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php": {
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "contentHash": "0eac2c6ae6ffcf69068b788f73521058b194e056e7bdc7a342493f0820188847",
+      "functions": [
+        {
+          "name": "evaluate",
+          "params": [
+            "$requested_scopes",
+            "$previously_granted",
+            "$last_interactive_unix",
+            "$now_unix",
+            "$consent_max_silent_days"
+          ],
+          "returnType": "ConsentDecision",
+          "exported": false,
+          "lineCount": 73
+        },
+        {
+          "name": "normalize",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsentDecisionEvaluator",
+          "methods": [
+            "evaluate",
+            "normalize"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 93
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ConsentDecisionEvaluator"
+      ],
+      "totalLines": 126,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/ConsentScreenRenderer.php": {
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "contentHash": "e51e5f2ecfc142fa9cfe18e8dbd48baf1531b30311c10a869fbe013f9dcb1ce3",
+      "functions": [
+        {
+          "name": "render",
+          "params": [
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "build_html",
+          "params": [
+            "$params"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 131
+        },
+        {
+          "name": "render_scope_groups",
+          "params": [
+            "$rendered_scopes",
+            "$decision",
+            "$previously_granted_at_unix"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "stylesheet_url",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "render_error",
+          "params": [
+            "$title",
+            "$detail",
+            "$status"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "build_error_html",
+          "params": [
+            "$title",
+            "$detail"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 26
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsentScreenRenderer",
+          "methods": [
+            "render",
+            "build_html",
+            "render_scope_groups",
+            "stylesheet_url",
+            "render_error",
+            "build_error_html"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 310
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ConsentScreenRenderer"
+      ],
+      "totalLines": 344,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/LastConsentLookup.php": {
+      "filePath": "src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "contentHash": "884e29a9b9ad4a3b3ea842c3f518f05bf087258cdb9043783a2c28abdddab097",
+      "functions": [
+        {
+          "name": "key",
+          "params": [
+            "$client_id",
+            "$user_id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "timestamp_for",
+          "params": [
+            "$client_id",
+            "$user_id"
+          ],
+          "returnType": "?int",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "record",
+          "params": [
+            "$client_id",
+            "$user_id",
+            "$now_unix"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "days_since",
+          "params": [
+            "$client_id",
+            "$user_id",
+            "$now_unix"
+          ],
+          "returnType": "?int",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "LastConsentLookup",
+          "methods": [
+            "key",
+            "timestamp_for",
+            "record",
+            "days_since"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 63
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "LastConsentLookup"
+      ],
+      "totalLines": 98,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/PolicyStore.php": {
+      "filePath": "src/Auth/OAuth/Consent/PolicyStore.php",
+      "contentHash": "586d1ef4a82221c0aacaa457687bb47d8d0370a7c701699d7ceb92cb02bf5d1f",
+      "functions": [
+        {
+          "name": "consent_max_silent_days",
+          "params": [],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "clamp",
+          "params": [
+            "$days"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "PolicyStore",
+          "methods": [
+            "consent_max_silent_days",
+            "clamp"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 49
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PolicyStore"
+      ],
+      "totalLines": 72,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/PriorGrantLookup.php": {
+      "filePath": "src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "contentHash": "33e60507a71c6d29acca1924d6259f07734816b79f46b6983f83a753ea1bbc1b",
+      "functions": [
+        {
+          "name": "scopes_for",
+          "params": [
+            "$client_id",
+            "$user_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 20
+        }
+      ],
+      "classes": [
+        {
+          "name": "PriorGrantLookup",
+          "methods": [
+            "scopes_for"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 34
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PriorGrantLookup"
+      ],
+      "totalLines": 56,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/RenderedScopeNonce.php": {
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "contentHash": "51fecde578196b266d08ffdd4329957ffc08f6b0bb8231bdae9e8b67f0bc7389",
+      "functions": [
+        {
+          "name": "issue",
+          "params": [
+            "$rendered_scopes",
+            "$user_id",
+            "$client_id",
+            "$redirect_uri",
+            "$state"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "redeem",
+          "params": [
+            "$nonce"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "submitted_subset_is_valid",
+          "params": [
+            "$payload",
+            "$user_id",
+            "$client_id",
+            "$redirect_uri",
+            "$state",
+            "$submitted_scopes"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 28
+        }
+      ],
+      "classes": [
+        {
+          "name": "RenderedScopeNonce",
+          "methods": [
+            "issue",
+            "redeem",
+            "submitted_subset_is_valid"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 97
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "RenderedScopeNonce"
+      ],
+      "totalLines": 126,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/RoleSelector.php": {
+      "filePath": "src/Auth/OAuth/Consent/RoleSelector.php",
+      "contentHash": "8a802fd02989021eec54c842a98afeca212d6b1d6592023319b92af814e561c3",
+      "functions": [
+        {
+          "name": "roles_for_user_id",
+          "params": [
+            "$user_id",
+            "$resolver"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "user_holds_role",
+          "params": [
+            "$user_id",
+            "$submitted_role",
+            "$resolver"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "RoleSelector",
+          "methods": [
+            "roles_for_user_id",
+            "user_holds_role"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 47
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "RoleSelector"
+      ],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Consent/ScopeGrouper.php": {
+      "filePath": "src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "contentHash": "0434d866eaf63b412927e690a915ad8d72ed4050a6101dbd07fab59117703583",
+      "functions": [
+        {
+          "name": "group",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "group_is_sensitive",
+          "params": [
+            "$module_scopes"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "ScopeGrouper",
+          "methods": [
+            "group",
+            "group_is_sensitive"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 60
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ScopeGrouper"
+      ],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/DiscoveryEndpoints.php": {
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "contentHash": "356348e46ad25c539cc4ed8a486d79a06f6fe55fc7a0a3ed3e40fda6190061ab",
+      "functions": [
+        {
+          "name": "issuer",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "resource_url",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "oauth_rest_base",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "serve_protected_resource",
+          "params": [
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "serve_authorization_server",
+          "params": [
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "serve_oidc_configuration",
+          "params": [
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "as_metadata",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "json_response",
+          "params": [
+            "$data",
+            "$status",
+            "$cors"
+          ],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "DiscoveryEndpoints",
+          "methods": [
+            "issuer",
+            "resource_url",
+            "oauth_rest_base",
+            "serve_protected_resource",
+            "serve_authorization_server",
+            "serve_oidc_configuration",
+            "as_metadata",
+            "json_response"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 125
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "DiscoveryEndpoints"
+      ],
+      "totalLines": 146,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php": {
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "contentHash": "9143534b57fe6590b06d303c39b2a0acdbcdce5efcbe88122197f335b37a7a30",
+      "functions": [
+        {
+          "name": "dispatch",
+          "params": [
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "reject_method",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "handle_get",
+          "params": [
+            "$params",
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "mint_code_and_redirect",
+          "params": [
+            "$validation",
+            "$decision",
+            "$user_id",
+            "$interactive",
+            "$effective_scopes",
+            "$selected_role"
+          ],
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "render_consent",
+          "params": [
+            "$validation",
+            "$decision",
+            "$user_id",
+            "$last_interactive_unix",
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "handle_post",
+          "params": [
+            "$params",
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 113
+        },
+        {
+          "name": "submitted_scopes",
+          "params": [
+            "$params"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "redirect_to_login",
+          "params": [
+            "$path_prefix"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "redirect_with_code",
+          "params": [
+            "$redirect_uri",
+            "$code",
+            "$state"
+          ],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "redirect_with_error",
+          "params": [
+            "$redirect_uri",
+            "$error_code",
+            "$description",
+            "$state"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "self_url",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "resource_indicator",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizeEndpoint",
+          "methods": [
+            "dispatch",
+            "reject_method",
+            "handle_get",
+            "mint_code_and_redirect",
+            "render_consent",
+            "handle_post",
+            "submitted_scopes",
+            "redirect_to_login",
+            "redirect_with_code",
+            "redirect_with_error",
+            "self_url",
+            "resource_indicator"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 418
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\oauth_client_ip",
+          "specifiers": [
+            "oauth_client_ip"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\oauth_log_boundary",
+          "specifiers": [
+            "oauth_log_boundary"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationCodeStore",
+          "specifiers": [
+            "AuthorizationCodeStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\AuthorizeRequestValidator",
+          "specifiers": [
+            "AuthorizeRequestValidator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\AuthorizeValidationResult",
+          "specifiers": [
+            "AuthorizeValidationResult"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecision",
+          "specifiers": [
+            "ConsentDecision"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecisionEvaluator",
+          "specifiers": [
+            "ConsentDecisionEvaluator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentScreenRenderer",
+          "specifiers": [
+            "ConsentScreenRenderer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\LastConsentLookup",
+          "specifiers": [
+            "LastConsentLookup"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\PolicyStore",
+          "specifiers": [
+            "PolicyStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\PriorGrantLookup",
+          "specifiers": [
+            "PriorGrantLookup"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\RenderedScopeNonce",
+          "specifiers": [
+            "RenderedScopeNonce"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\RoleSelector",
+          "specifiers": [
+            "RoleSelector"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\DiscoveryEndpoints",
+          "specifiers": [
+            "DiscoveryEndpoints"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\McpResourcePath",
+          "specifiers": [
+            "McpResourcePath"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizeEndpoint"
+      ],
+      "totalLines": 472,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Endpoints/RegisterEndpoint.php": {
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "contentHash": "24c4104906b911a08e3802a9a4a63ffc5d215b2eda8beeb3181200bf9c226a08",
+      "functions": [
+        {
+          "name": "handle_get",
+          "params": [
+            "$request"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "handle_post",
+          "params": [
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 88
+        },
+        {
+          "name": "classify_scopes",
+          "params": [
+            "$scope_str"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "is_valid_redirect_uri",
+          "params": [
+            "$uri"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 14
+        }
+      ],
+      "classes": [
+        {
+          "name": "RegisterEndpoint",
+          "methods": [
+            "handle_get",
+            "handle_post",
+            "classify_scopes",
+            "is_valid_redirect_uri"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 149
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\DiscoveryEndpoints",
+          "specifiers": [
+            "DiscoveryEndpoints"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "RegisterEndpoint"
+      ],
+      "totalLines": 175,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Endpoints/RevokeEndpoint.php": {
+      "filePath": "src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "contentHash": "4bd3c1a23fbb95f98429eea166f4e1da16e44a64941366c61e80bf8ac1967c37",
+      "functions": [
+        {
+          "name": "handle_get",
+          "params": [
+            "$request"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "handle_post",
+          "params": [
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 47
+        }
+      ],
+      "classes": [
+        {
+          "name": "RevokeEndpoint",
+          "methods": [
+            "handle_get",
+            "handle_post"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 65
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "RevokeEndpoint"
+      ],
+      "totalLines": 101,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/Endpoints/TokenEndpoint.php": {
+      "filePath": "src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "contentHash": "d251b565efebced6df2a76a271748be85ae127335aa7f213ba4189982084dd72",
+      "functions": [
+        {
+          "name": "handle_get",
+          "params": [
+            "$request"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "handle_post",
+          "params": [
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "handle_auth_code",
+          "params": [
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 49
+        },
+        {
+          "name": "handle_refresh",
+          "params": [
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 27
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenEndpoint",
+          "methods": [
+            "handle_get",
+            "handle_post",
+            "handle_auth_code",
+            "handle_refresh"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 103
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationCodeStore",
+          "specifiers": [
+            "AuthorizationCodeStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenEndpoint"
+      ],
+      "totalLines": 128,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/helpers.php": {
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "contentHash": "1acbf086fbcffee71f74058c00da70d35aaba147a9647b07487bd58e3de2e639",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 178,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/McpResourcePath.php": {
+      "filePath": "src/Auth/OAuth/McpResourcePath.php",
+      "contentHash": "b0df5c772a0c5cfff0c62ef3187f5797ef91b5c72e21a34713dcb189df72bf49",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpResourcePath",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 14
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpResourcePath"
+      ],
+      "totalLines": 38,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/OAuthCleanup.php": {
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "contentHash": "1518bddb127108e3d50f33b4b287cf95ccc310653315ccb5fca55c7436b1d89f",
+      "functions": [
+        {
+          "name": "schedule",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "unschedule",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "run",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "batch_delete",
+          "params": [
+            "$table",
+            "$where_clause"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "maybe_alert_row_counts",
+          "params": [
+            "$p"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 31
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthCleanup",
+          "methods": [
+            "schedule",
+            "unschedule",
+            "run",
+            "batch_delete",
+            "maybe_alert_row_counts"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 144
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "OAuthCleanup"
+      ],
+      "totalLines": 179,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/OAuthHostAllowlist.php": {
+      "filePath": "src/Auth/OAuth/OAuthHostAllowlist.php",
+      "contentHash": "b256b0a0201e490289afe6194776ff6e14d942302aad57a4bd251e1cd55a1e4e",
+      "functions": [
+        {
+          "name": "build",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "override",
+          "params": [
+            "$hosts"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "reset",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_allowed",
+          "params": [
+            "$host"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthHostAllowlist",
+          "methods": [
+            "build",
+            "override",
+            "reset",
+            "is_allowed"
+          ],
+          "properties": [
+            "hosts"
+          ],
+          "exported": true,
+          "lineCount": 64
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "OAuthHostAllowlist"
+      ],
+      "totalLines": 88,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/OAuthRequestContext.php": {
+      "filePath": "src/Auth/OAuth/OAuthRequestContext.php",
+      "contentHash": "9bbaa2a4cdf5161743c0cf061c11da52d0854e4f3deee497d893adbb73ffeb70",
+      "functions": [
+        {
+          "name": "set",
+          "params": [
+            "$user_id",
+            "$scopes",
+            "$resource",
+            "$client_id",
+            "$token_id",
+            "$selected_role"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "is_oauth_request",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "user_id",
+          "params": [],
+          "returnType": "?int",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "granted_scopes",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "client_id",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "token_id",
+          "params": [],
+          "returnType": "?int",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "resource",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "selected_role",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "reset",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "oauth_has_scope",
+          "params": [
+            "$required_scope"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthRequestContext",
+          "methods": [
+            "set",
+            "is_oauth_request",
+            "user_id",
+            "granted_scopes",
+            "client_id",
+            "token_id",
+            "resource",
+            "selected_role",
+            "reset",
+            "oauth_has_scope"
+          ],
+          "properties": [
+            "current"
+          ],
+          "exported": true,
+          "lineCount": 98
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "OAuthRequestContext"
+      ],
+      "totalLines": 119,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/OAuthScopeEnforcer.php": {
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "contentHash": "ae572bc1abeb5d834f52a3fc9ce1d399f2485c610727da695d2f713af008550d",
+      "functions": [
+        {
+          "name": "required_scope_for",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "check",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "check_scope",
+          "params": [
+            "$required"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "category_segment",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "umbrella_for",
+          "params": [
+            "$required"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthScopeEnforcer",
+          "methods": [
+            "required_scope_for",
+            "check",
+            "check_scope",
+            "category_segment",
+            "umbrella_for"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 127
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthScopeEnforcer"
+      ],
+      "totalLines": 174,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/RateLimiter.php": {
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "contentHash": "f130cf2ad2a875a76e8fa70ee8af582dc5f688568a74cb545ee9dae9f89a5cd4",
+      "functions": [
+        {
+          "name": "check_dcr",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "true|int",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "record_dcr",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "check_revoke",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "true|int",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "record_revoke",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "site_cap_reached",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "counter_read",
+          "params": [
+            "$key"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "counter_increment",
+          "params": [
+            "$key",
+            "$ttl"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "RateLimiter",
+          "methods": [
+            "check_dcr",
+            "record_dcr",
+            "check_revoke",
+            "record_revoke",
+            "site_cap_reached",
+            "counter_read",
+            "counter_increment"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 149
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "RateLimiter"
+      ],
+      "totalLines": 179,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/ScopeRegistry.php": {
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "contentHash": "7d49b7167b8a2e2a0390d618436a5ef4a60a264048dcaed60136be7da01f788e",
+      "functions": [
+        {
+          "name": "unknown_scopes",
+          "params": [
+            "$requested"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "expand",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "is_sensitive",
+          "params": [
+            "$scope"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "all_scopes",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 89
+        },
+        {
+          "name": "categories_from_registry",
+          "params": [
+            "$abilities"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "has_category_coverage",
+          "params": [
+            "$category"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "reset_cache_for_testing",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "ScopeRegistry",
+          "methods": [
+            "unknown_scopes",
+            "expand",
+            "is_sensitive",
+            "all_scopes",
+            "categories_from_registry",
+            "has_category_coverage",
+            "reset_cache_for_testing"
+          ],
+          "properties": [
+            "all_scopes"
+          ],
+          "exported": true,
+          "lineCount": 301
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ScopeRegistry"
+      ],
+      "totalLines": 322,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/SelectedRoleEnforcer.php": {
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "contentHash": "a92f5cfa7821cfdade9a8c006319f6b6d178e2aef83246f9ad9d7a7f4b107b64",
+      "functions": [
+        {
+          "name": "set_resolver",
+          "params": [
+            "$resolver"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "apply",
+          "params": [
+            "$allcaps",
+            "$caps",
+            "$args",
+            "$user"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "role_capabilities",
+          "params": [
+            "$role_slug"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "default_role_capabilities",
+          "params": [
+            "$role_slug"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "user_id_from",
+          "params": [
+            "$user"
+          ],
+          "returnType": "?int",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "SelectedRoleEnforcer",
+          "methods": [
+            "set_resolver",
+            "apply",
+            "role_capabilities",
+            "default_role_capabilities",
+            "user_id_from"
+          ],
+          "properties": [
+            "resolver"
+          ],
+          "exported": true,
+          "lineCount": 125
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SelectedRoleEnforcer"
+      ],
+      "totalLines": 160,
+      "hasStructuralAnalysis": true
+    },
+    "src/Auth/OAuth/TokenStore.php": {
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "contentHash": "3481ee0e545408f0d55f76d07fd2c46c068cbe1cb6ec928d8c52798e4898c860",
+      "functions": [
+        {
+          "name": "access_table",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "refresh_table",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "issue",
+          "params": [
+            "$client_id",
+            "$user_id",
+            "$scope",
+            "$resource",
+            "$access_ttl",
+            "$refresh_ttl",
+            "$family_id",
+            "$selected_role"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 81
+        },
+        {
+          "name": "rotate",
+          "params": [
+            "$refresh_token",
+            "$client_id"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 108
+        },
+        {
+          "name": "replay_blob_key",
+          "params": [
+            "$old_refresh_plaintext"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "encrypt_replay_blob",
+          "params": [
+            "$pair",
+            "$old_refresh_plaintext"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "decrypt_replay_blob",
+          "params": [
+            "$row",
+            "$old_refresh_plaintext"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "lookup_access_token",
+          "params": [
+            "$bearer_token"
+          ],
+          "returnType": "?object",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "find_token_meta",
+          "params": [
+            "$token"
+          ],
+          "returnType": "?object",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "revoke_by_plaintext",
+          "params": [
+            "$token"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "revoke_family",
+          "params": [
+            "$family_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "touch",
+          "params": [
+            "$token_hash"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "flush_pending_touches",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "reset_pending_touches_for_tests",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStore",
+          "methods": [
+            "access_table",
+            "refresh_table",
+            "issue",
+            "rotate",
+            "replay_blob_key",
+            "encrypt_replay_blob",
+            "decrypt_replay_blob",
+            "lookup_access_token",
+            "find_token_meta",
+            "revoke_by_plaintext",
+            "revoke_family",
+            "touch",
+            "flush_pending_touches",
+            "reset_pending_touches_for_tests"
+          ],
+          "properties": [
+            "pending_touches",
+            "touch_flush_registered"
+          ],
+          "exported": true,
+          "lineCount": 533
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "TokenStore"
+      ],
+      "totalLines": 554,
+      "hasStructuralAnalysis": true
+    },
+    "src/Cli/McpCommand.php": {
+      "filePath": "src/Cli/McpCommand.php",
+      "contentHash": "ca05e6b833dffe01960f4bb27ca3338c697daf009b68d57bfc420f83b2959870",
+      "functions": [
+        {
+          "name": "serve",
+          "params": [
+            "$args",
+            "$assoc_args"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "list",
+          "params": [
+            "$args",
+            "$assoc_args"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "get_user",
+          "params": [
+            "$user"
+          ],
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpCommand",
+          "methods": [
+            "serve",
+            "list",
+            "get_user"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 165
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpAdapter",
+          "specifiers": [
+            "McpAdapter"
+          ]
+        },
+        {
+          "source": "WP_CLI\\Utils\\format_items",
+          "specifiers": [
+            "format_items"
+          ]
+        }
+      ],
+      "exports": [
+        "McpCommand"
+      ],
+      "totalLines": 190,
+      "hasStructuralAnalysis": true
+    },
+    "src/Cli/StdioServerBridge.php": {
+      "filePath": "src/Cli/StdioServerBridge.php",
+      "contentHash": "8d9c28389e528bc53915cbd5389868a12b1e675d44a72c519c2c3af0a1e7d582",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$server"
+          ],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "serve",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 71
+        },
+        {
+          "name": "stop",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "handle_request",
+          "params": [
+            "$json_input"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 95
+        },
+        {
+          "name": "request_id_state",
+          "params": [
+            "$request"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "format_response",
+          "params": [
+            "$result",
+            "$id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 39
+        },
+        {
+          "name": "create_error_response",
+          "params": [
+            "$id",
+            "$code",
+            "$message",
+            "$data"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "create_request_router",
+          "params": [],
+          "returnType": "RequestRouter",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "log_to_stderr",
+          "params": [
+            "$message"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server",
+          "params": [],
+          "returnType": "McpServer",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "StdioServerBridge",
+          "methods": [
+            "__construct",
+            "serve",
+            "stop",
+            "handle_request",
+            "request_id_state",
+            "format_response",
+            "create_error_response",
+            "create_request_router",
+            "log_to_stderr",
+            "get_server"
+          ],
+          "properties": [
+            "server",
+            "request_router",
+            "is_running"
+          ],
+          "exported": true,
+          "lineCount": 359
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactionGate",
+          "specifiers": [
+            "ResponseRedactionGate"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\RequestRouter",
+          "specifiers": [
+            "RequestRouter"
+          ]
+        }
+      ],
+      "exports": [
+        "StdioServerBridge"
+      ],
+      "totalLines": 389,
+      "hasStructuralAnalysis": true
+    },
+    "src/Core/McpAdapter.php": {
+      "filePath": "src/Core/McpAdapter.php",
+      "contentHash": "0483d60b78d1d2a43e1bb3b7a0ffeb3029ba9f139492e270eb68b5c62736b1f2",
+      "functions": [
+        {
+          "name": "instance",
+          "params": [],
+          "returnType": "self",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "init",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "create_server_from_config",
+          "params": [
+            "$config"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "create_server",
+          "params": [
+            "$server_id",
+            "$server_route_namespace",
+            "$server_route",
+            "$server_name",
+            "$server_description",
+            "$server_version",
+            "$mcp_transports",
+            "$error_handler",
+            "$observability_handler",
+            "$tools",
+            "$resources",
+            "$prompts",
+            "$transport_permission_callback"
+          ],
+          "exported": false,
+          "lineCount": 121
+        },
+        {
+          "name": "get_server",
+          "params": [
+            "$server_id"
+          ],
+          "returnType": "?McpServer",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_servers",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "maybe_create_default_server",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "register_default_category",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "register_default_abilities",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "register_wp_cli_commands",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpAdapter",
+          "methods": [
+            "instance",
+            "init",
+            "create_server_from_config",
+            "create_server",
+            "get_server",
+            "get_servers",
+            "maybe_create_default_server",
+            "register_default_category",
+            "register_default_abilities",
+            "register_wp_cli_commands"
+          ],
+          "properties": [
+            "instance",
+            "servers",
+            "initialized"
+          ],
+          "exported": true,
+          "lineCount": 332
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\BatchExecuteAbility",
+          "specifiers": [
+            "BatchExecuteAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\DiscoverAbilitiesAbility",
+          "specifiers": [
+            "DiscoverAbilitiesAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\ExecuteAbilityAbility",
+          "specifiers": [
+            "ExecuteAbilityAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\GetAbilityInfoAbility",
+          "specifiers": [
+            "GetAbilityInfoAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\GetStartedAbility",
+          "specifiers": [
+            "GetStartedAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Cli\\McpCommand",
+          "specifiers": [
+            "McpCommand"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\Contracts\\McpErrorHandlerInterface",
+          "specifiers": [
+            "McpErrorHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\NullMcpErrorHandler",
+          "specifiers": [
+            "NullMcpErrorHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\NullMcpObservabilityHandler",
+          "specifiers": [
+            "NullMcpObservabilityHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Servers\\DefaultServerFactory",
+          "specifiers": [
+            "DefaultServerFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "McpAdapter"
+      ],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "src/Core/McpComponentRegistry.php": {
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "contentHash": "bacb012da001f03067f48bd0bebdfac18a624bd34d4d24a832abd60778d039fe",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp_server",
+            "$error_handler",
+            "$observability_handler",
+            "$mcp_validation_enabled"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "register_tools",
+          "params": [
+            "$tools"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 101
+        },
+        {
+          "name": "add_tool",
+          "params": [
+            "$tool"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 62
+        },
+        {
+          "name": "register_resources",
+          "params": [
+            "$abilities"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 74
+        },
+        {
+          "name": "register_prompts",
+          "params": [
+            "$prompts"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 145
+        },
+        {
+          "name": "get_tools",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_resources",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_prompts",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_tool",
+          "params": [
+            "$tool_name"
+          ],
+          "returnType": "?McpTool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_resource",
+          "params": [
+            "$resource_uri"
+          ],
+          "returnType": "?McpResource",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_prompt",
+          "params": [
+            "$prompt_name"
+          ],
+          "returnType": "?McpPrompt",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpComponentRegistry",
+          "methods": [
+            "__construct",
+            "register_tools",
+            "add_tool",
+            "register_resources",
+            "register_prompts",
+            "get_tools",
+            "get_resources",
+            "get_prompts",
+            "get_tool",
+            "get_resource",
+            "get_prompt"
+          ],
+          "properties": [
+            "tools",
+            "resources",
+            "prompts",
+            "mcp_server",
+            "error_handler",
+            "observability_handler",
+            "mcp_validation_enabled",
+            "should_record_component_registration"
+          ],
+          "exported": true,
+          "lineCount": 555
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\Contracts\\McpPromptBuilderInterface",
+          "specifiers": [
+            "McpPromptBuilderInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\McpPrompt",
+          "specifiers": [
+            "McpPrompt"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\RegisterAbilityAsMcpPrompt",
+          "specifiers": [
+            "RegisterAbilityAsMcpPrompt"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\McpResource",
+          "specifiers": [
+            "McpResource"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\RegisterAbilityAsMcpResource",
+          "specifiers": [
+            "RegisterAbilityAsMcpResource"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\McpTool",
+          "specifiers": [
+            "McpTool"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\RegisterAbilityAsMcpTool",
+          "specifiers": [
+            "RegisterAbilityAsMcpTool"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpValidator",
+          "specifiers": [
+            "McpValidator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\Contracts\\McpErrorHandlerInterface",
+          "specifiers": [
+            "McpErrorHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "McpComponentRegistry"
+      ],
+      "totalLines": 585,
+      "hasStructuralAnalysis": true
+    },
+    "src/Core/McpServer.php": {
+      "filePath": "src/Core/McpServer.php",
+      "contentHash": "37e495e96f5ea6e4af6c3d0c864cd3dbf49bb5ddb08fed12b85f49a64d3c70f3",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$server_id",
+            "$server_route_namespace",
+            "$server_route",
+            "$server_name",
+            "$server_description",
+            "$server_version",
+            "$mcp_transports",
+            "$error_handler",
+            "$observability_handler",
+            "$tools",
+            "$resources",
+            "$prompts",
+            "$transport_permission_callback"
+          ],
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "setup_handlers",
+          "params": [
+            "$error_handler",
+            "$observability_handler"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "setup_components",
+          "params": [
+            "$tools",
+            "$resources",
+            "$prompts",
+            "$mcp_transports"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "register_mcp_components",
+          "params": [
+            "$tools",
+            "$resources",
+            "$prompts"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "get_server_id",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_route_namespace",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_route",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_description",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_version",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_transport_permission_callback",
+          "params": [],
+          "returnType": "?callable",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_observability_handler",
+          "params": [],
+          "returnType": "McpObservabilityHandlerInterface",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_error_handler",
+          "params": [],
+          "returnType": "McpErrorHandlerInterface",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_tools",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_resources",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_prompts",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_tool",
+          "params": [
+            "$tool_name"
+          ],
+          "returnType": "?McpTool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_resource",
+          "params": [
+            "$resource_uri"
+          ],
+          "returnType": "?McpResource",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_prompt",
+          "params": [
+            "$prompt_name"
+          ],
+          "returnType": "?McpPrompt",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "create_transport_context",
+          "params": [],
+          "returnType": "McpTransportContext",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_mcp_validation_enabled",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_component_registry",
+          "params": [],
+          "returnType": "McpComponentRegistry",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpServer",
+          "methods": [
+            "__construct",
+            "setup_handlers",
+            "setup_components",
+            "register_mcp_components",
+            "get_server_id",
+            "get_server_route_namespace",
+            "get_server_route",
+            "get_server_name",
+            "get_server_description",
+            "get_server_version",
+            "get_transport_permission_callback",
+            "get_observability_handler",
+            "get_error_handler",
+            "get_tools",
+            "get_resources",
+            "get_prompts",
+            "get_tool",
+            "get_resource",
+            "get_prompt",
+            "create_transport_context",
+            "is_mcp_validation_enabled",
+            "get_component_registry"
+          ],
+          "properties": [
+            "server_id",
+            "server_route_namespace",
+            "server_route",
+            "server_name",
+            "server_description",
+            "server_version",
+            "component_registry",
+            "transport_factory",
+            "error_handler",
+            "observability_handler",
+            "mcp_validation_enabled",
+            "transport_permission_callback"
+          ],
+          "exported": true,
+          "lineCount": 382
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\McpPrompt",
+          "specifiers": [
+            "McpPrompt"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\McpResource",
+          "specifiers": [
+            "McpResource"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\McpTool",
+          "specifiers": [
+            "McpTool"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\Contracts\\McpErrorHandlerInterface",
+          "specifiers": [
+            "McpErrorHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\NullMcpErrorHandler",
+          "specifiers": [
+            "NullMcpErrorHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\NullMcpObservabilityHandler",
+          "specifiers": [
+            "NullMcpObservabilityHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\McpTransportContext",
+          "specifiers": [
+            "McpTransportContext"
+          ]
+        }
+      ],
+      "exports": [
+        "McpServer"
+      ],
+      "totalLines": 410,
+      "hasStructuralAnalysis": true
+    },
+    "src/Core/McpServerConfig.php": {
+      "filePath": "src/Core/McpServerConfig.php",
+      "contentHash": "a3fa60cfe8702906186e321f56c16b4e6472d177b2dcca00b1a57a08725451c0",
+      "functions": [
+        {
+          "name": "from_array",
+          "params": [
+            "$config"
+          ],
+          "returnType": "self",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "__construct",
+          "params": [],
+          "exported": false,
+          "lineCount": 2
+        },
+        {
+          "name": "get_server_id",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_route_namespace",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_route",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_description",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_server_version",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_mcp_transports",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_error_handler",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_observability_handler",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_tools",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_resources",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_prompts",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_transport_permission_callback",
+          "params": [],
+          "returnType": "?callable",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpServerConfig",
+          "methods": [
+            "from_array",
+            "__construct",
+            "get_server_id",
+            "get_server_route_namespace",
+            "get_server_route",
+            "get_server_name",
+            "get_server_description",
+            "get_server_version",
+            "get_mcp_transports",
+            "get_error_handler",
+            "get_observability_handler",
+            "get_tools",
+            "get_resources",
+            "get_prompts",
+            "get_transport_permission_callback"
+          ],
+          "properties": [
+            "server_id",
+            "server_route_namespace",
+            "server_route",
+            "server_name",
+            "server_description",
+            "server_version",
+            "mcp_transports",
+            "error_handler",
+            "observability_handler",
+            "tools",
+            "resources",
+            "prompts",
+            "transport_permission_callback"
+          ],
+          "exported": true,
+          "lineCount": 191
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\Contracts\\McpErrorHandlerInterface",
+          "specifiers": [
+            "McpErrorHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\NullMcpErrorHandler",
+          "specifiers": [
+            "NullMcpErrorHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\NullMcpObservabilityHandler",
+          "specifiers": [
+            "NullMcpObservabilityHandler"
+          ]
+        }
+      ],
+      "exports": [
+        "McpServerConfig"
+      ],
+      "totalLines": 217,
+      "hasStructuralAnalysis": true
+    },
+    "src/Core/McpTransportFactory.php": {
+      "filePath": "src/Core/McpTransportFactory.php",
+      "contentHash": "75a43d55347d964465dfbea89da688e8d9bc68f1c0da7c2061f70e6b38899af1",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "initialize_transports",
+          "params": [
+            "$mcp_transports"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 45
+        },
+        {
+          "name": "create_transport_context",
+          "params": [],
+          "returnType": "McpTransportContext",
+          "exported": false,
+          "lineCount": 23
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpTransportFactory",
+          "methods": [
+            "__construct",
+            "initialize_transports",
+            "create_transport_context"
+          ],
+          "properties": [
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 97
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Initialize\\InitializeHandler",
+          "specifiers": [
+            "InitializeHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Prompts\\PromptsHandler",
+          "specifiers": [
+            "PromptsHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Resources\\ResourcesHandler",
+          "specifiers": [
+            "ResourcesHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\System\\SystemHandler",
+          "specifiers": [
+            "SystemHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Tools\\ToolsHandler",
+          "specifiers": [
+            "ToolsHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Contracts\\McpTransportInterface",
+          "specifiers": [
+            "McpTransportInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\McpTransportContext",
+          "specifiers": [
+            "McpTransportContext"
+          ]
+        }
+      ],
+      "exports": [
+        "McpTransportFactory"
+      ],
+      "totalLines": 124,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php": {
+      "filePath": "src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "contentHash": "8508972d3d20047531ab685d26775d0c04358da4d4edf29c6d6a237371f6c1ab",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpPromptBuilderInterface",
+          "methods": [
+            "build",
+            "get_name",
+            "get_title",
+            "get_description",
+            "get_arguments",
+            "handle",
+            "has_permission"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 55
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\McpPrompt",
+          "specifiers": [
+            "McpPrompt"
+          ]
+        }
+      ],
+      "exports": [
+        "McpPromptBuilderInterface"
+      ],
+      "totalLines": 79,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Prompts/McpPrompt.php": {
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "contentHash": "4a88226d1da2b649854322c9b60492d50f4a4822ceddd4813bb00aa5b0955d26",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$name",
+            "$title",
+            "$description",
+            "$arguments",
+            "$annotations"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "get_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_title",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_description",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_arguments",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_annotations",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_ability",
+          "params": [],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "set_title",
+          "params": [
+            "$title"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_description",
+          "params": [
+            "$description"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_arguments",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_annotations",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "add_argument",
+          "params": [
+            "$argument"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "remove_argument",
+          "params": [
+            "$name"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "get_argument",
+          "params": [
+            "$name"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "has_argument",
+          "params": [
+            "$name"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "add_annotation",
+          "params": [
+            "$key",
+            "$value"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "remove_annotation",
+          "params": [
+            "$key"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "to_array",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "to_json",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "from_array",
+          "params": [
+            "$data",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "validate",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "create_argument",
+          "params": [
+            "$name",
+            "$description",
+            "$required"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "get_mcp_server",
+          "params": [],
+          "returnType": "McpServer",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "set_mcp_server",
+          "params": [
+            "$mcp_server"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_builder_based",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "execute_direct",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "check_permission_direct",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpPrompt",
+          "methods": [
+            "__construct",
+            "get_name",
+            "get_title",
+            "get_description",
+            "get_arguments",
+            "get_annotations",
+            "get_ability",
+            "set_title",
+            "set_description",
+            "set_arguments",
+            "set_annotations",
+            "add_argument",
+            "remove_argument",
+            "get_argument",
+            "has_argument",
+            "add_annotation",
+            "remove_annotation",
+            "to_array",
+            "to_json",
+            "from_array",
+            "validate",
+            "create_argument",
+            "get_mcp_server",
+            "set_mcp_server",
+            "is_builder_based",
+            "execute_direct",
+            "check_permission_direct"
+          ],
+          "properties": [
+            "ability",
+            "name",
+            "title",
+            "description",
+            "arguments",
+            "annotations",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 440
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        }
+      ],
+      "exports": [
+        "McpPrompt"
+      ],
+      "totalLines": 466,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Prompts/McpPromptBuilder.php": {
+      "filePath": "src/Domain/Prompts/McpPromptBuilder.php",
+      "contentHash": "70d3d2ddd168dad422f08cb7ab0e4f821429a1a408c9fe778f0338d83a4c38bf",
+      "functions": [
+        {
+          "name": "build",
+          "params": [],
+          "returnType": "McpPrompt",
+          "exported": false,
+          "lineCount": 64
+        },
+        {
+          "name": "get_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "get_title",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "get_description",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "get_arguments",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "get_annotations",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "configure",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "handle",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "has_permission",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "create_argument",
+          "params": [
+            "$name",
+            "$description",
+            "$required"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "add_argument",
+          "params": [
+            "$name",
+            "$description",
+            "$required"
+          ],
+          "returnType": "self",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpPromptBuilder",
+          "methods": [
+            "build",
+            "get_name",
+            "get_title",
+            "get_description",
+            "get_arguments",
+            "get_annotations",
+            "configure",
+            "handle",
+            "has_permission",
+            "create_argument",
+            "add_argument"
+          ],
+          "properties": [
+            "name",
+            "title",
+            "description",
+            "arguments",
+            "annotations"
+          ],
+          "exported": true,
+          "lineCount": 250
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\Contracts\\McpPromptBuilderInterface",
+          "specifiers": [
+            "McpPromptBuilderInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "McpPromptBuilder"
+      ],
+      "totalLines": 274,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Prompts/McpPromptValidator.php": {
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "contentHash": "45175c1eeab704040571fb2c20dd9ba95b4e7d690c9de328702a32e5ca01b128",
+      "functions": [
+        {
+          "name": "validate_prompt_data",
+          "params": [
+            "$prompt_data",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "validate_prompt_instance",
+          "params": [
+            "$prompt",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "validate_prompt_uniqueness",
+          "params": [
+            "$prompt",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "get_validation_errors",
+          "params": [
+            "$prompt_data"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 50
+        },
+        {
+          "name": "get_arguments_validation_errors",
+          "params": [
+            "$arguments"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 61
+        },
+        {
+          "name": "validate_prompt_messages",
+          "params": [
+            "$messages"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "get_content_validation_errors",
+          "params": [
+            "$content",
+            "$message_index"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 136
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpPromptValidator",
+          "methods": [
+            "validate_prompt_data",
+            "validate_prompt_instance",
+            "validate_prompt_uniqueness",
+            "get_validation_errors",
+            "get_arguments_validation_errors",
+            "validate_prompt_messages",
+            "get_content_validation_errors"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 401
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\McpResourceValidator",
+          "specifiers": [
+            "McpResourceValidator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpValidator",
+          "specifiers": [
+            "McpValidator"
+          ]
+        }
+      ],
+      "exports": [
+        "McpPromptValidator"
+      ],
+      "totalLines": 428,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php": {
+      "filePath": "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "contentHash": "e4b68a2c8a1165b8a3944fa241afe5ccc7326dfec94ae8b98132898e3313fcf2",
+      "functions": [
+        {
+          "name": "make",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "get_data",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "convert_input_schema_to_arguments",
+          "params": [
+            "$input_schema"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "get_prompt",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "RegisterAbilityAsMcpPrompt",
+          "methods": [
+            "make",
+            "__construct",
+            "get_data",
+            "convert_input_schema_to_arguments",
+            "get_prompt"
+          ],
+          "properties": [
+            "ability",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 148
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpAnnotationMapper",
+          "specifiers": [
+            "McpAnnotationMapper"
+          ]
+        },
+        {
+          "source": "WP_Ability",
+          "specifiers": [
+            "WP_Ability"
+          ]
+        }
+      ],
+      "exports": [
+        "RegisterAbilityAsMcpPrompt"
+      ],
+      "totalLines": 195,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Resources/McpResource.php": {
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "contentHash": "08f702ad4644c9ab15faf887f0f6aefe7aa37554df999d4e1eaf8bbfb165a81f",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$uri",
+            "$name",
+            "$description",
+            "$mime_type",
+            "$text",
+            "$blob",
+            "$annotations"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "get_uri",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_name",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_description",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_mime_type",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_text",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_blob",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_annotations",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_ability",
+          "params": [],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "set_name",
+          "params": [
+            "$name"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_description",
+          "params": [
+            "$description"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_mime_type",
+          "params": [
+            "$mime_type"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_text",
+          "params": [
+            "$text"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "set_blob",
+          "params": [
+            "$blob"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "set_annotations",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "add_annotation",
+          "params": [
+            "$key",
+            "$value"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "remove_annotation",
+          "params": [
+            "$key"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_mcp_server",
+          "params": [],
+          "returnType": "McpServer",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "set_mcp_server",
+          "params": [
+            "$mcp_server"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "to_array",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "to_json",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "from_array",
+          "params": [
+            "$data",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "is_text_resource",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_blob_resource",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 21
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpResource",
+          "methods": [
+            "__construct",
+            "get_uri",
+            "get_name",
+            "get_description",
+            "get_mime_type",
+            "get_text",
+            "get_blob",
+            "get_annotations",
+            "get_ability",
+            "set_name",
+            "set_description",
+            "set_mime_type",
+            "set_text",
+            "set_blob",
+            "set_annotations",
+            "add_annotation",
+            "remove_annotation",
+            "get_mcp_server",
+            "set_mcp_server",
+            "to_array",
+            "to_json",
+            "from_array",
+            "is_text_resource",
+            "is_blob_resource",
+            "validate"
+          ],
+          "properties": [
+            "ability",
+            "uri",
+            "name",
+            "description",
+            "mime_type",
+            "text",
+            "blob",
+            "annotations",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 425
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        }
+      ],
+      "exports": [
+        "McpResource"
+      ],
+      "totalLines": 452,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Resources/McpResourceValidator.php": {
+      "filePath": "src/Domain/Resources/McpResourceValidator.php",
+      "contentHash": "2f3cbf2e4624ee28625abff6d447678917936134e32541cabf8b07585f466da6",
+      "functions": [
+        {
+          "name": "validate_resource_data",
+          "params": [
+            "$resource_data",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "validate_resource_instance",
+          "params": [
+            "$the_resource",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "get_validation_errors",
+          "params": [
+            "$resource_data"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 75
+        },
+        {
+          "name": "validate_resource_uniqueness",
+          "params": [
+            "$the_resource",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpResourceValidator",
+          "methods": [
+            "validate_resource_data",
+            "validate_resource_instance",
+            "get_validation_errors",
+            "validate_resource_uniqueness"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 151
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpValidator",
+          "specifiers": [
+            "McpValidator"
+          ]
+        }
+      ],
+      "exports": [
+        "McpResourceValidator"
+      ],
+      "totalLines": 177,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Resources/RegisterAbilityAsMcpResource.php": {
+      "filePath": "src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "contentHash": "ec6640f648c65fdf1c0eb582358c5bd2af07c421717c283948f5adc0c52a1655",
+      "functions": [
+        {
+          "name": "make",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "get_uri",
+          "params": [],
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "get_data",
+          "params": [],
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "get_ability_content",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "get_resource",
+          "params": [],
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "RegisterAbilityAsMcpResource",
+          "methods": [
+            "make",
+            "__construct",
+            "get_uri",
+            "get_data",
+            "get_ability_content",
+            "get_resource"
+          ],
+          "properties": [
+            "ability",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 155
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpAnnotationMapper",
+          "specifiers": [
+            "McpAnnotationMapper"
+          ]
+        },
+        {
+          "source": "WP_Ability",
+          "specifiers": [
+            "WP_Ability"
+          ]
+        }
+      ],
+      "exports": [
+        "RegisterAbilityAsMcpResource"
+      ],
+      "totalLines": 188,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Tools/McpTool.php": {
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "contentHash": "2ce5048ad1358cfcb711dd00923db10984dd5ecd27df35ff4655c79ebfa83d06",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$name",
+            "$description",
+            "$input_schema",
+            "$title",
+            "$output_schema",
+            "$annotations",
+            "$metadata"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "get_ability",
+          "params": [],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "get_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_title",
+          "params": [],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_description",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_input_schema",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_output_schema",
+          "params": [],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_annotations",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_metadata",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_title",
+          "params": [
+            "$title"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_description",
+          "params": [
+            "$description"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_input_schema",
+          "params": [
+            "$input_schema"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_output_schema",
+          "params": [
+            "$output_schema"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_annotations",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_metadata",
+          "params": [
+            "$metadata"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "add_annotation",
+          "params": [
+            "$key",
+            "$value"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "remove_annotation",
+          "params": [
+            "$key"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_mcp_server",
+          "params": [],
+          "returnType": "McpServer",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "set_mcp_server",
+          "params": [
+            "$mcp_server"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "to_array",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "from_array",
+          "params": [
+            "$data",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "validate",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 21
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpTool",
+          "methods": [
+            "__construct",
+            "get_ability",
+            "get_name",
+            "get_title",
+            "get_description",
+            "get_input_schema",
+            "get_output_schema",
+            "get_annotations",
+            "get_metadata",
+            "set_title",
+            "set_description",
+            "set_input_schema",
+            "set_output_schema",
+            "set_annotations",
+            "set_metadata",
+            "add_annotation",
+            "remove_annotation",
+            "get_mcp_server",
+            "set_mcp_server",
+            "to_array",
+            "from_array",
+            "validate"
+          ],
+          "properties": [
+            "ability",
+            "name",
+            "title",
+            "description",
+            "input_schema",
+            "output_schema",
+            "annotations",
+            "metadata",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 378
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        }
+      ],
+      "exports": [
+        "McpTool"
+      ],
+      "totalLines": 405,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Tools/McpToolValidator.php": {
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "contentHash": "85137663312b48754090c73a72945ccc0bfa89d38f4d6495feadd0ade1423dbe",
+      "functions": [
+        {
+          "name": "validate_tool_data",
+          "params": [
+            "$tool_data",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "validate_tool_instance",
+          "params": [
+            "$tool",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "get_validation_errors",
+          "params": [
+            "$tool_data"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 63
+        },
+        {
+          "name": "get_schema_validation_errors",
+          "params": [
+            "$schema",
+            "$field_name"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 115
+        },
+        {
+          "name": "validate_tool_uniqueness",
+          "params": [
+            "$tool",
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 19
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpToolValidator",
+          "methods": [
+            "validate_tool_data",
+            "validate_tool_instance",
+            "get_validation_errors",
+            "get_schema_validation_errors",
+            "validate_tool_uniqueness"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 267
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpValidator",
+          "specifiers": [
+            "McpValidator"
+          ]
+        },
+        {
+          "source": "stdClass",
+          "specifiers": [
+            "stdClass"
+          ]
+        }
+      ],
+      "exports": [
+        "McpToolValidator"
+      ],
+      "totalLines": 294,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Tools/RegisterAbilityAsMcpTool.php": {
+      "filePath": "src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "contentHash": "8ca8bd6ed07adfd05370e4895fcb614e0987d0f3b10b9b3f8b4d36559a0a1c73",
+      "functions": [
+        {
+          "name": "make",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "__construct",
+          "params": [
+            "$ability",
+            "$mcp_server"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "get_data",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 59
+        },
+        {
+          "name": "get_tool",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "RegisterAbilityAsMcpTool",
+          "methods": [
+            "make",
+            "__construct",
+            "get_data",
+            "get_tool"
+          ],
+          "properties": [
+            "ability",
+            "mcp_server"
+          ],
+          "exported": true,
+          "lineCount": 114
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpAnnotationMapper",
+          "specifiers": [
+            "McpAnnotationMapper"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\SchemaTransformer",
+          "specifiers": [
+            "SchemaTransformer"
+          ]
+        },
+        {
+          "source": "WP_Ability",
+          "specifiers": [
+            "WP_Ability"
+          ]
+        }
+      ],
+      "exports": [
+        "RegisterAbilityAsMcpTool"
+      ],
+      "totalLines": 142,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Utils/McpAnnotationMapper.php": {
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "contentHash": "4f5f306549b107ea3a22a648c4c1862fb8b0ad087890691940c70e5095f15ed0",
+      "functions": [
+        {
+          "name": "build_from_ability",
+          "params": [
+            "$ability",
+            "$feature_type"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "map",
+          "params": [
+            "$ability_annotations",
+            "$feature_type"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "resolve_annotation_value",
+          "params": [
+            "$annotations",
+            "$mcp_field",
+            "$ability_property"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "normalize_annotation_value",
+          "params": [
+            "$field_type",
+            "$value"
+          ],
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpAnnotationMapper",
+          "methods": [
+            "build_from_ability",
+            "map",
+            "resolve_annotation_value",
+            "normalize_annotation_value"
+          ],
+          "properties": [
+            "mcp_annotations"
+          ],
+          "exported": true,
+          "lineCount": 223
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        }
+      ],
+      "exports": [
+        "McpAnnotationMapper"
+      ],
+      "totalLines": 248,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Utils/McpValidator.php": {
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "contentHash": "0e8fb3618d565a6c6a0fcf23494e1c7a088348971bcea85756123631b9ebe20a",
+      "functions": [
+        {
+          "name": "validate_iso8601_timestamp",
+          "params": [
+            "$timestamp"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "validate_name",
+          "params": [
+            "$name",
+            "$max_length"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "validate_tool_or_prompt_name",
+          "params": [
+            "$name"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_ability_name",
+          "params": [
+            "$name"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "validate_argument_name",
+          "params": [
+            "$name"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_mime_type",
+          "params": [
+            "$mime_type"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_image_mime_type",
+          "params": [
+            "$mime_type"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_audio_mime_type",
+          "params": [
+            "$mime_type"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_base64",
+          "params": [
+            "$content"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "validate_resource_uri",
+          "params": [
+            "$uri"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "validate_role",
+          "params": [
+            "$role"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "validate_roles_array",
+          "params": [
+            "$roles"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "validate_priority",
+          "params": [
+            "$priority"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "get_tool_annotation_validation_errors",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 44
+        },
+        {
+          "name": "get_annotation_validation_errors",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 47
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpValidator",
+          "methods": [
+            "validate_iso8601_timestamp",
+            "validate_name",
+            "validate_tool_or_prompt_name",
+            "validate_ability_name",
+            "validate_argument_name",
+            "validate_mime_type",
+            "validate_image_mime_type",
+            "validate_audio_mime_type",
+            "validate_base64",
+            "validate_resource_uri",
+            "validate_role",
+            "validate_roles_array",
+            "validate_priority",
+            "get_tool_annotation_validation_errors",
+            "get_annotation_validation_errors"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 371
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpValidator"
+      ],
+      "totalLines": 393,
+      "hasStructuralAnalysis": true
+    },
+    "src/Domain/Utils/SchemaTransformer.php": {
+      "filePath": "src/Domain/Utils/SchemaTransformer.php",
+      "contentHash": "8d365d34a0db7df6a4003f30dc93d74a519d5c2ec0da642e3dc9647526724a43",
+      "functions": [
+        {
+          "name": "transform_to_object_schema",
+          "params": [
+            "$schema",
+            "$wrapper_key"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 38
+        },
+        {
+          "name": "wrap_in_object",
+          "params": [
+            "$schema",
+            "$wrapper_key"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "SchemaTransformer",
+          "methods": [
+            "transform_to_object_schema",
+            "wrap_in_object"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 73
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SchemaTransformer"
+      ],
+      "totalLines": 97,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/HandlerHelperTrait.php": {
+      "filePath": "src/Handlers/HandlerHelperTrait.php",
+      "contentHash": "5443ba21769f1e83c4bb2abd1836997d985577b0e28b2c7c665157c623af982f",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 121,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/Initialize/InitializeHandler.php": {
+      "filePath": "src/Handlers/Initialize/InitializeHandler.php",
+      "contentHash": "bf757d67f344e7026bfaf74e4f028ef56b43f2864858fe00905bf335b93c9438",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "handle",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 30
+        }
+      ],
+      "classes": [
+        {
+          "name": "InitializeHandler",
+          "methods": [
+            "__construct",
+            "handle"
+          ],
+          "properties": [
+            "mcp"
+          ],
+          "exported": true,
+          "lineCount": 67
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "stdClass",
+          "specifiers": [
+            "stdClass"
+          ]
+        }
+      ],
+      "exports": [
+        "InitializeHandler"
+      ],
+      "totalLines": 89,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/Prompts/PromptsHandler.php": {
+      "filePath": "src/Handlers/Prompts/PromptsHandler.php",
+      "contentHash": "808ab2df3fdf73dd4a033f5765c76f1d03b9fcc13f4e7fe15c64105d3162dc45",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "list_prompts",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "get_prompt",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 224
+        }
+      ],
+      "classes": [
+        {
+          "name": "PromptsHandler",
+          "methods": [
+            "__construct",
+            "list_prompts",
+            "get_prompt"
+          ],
+          "properties": [
+            "mcp"
+          ],
+          "exported": true,
+          "lineCount": 276
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\HandlerHelperTrait",
+          "specifiers": [
+            "HandlerHelperTrait"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "PromptsHandler"
+      ],
+      "totalLines": 300,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/Resources/ResourcesHandler.php": {
+      "filePath": "src/Handlers/Resources/ResourcesHandler.php",
+      "contentHash": "e17345ea91ebf5ab01b6292c8994611be9152de1742ae8c87f2fdd4918cc66bf",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "list_resources",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "read_resource",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 166
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResourcesHandler",
+          "methods": [
+            "__construct",
+            "list_resources",
+            "read_resource"
+          ],
+          "properties": [
+            "mcp"
+          ],
+          "exported": true,
+          "lineCount": 222
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\HandlerHelperTrait",
+          "specifiers": [
+            "HandlerHelperTrait"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "ResourcesHandler"
+      ],
+      "totalLines": 246,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/System/SystemHandler.php": {
+      "filePath": "src/Handlers/System/SystemHandler.php",
+      "contentHash": "aec6c4b2ba7b9eec1949ec6acf0469bfe3caac70dad9fdb4c833ae1848fc744a",
+      "functions": [
+        {
+          "name": "ping",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "set_logging_level",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "complete",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "list_roots",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "method_not_found",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "SystemHandler",
+          "methods": [
+            "ping",
+            "set_logging_level",
+            "complete",
+            "list_roots",
+            "method_not_found"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 74
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "SystemHandler"
+      ],
+      "totalLines": 95,
+      "hasStructuralAnalysis": true
+    },
+    "src/Handlers/Tools/ToolsHandler.php": {
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "contentHash": "9d4b9d7b1a189ad20a463c38e08e4695d03957f819648b22939b08c2b49342d3",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$mcp"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "list_tools",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "list_all_tools",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "call_tool",
+          "params": [
+            "$message",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 122
+        },
+        {
+          "name": "sanitize_tool_data",
+          "params": [
+            "$tool"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "handle_tool_call",
+          "params": [
+            "$params",
+            "$request_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 272
+        }
+      ],
+      "classes": [
+        {
+          "name": "ToolsHandler",
+          "methods": [
+            "__construct",
+            "list_tools",
+            "list_all_tools",
+            "call_tool",
+            "sanitize_tool_data",
+            "handle_tool_call"
+          ],
+          "properties": [
+            "mcp"
+          ],
+          "exported": true,
+          "lineCount": 520
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\McpTool",
+          "specifiers": [
+            "McpTool"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\HandlerHelperTrait",
+          "specifiers": [
+            "HandlerHelperTrait"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorMapper",
+          "specifiers": [
+            "McpErrorMapper"
+          ]
+        }
+      ],
+      "exports": [
+        "ToolsHandler"
+      ],
+      "totalLines": 547,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php": {
+      "filePath": "src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "contentHash": "9f25c76e0e66f070357d6b33919b04e54e7a259e38320924d3c3eab24491a5e4",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpErrorHandlerInterface",
+          "methods": [
+            "log"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 13
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpErrorHandlerInterface"
+      ],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php": {
+      "filePath": "src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "contentHash": "e8a51eea91e8304877e85f64579a525551fe6d1974ea39aa5955e6b85bec5c1e",
+      "functions": [
+        {
+          "name": "log",
+          "params": [
+            "$message",
+            "$context",
+            "$type"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "ErrorLogMcpErrorHandler",
+          "methods": [
+            "log"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 23
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ErrorLogMcpErrorHandler"
+      ],
+      "totalLines": 46,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/ErrorHandling/McpErrorFactory.php": {
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "contentHash": "45b49d0afd66547a52f6516353168deaa0d7e8301f85d5e0fb2d5ccc75ad3985",
+      "functions": [
+        {
+          "name": "create_error_response",
+          "params": [
+            "$id",
+            "$code",
+            "$message",
+            "$data"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "parse_error",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "invalid_request",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "method_not_found",
+          "params": [
+            "$id",
+            "$method"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "invalid_params",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "internal_error",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "mcp_disabled",
+          "params": [
+            "$id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "validation_error",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "missing_parameter",
+          "params": [
+            "$id",
+            "$parameter"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "resource_not_found",
+          "params": [
+            "$id",
+            "$resource_uri"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "tool_not_found",
+          "params": [
+            "$id",
+            "$tool"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "ability_not_found",
+          "params": [
+            "$id",
+            "$ability"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "prompt_not_found",
+          "params": [
+            "$id",
+            "$prompt"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "permission_denied",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "unauthorized",
+          "params": [
+            "$id",
+            "$details"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "rate_limited",
+          "params": [
+            "$id",
+            "$retry_after_ms",
+            "$limit",
+            "$window",
+            "$dimension"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "mcp_error_to_http_status",
+          "params": [
+            "$mcp_error_code"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 41
+        },
+        {
+          "name": "get_http_status_for_error",
+          "params": [
+            "$error_response"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "validate_jsonrpc_message",
+          "params": [
+            "$message"
+          ],
+          "exported": false,
+          "lineCount": 25
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpErrorFactory",
+          "methods": [
+            "create_error_response",
+            "parse_error",
+            "invalid_request",
+            "method_not_found",
+            "invalid_params",
+            "internal_error",
+            "mcp_disabled",
+            "validation_error",
+            "missing_parameter",
+            "resource_not_found",
+            "tool_not_found",
+            "ability_not_found",
+            "prompt_not_found",
+            "permission_denied",
+            "unauthorized",
+            "rate_limited",
+            "mcp_error_to_http_status",
+            "get_http_status_for_error",
+            "validate_jsonrpc_message"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 438
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpErrorFactory"
+      ],
+      "totalLines": 460,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/ErrorHandling/McpErrorMapper.php": {
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "contentHash": "69da86e31bed0bdec061c071bfe0154a692e22e288bc036579e5da57c7118a97",
+      "functions": [
+        {
+          "name": "map_code",
+          "params": [
+            "$wp_error_code",
+            "$default_code"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "from_wp_error",
+          "params": [
+            "$request_id",
+            "$wp_error",
+            "$default_code"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpErrorMapper",
+          "methods": [
+            "map_code",
+            "from_wp_error"
+          ],
+          "properties": [
+            "error_code_map"
+          ],
+          "exported": true,
+          "lineCount": 56
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpErrorMapper"
+      ],
+      "totalLines": 78,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php": {
+      "filePath": "src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "contentHash": "debae2417442c962090add0b288142e468dbd229502e27bc5d2fd16f75ad4543",
+      "functions": [
+        {
+          "name": "log",
+          "params": [
+            "$message",
+            "$context",
+            "$type"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "NullMcpErrorHandler",
+          "methods": [
+            "log"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "NullMcpErrorHandler"
+      ],
+      "totalLines": 40,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/BoundaryEventEmitter.php": {
+      "filePath": "src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "contentHash": "4e9faf3d15fb751ccc9762ebf11a02d4b7d93c8087b18e76adbd1f936573c0ad",
+      "functions": [
+        {
+          "name": "emit",
+          "params": [
+            "$handler",
+            "$event",
+            "$tags",
+            "$duration_ms"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "sanitize",
+          "params": [
+            "$tags"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 43
+        },
+        {
+          "name": "hash_api_key",
+          "params": [
+            "$key"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "BoundaryEventEmitter",
+          "methods": [
+            "emit",
+            "sanitize",
+            "hash_api_key"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 142
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "BoundaryEventEmitter"
+      ],
+      "totalLines": 172,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/ConsoleObservabilityHandler.php": {
+      "filePath": "src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "contentHash": "b867a2bca0b231cf54eb0b51c7faaf57cb5c0131b56e11548a7c79967983a749",
+      "functions": [
+        {
+          "name": "record_event",
+          "params": [
+            "$event",
+            "$tags",
+            "$duration_ms"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsoleObservabilityHandler",
+          "methods": [
+            "record_event"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 36
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "ConsoleObservabilityHandler"
+      ],
+      "totalLines": 61,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php": {
+      "filePath": "src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "contentHash": "1eb4d115bf58d86cee438a8966ac6ef0aa6f3469cd518a54b256bfbc69b95b7c",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpObservabilityHandlerInterface",
+          "methods": [
+            "record_event"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 13
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "McpObservabilityHandlerInterface"
+      ],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php": {
+      "filePath": "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "contentHash": "9130836e7909dd91b638a2cccf9c1255f2afc84a0480d951e6fb618346bc1ec3",
+      "functions": [
+        {
+          "name": "record_event",
+          "params": [
+            "$event",
+            "$tags",
+            "$duration_ms"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "format_tags",
+          "params": [
+            "$tags"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "ErrorLogMcpObservabilityHandler",
+          "methods": [
+            "record_event",
+            "format_tags"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 60
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ErrorLogMcpObservabilityHandler"
+      ],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/McpObservabilityHelperTrait.php": {
+      "filePath": "src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "contentHash": "1f1b0955e0ab038aba25c32a8f20101a9d314cae360513458f1f64be4c22260a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 133,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Observability/NullMcpObservabilityHandler.php": {
+      "filePath": "src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "contentHash": "e7b5bc76463a81e17bcb13f69ad859715620a2aeb1c1659f2ed1529e0f675130",
+      "functions": [
+        {
+          "name": "record_event",
+          "params": [
+            "$event",
+            "$tags",
+            "$duration_ms"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "NullMcpObservabilityHandler",
+          "methods": [
+            "record_event"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "NullMcpObservabilityHandler"
+      ],
+      "totalLines": 41,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Redaction/PatternMatchers.php": {
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "contentHash": "b9e2adbe3529d0c4938db9aa57f0bc06e4f9558f20f7dbe78d1ab8b94dccd223",
+      "functions": [
+        {
+          "name": "is_password_hash",
+          "params": [
+            "$value"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "is_known_api_key",
+          "params": [
+            "$value"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "passes_luhn",
+          "params": [
+            "$value"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "PatternMatchers",
+          "methods": [
+            "is_password_hash",
+            "is_known_api_key",
+            "passes_luhn"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 124
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PatternMatchers"
+      ],
+      "totalLines": 148,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Redaction/RedactionConfig.php": {
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "contentHash": "bd3e82f75e1139634cee4d4f161d67eb4c00e9286a8953eb07fa08feee838ed1",
+      "functions": [
+        {
+          "name": "bucket1_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "bucket2_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "bucket3_default_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "is_master_enabled",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "bucket3_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "is_ability_exempt",
+          "params": [
+            "$ability_name",
+            "$bucket"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "normalize_keywords",
+          "params": [
+            "$keywords"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 14
+        }
+      ],
+      "classes": [
+        {
+          "name": "RedactionConfig",
+          "methods": [
+            "bucket1_keywords",
+            "bucket2_keywords",
+            "bucket3_default_keywords",
+            "is_master_enabled",
+            "bucket3_keywords",
+            "is_ability_exempt",
+            "normalize_keywords"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 119
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "RedactionConfig"
+      ],
+      "totalLines": 150,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Redaction/RedactionLimitExceeded.php": {
+      "filePath": "src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "contentHash": "bee1798debf43ba333d4ee1e2c35a17b6eca09389c1dfff9deeb2561accedfb8",
+      "functions": [],
+      "classes": [
+        {
+          "name": "RedactionLimitExceeded",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 1
+        }
+      ],
+      "imports": [
+        {
+          "source": "RuntimeException",
+          "specifiers": [
+            "RuntimeException"
+          ]
+        }
+      ],
+      "exports": [
+        "RedactionLimitExceeded"
+      ],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Redaction/ResponseRedactionGate.php": {
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "contentHash": "41395b381c1db6fec92d2fe4b2302e922d8909575c2f812330d5b79ff2553570",
+      "functions": [
+        {
+          "name": "apply",
+          "params": [
+            "$result",
+            "$method",
+            "$params",
+            "$request_id",
+            "$observability"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 64
+        },
+        {
+          "name": "reconcile_tool_channels",
+          "params": [
+            "$redacted",
+            "$redactor"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 60
+        },
+        {
+          "name": "extract_ability_name",
+          "params": [
+            "$method",
+            "$params"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "tool_name_to_ability_name",
+          "params": [
+            "$tool_name"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "dash_to_slash_map",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 37
+        },
+        {
+          "name": "reset_name_cache_for_testing",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "emit_redaction_event",
+          "params": [
+            "$handler",
+            "$method",
+            "$ability_name",
+            "$counts"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "emit_redaction_failure",
+          "params": [
+            "$handler",
+            "$method",
+            "$ability_name",
+            "$reason"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResponseRedactionGate",
+          "methods": [
+            "apply",
+            "reconcile_tool_channels",
+            "extract_ability_name",
+            "tool_name_to_ability_name",
+            "dash_to_slash_map",
+            "reset_name_cache_for_testing",
+            "emit_redaction_event",
+            "emit_redaction_failure"
+          ],
+          "properties": [
+            "dash_to_slash_cache"
+          ],
+          "exported": true,
+          "lineCount": 365
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "ResponseRedactionGate"
+      ],
+      "totalLines": 398,
+      "hasStructuralAnalysis": true
+    },
+    "src/Infrastructure/Redaction/ResponseRedactor.php": {
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "contentHash": "e7dcc156692ef66b3f40b6e2cf109ec87844d3efa5931f98543b02591fa3f572",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$ability_name",
+            "$method"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "redact",
+          "params": [
+            "$response"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "get_counts",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "walk_array",
+          "params": [
+            "$arr",
+            "$depth",
+            "$key"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "process_named_field",
+          "params": [
+            "$key",
+            "$value",
+            "$depth"
+          ],
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "is_schema_metadata_key",
+          "params": [
+            "$lower_key"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "is_email_family_token",
+          "params": [
+            "$key"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "count_subtree_safe",
+          "params": [
+            "$value",
+            "$depth"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "process_value",
+          "params": [
+            "$value",
+            "$depth",
+            "$key"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "maybe_redact_scalar_string",
+          "params": [
+            "$value",
+            "$key"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "build_marker",
+          "params": [
+            "$value",
+            "$field_name",
+            "$bucket"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "default_marker",
+          "params": [
+            "$value",
+            "$bucket"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "flip_lower",
+          "params": [
+            "$keywords"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResponseRedactor",
+          "methods": [
+            "__construct",
+            "redact",
+            "get_counts",
+            "walk_array",
+            "process_named_field",
+            "is_schema_metadata_key",
+            "is_email_family_token",
+            "count_subtree_safe",
+            "process_value",
+            "maybe_redact_scalar_string",
+            "build_marker",
+            "default_marker",
+            "flip_lower"
+          ],
+          "properties": [
+            "bucket1_set",
+            "bucket2_set",
+            "bucket3_set",
+            "bucket2_active",
+            "bucket3_active",
+            "counts",
+            "node_count",
+            "schema_metadata_exempt"
+          ],
+          "exported": true,
+          "lineCount": 473
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ResponseRedactor"
+      ],
+      "totalLines": 532,
+      "hasStructuralAnalysis": true
+    },
+    "src/Plugin.php": {
+      "filePath": "src/Plugin.php",
+      "contentHash": "cbda72efeeb771fb5ef31a45b0291bd5b8d02ba38d1ea51aab44ea1f55b1ac43",
+      "functions": [
+        {
+          "name": "instance",
+          "params": [],
+          "returnType": "self",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "setup",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "has_dependencies",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "__clone",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "__wakeup",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "Plugin",
+          "methods": [
+            "instance",
+            "setup",
+            "has_dependencies",
+            "__clone",
+            "__wakeup"
+          ],
+          "properties": [
+            "instance"
+          ],
+          "exported": true,
+          "lineCount": 109
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\Settings\\SettingsAbilities",
+          "specifiers": [
+            "SettingsAbilities"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AbilitySettingsPage",
+          "specifiers": [
+            "AbilitySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\SafetySettingsPage",
+          "specifiers": [
+            "SafetySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpAdapter",
+          "specifiers": [
+            "McpAdapter"
+          ]
+        }
+      ],
+      "exports": [
+        "Plugin"
+      ],
+      "totalLines": 135,
+      "hasStructuralAnalysis": true
+    },
+    "src/RateLimit/BurstHarness.php": {
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "contentHash": "64f6afa2921975626aa206a210b6d88313e01089261202874277a62c17d3a7f3",
+      "functions": [
+        {
+          "name": "parse_response",
+          "params": [
+            "$raw"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 37
+        },
+        {
+          "name": "extract_session",
+          "params": [
+            "$response"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "merge_session",
+          "params": [
+            "$current",
+            "$observed"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "classify_threshold_trip",
+          "params": [
+            "$results",
+            "$threshold"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "build_tools_call_body",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "build_initialize_body",
+          "params": [
+            "$request_id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "BurstHarness",
+          "methods": [
+            "parse_response",
+            "extract_session",
+            "merge_session",
+            "classify_threshold_trip",
+            "build_tools_call_body",
+            "build_initialize_body"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 206
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "BurstHarness"
+      ],
+      "totalLines": 236,
+      "hasStructuralAnalysis": true
+    },
+    "src/RateLimit/CloudflareIps.php": {
+      "filePath": "src/RateLimit/CloudflareIps.php",
+      "contentHash": "e18ab62c6ce2f5d7a49c5f260c1819c078d1abe928b7f200b2c82594e7eb14df",
+      "functions": [
+        {
+          "name": "bundled_v4",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "bundled_v6",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "CloudflareIps",
+          "methods": [
+            "bundled_v4",
+            "bundled_v6"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 40
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CloudflareIps"
+      ],
+      "totalLines": 60,
+      "hasStructuralAnalysis": true
+    },
+    "src/RateLimit/CounterStore.php": {
+      "filePath": "src/RateLimit/CounterStore.php",
+      "contentHash": "30ec21d9ceb50829c340a2d3897f2a9c791acb907646ed0ede6e62b1888ba209",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$force_backend"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "backend",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "increment",
+          "params": [
+            "$key",
+            "$ttl_seconds"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "get",
+          "params": [
+            "$key"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "detect_backend",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "CounterStore",
+          "methods": [
+            "__construct",
+            "backend",
+            "increment",
+            "get",
+            "detect_backend"
+          ],
+          "properties": [
+            "backend"
+          ],
+          "exported": true,
+          "lineCount": 82
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CounterStore"
+      ],
+      "totalLines": 101,
+      "hasStructuralAnalysis": true
+    },
+    "src/RateLimit/RateLimiter.php": {
+      "filePath": "src/RateLimit/RateLimiter.php",
+      "contentHash": "0d12fe2c9c7f7e9d2998fe1ccc8e36a0871c03b2ed39e4bb43b131b76ba7cb6a",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$store"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "check",
+          "params": [
+            "$method",
+            "$client_ip",
+            "$user_id",
+            "$site_key",
+            "$tags"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "check_initialize",
+          "params": [
+            "$client_ip",
+            "$site_key",
+            "$tags"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "ip_key",
+          "params": [
+            "$ip",
+            "$site_key",
+            "$bucket"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "initialize_ip_key",
+          "params": [
+            "$ip",
+            "$site_key",
+            "$bucket"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "user_key",
+          "params": [
+            "$user_id",
+            "$site_key",
+            "$bucket"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "build_site_key",
+          "params": [
+            "$server_id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "run_filter",
+          "params": [
+            "$method",
+            "$tags"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "config_int",
+          "params": [
+            "$filter",
+            "$default",
+            "$min"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "retry_after_seconds",
+          "params": [
+            "$now",
+            "$bucket",
+            "$window"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "RateLimiter",
+          "methods": [
+            "__construct",
+            "check",
+            "check_initialize",
+            "ip_key",
+            "initialize_ip_key",
+            "user_key",
+            "build_site_key",
+            "run_filter",
+            "config_int",
+            "retry_after_seconds"
+          ],
+          "properties": [
+            "store"
+          ],
+          "exported": true,
+          "lineCount": 201
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "RateLimiter"
+      ],
+      "totalLines": 223,
+      "hasStructuralAnalysis": true
+    },
+    "src/RateLimit/TrustedProxyResolver.php": {
+      "filePath": "src/RateLimit/TrustedProxyResolver.php",
+      "contentHash": "09a9bc5ac91e9c03c4238622c23286b7ac4d7676e933a7e5b2fd8fa994d8a6db",
+      "functions": [
+        {
+          "name": "resolve",
+          "params": [
+            "$server"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "truncate_for_log",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "get_settings",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "update_settings",
+          "params": [
+            "$settings"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "parse_allowlist_raw",
+          "params": [
+            "$raw"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "get_cloudflare_ips",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "refresh_cloudflare_ips",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "ip_in_cidr_list",
+          "params": [
+            "$ip",
+            "$cidrs"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "ip_in_cidr",
+          "params": [
+            "$ip",
+            "$cidr"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "is_valid_cidr",
+          "params": [
+            "$cidr"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "extract_remote_addr",
+          "params": [
+            "$server"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "first_valid_ip",
+          "params": [
+            "$value"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "expand_ipv6",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "fetch_cf_list",
+          "params": [
+            "$url"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 25
+        }
+      ],
+      "classes": [
+        {
+          "name": "TrustedProxyResolver",
+          "methods": [
+            "resolve",
+            "truncate_for_log",
+            "get_settings",
+            "update_settings",
+            "parse_allowlist_raw",
+            "get_cloudflare_ips",
+            "refresh_cloudflare_ips",
+            "ip_in_cidr_list",
+            "ip_in_cidr",
+            "is_valid_cidr",
+            "extract_remote_addr",
+            "first_valid_ip",
+            "expand_ipv6",
+            "fetch_cf_list"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 412
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "TrustedProxyResolver"
+      ],
+      "totalLines": 438,
+      "hasStructuralAnalysis": true
+    },
+    "src/Servers/DefaultServerFactory.php": {
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "contentHash": "6f135be2b76227b866453c5a716e9e718e5f607bd9b88e90c8ff4e2315ba5a4e",
+      "functions": [
+        {
+          "name": "create",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 63
+        },
+        {
+          "name": "is_ability_mcp_public",
+          "params": [
+            "$ability"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "discover_abilities_by_type",
+          "params": [
+            "$type"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 26
+        }
+      ],
+      "classes": [
+        {
+          "name": "DefaultServerFactory",
+          "methods": [
+            "create",
+            "is_ability_mcp_public",
+            "discover_abilities_by_type"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 137
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpAdapter",
+          "specifiers": [
+            "McpAdapter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServerConfig",
+          "specifiers": [
+            "McpServerConfig"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\ErrorLogMcpErrorHandler",
+          "specifiers": [
+            "ErrorLogMcpErrorHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\NullMcpObservabilityHandler",
+          "specifiers": [
+            "NullMcpObservabilityHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\HttpTransport",
+          "specifiers": [
+            "HttpTransport"
+          ]
+        }
+      ],
+      "exports": [
+        "DefaultServerFactory"
+      ],
+      "totalLines": 167,
+      "hasStructuralAnalysis": true
+    },
+    "src/Settings/ConfirmationTokenStore.php": {
+      "filePath": "src/Settings/ConfirmationTokenStore.php",
+      "contentHash": "e03fa6c48dd51c9aca1f8a223bd0ba4c5b373b9752f7cc2871aac9ee9337eee7",
+      "functions": [
+        {
+          "name": "mint",
+          "params": [
+            "$session_id",
+            "$ability",
+            "$params"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "consume",
+          "params": [
+            "$token",
+            "$session_id",
+            "$ability",
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "current_session_id",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "params_hash",
+          "params": [
+            "$params"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConfirmationTokenStore",
+          "methods": [
+            "mint",
+            "consume",
+            "current_session_id",
+            "params_hash"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 111
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ConfirmationTokenStore"
+      ],
+      "totalLines": 138,
+      "hasStructuralAnalysis": true
+    },
+    "src/Settings/SafetySettingsRepository.php": {
+      "filePath": "src/Settings/SafetySettingsRepository.php",
+      "contentHash": "be45497d92b7c71a79fce64ce71dabc35d0f99964f270544470e140bc0d51247",
+      "functions": [
+        {
+          "name": "bucket1_default_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "bucket2_default_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "bucket3_default_keywords",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "is_master_enabled",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_master_enabled",
+          "params": [
+            "$enabled"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_custom_keywords",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "get_removed_defaults",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "get_active_keywords",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "add_custom_keyword",
+          "params": [
+            "$bucket",
+            "$keyword"
+          ],
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "remove_custom_keyword",
+          "params": [
+            "$bucket",
+            "$keyword"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "remove_default_keyword",
+          "params": [
+            "$bucket",
+            "$keyword"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "restore_defaults",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "get_exemptions",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "add_exemption",
+          "params": [
+            "$bucket",
+            "$ability_name"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "remove_exemption",
+          "params": [
+            "$bucket",
+            "$ability_name"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "is_trusted_proxy_enabled",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_trusted_proxy_enabled",
+          "params": [
+            "$enabled"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "get_trusted_proxy_mode",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "set_trusted_proxy_mode",
+          "params": [
+            "$mode"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "get_trusted_proxy_allowlist_raw",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_trusted_proxy_allowlist_raw",
+          "params": [
+            "$raw"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "clean_keyword_list",
+          "params": [
+            "$list"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "clean_ability_list",
+          "params": [
+            "$list"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "sanitize_keyword",
+          "params": [
+            "$keyword"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "sanitize_ability_name",
+          "params": [
+            "$name"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "custom_keywords_option",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "removed_defaults_option",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "exemptions_option",
+          "params": [
+            "$bucket"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "write_keyword_option",
+          "params": [
+            "$option",
+            "$list"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "SafetySettingsRepository",
+          "methods": [
+            "bucket1_default_keywords",
+            "bucket2_default_keywords",
+            "bucket3_default_keywords",
+            "is_master_enabled",
+            "set_master_enabled",
+            "get_custom_keywords",
+            "get_removed_defaults",
+            "get_active_keywords",
+            "add_custom_keyword",
+            "remove_custom_keyword",
+            "remove_default_keyword",
+            "restore_defaults",
+            "get_exemptions",
+            "add_exemption",
+            "remove_exemption",
+            "is_trusted_proxy_enabled",
+            "set_trusted_proxy_enabled",
+            "get_trusted_proxy_mode",
+            "set_trusted_proxy_mode",
+            "get_trusted_proxy_allowlist_raw",
+            "set_trusted_proxy_allowlist_raw",
+            "clean_keyword_list",
+            "clean_ability_list",
+            "sanitize_keyword",
+            "sanitize_ability_name",
+            "custom_keywords_option",
+            "removed_defaults_option",
+            "exemptions_option",
+            "write_keyword_option"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 503
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SafetySettingsRepository"
+      ],
+      "totalLines": 544,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Contracts/McpRestTransportInterface.php": {
+      "filePath": "src/Transport/Contracts/McpRestTransportInterface.php",
+      "contentHash": "edc360453dccff50fa647753b769fa5f8c23c69de1c840cbbee160e5f82df518",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpRestTransportInterface",
+          "methods": [
+            "check_permission",
+            "handle_request"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 18
+        }
+      ],
+      "imports": [
+        {
+          "source": "WP_REST_Request",
+          "specifiers": [
+            "WP_REST_Request"
+          ]
+        }
+      ],
+      "exports": [
+        "McpRestTransportInterface"
+      ],
+      "totalLines": 43,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Contracts/McpTransportInterface.php": {
+      "filePath": "src/Transport/Contracts/McpTransportInterface.php",
+      "contentHash": "95a9536070af5ca1e1f48c0aa6d1c714e84ce2cd31b93890e862485e2b2e20a0",
+      "functions": [],
+      "classes": [
+        {
+          "name": "McpTransportInterface",
+          "methods": [
+            "__construct",
+            "register_routes"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\McpTransportContext",
+          "specifiers": [
+            "McpTransportContext"
+          ]
+        }
+      ],
+      "exports": [
+        "McpTransportInterface"
+      ],
+      "totalLines": 43,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/HttpTransport.php": {
+      "filePath": "src/Transport/HttpTransport.php",
+      "contentHash": "11c553c1dc5c75d67e8321d6ecdf5e6cc55cef4218d2679a71f0c8cb9cf673be",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$transport_context"
+          ],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "maybe_disable_core_cors_for_mcp",
+          "params": [
+            "$served",
+            "$result",
+            "$request",
+            "$server"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "is_mcp_route",
+          "params": [
+            "$request"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "register_routes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "check_permission",
+          "params": [
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 89
+        },
+        {
+          "name": "emit_auth_denied",
+          "params": [
+            "$context",
+            "$reason_enum"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "truncate_ip_for_log",
+          "params": [
+            "$ip"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "handle_request",
+          "params": [
+            "$request"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "handle_preflight",
+          "params": [
+            "$request"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "emit_cors_headers",
+          "params": [
+            "$response",
+            "$server",
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "safe_origin_tag",
+          "params": [
+            "$request"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "HttpTransport",
+          "methods": [
+            "__construct",
+            "maybe_disable_core_cors_for_mcp",
+            "is_mcp_route",
+            "register_routes",
+            "check_permission",
+            "emit_auth_denied",
+            "truncate_ip_for_log",
+            "handle_request",
+            "handle_preflight",
+            "emit_cors_headers",
+            "safe_origin_tag"
+          ],
+          "properties": [
+            "request_handler"
+          ],
+          "exported": true,
+          "lineCount": 411
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Contracts\\McpRestTransportInterface",
+          "specifiers": [
+            "McpRestTransportInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\HttpRequestContext",
+          "specifiers": [
+            "HttpRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\HttpRequestHandler",
+          "specifiers": [
+            "HttpRequestHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\McpTransportContext",
+          "specifiers": [
+            "McpTransportContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\McpTransportHelperTrait",
+          "specifiers": [
+            "McpTransportHelperTrait"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\OriginValidator",
+          "specifiers": [
+            "OriginValidator"
+          ]
+        }
+      ],
+      "exports": [
+        "HttpTransport"
+      ],
+      "totalLines": 443,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/HttpRequestContext.php": {
+      "filePath": "src/Transport/Infrastructure/HttpRequestContext.php",
+      "contentHash": "1e370dfb230e737634090930167c198dded53cb5a525833c5fca4b6c0ec847dc",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$request"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "HttpRequestContext",
+          "methods": [
+            "__construct"
+          ],
+          "properties": [
+            "request",
+            "method",
+            "session_id",
+            "body",
+            "accept_header"
+          ],
+          "exported": true,
+          "lineCount": 51
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "HttpRequestContext"
+      ],
+      "totalLines": 70,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/HttpRequestHandler.php": {
+      "filePath": "src/Transport/Infrastructure/HttpRequestHandler.php",
+      "contentHash": "b853d2fa8ed970d87624f4e68526ade6cf1180160eb252a0f1380a30dd2770f9",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$transport_context"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "handle_request",
+          "params": [
+            "$context"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "handle_mcp_request",
+          "params": [
+            "$context"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "process_mcp_messages",
+          "params": [
+            "$context"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 43
+        },
+        {
+          "name": "process_single_message",
+          "params": [
+            "$message",
+            "$context"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "process_jsonrpc_request",
+          "params": [
+            "$message",
+            "$context"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 73
+        },
+        {
+          "name": "handle_sse_request",
+          "params": [
+            "$context"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 41
+        },
+        {
+          "name": "handle_session_termination",
+          "params": [
+            "$context"
+          ],
+          "returnType": "\\WP_REST_Response",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "get_transport_name",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "record_transport_error",
+          "params": [
+            "$context",
+            "$error_code",
+            "$status_code",
+            "$extra"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "emit_transport_error",
+          "params": [
+            "$context",
+            "$error_code",
+            "$status_code",
+            "$extra"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "emit_session_event",
+          "params": [
+            "$context",
+            "$event",
+            "$session_id",
+            "$init_params"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "add_session_header_to_response",
+          "params": [
+            "$session_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "add_response_header",
+          "params": [
+            "$header_name",
+            "$header_value"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "HttpRequestHandler",
+          "methods": [
+            "__construct",
+            "handle_request",
+            "handle_mcp_request",
+            "process_mcp_messages",
+            "process_single_message",
+            "process_jsonrpc_request",
+            "handle_sse_request",
+            "handle_session_termination",
+            "get_transport_name",
+            "record_transport_error",
+            "emit_transport_error",
+            "emit_session_event",
+            "add_session_header_to_response",
+            "add_response_header"
+          ],
+          "properties": [
+            "transport_context"
+          ],
+          "exported": true,
+          "lineCount": 521
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactionGate",
+          "specifiers": [
+            "ResponseRedactionGate"
+          ]
+        }
+      ],
+      "exports": [
+        "HttpRequestHandler"
+      ],
+      "totalLines": 548,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/HttpSessionValidator.php": {
+      "filePath": "src/Transport/Infrastructure/HttpSessionValidator.php",
+      "contentHash": "719cf00457d136454767f3cb913bcd8f57a4ee8126cfe5a4affbedf326c8a72c",
+      "functions": [
+        {
+          "name": "validate_session",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "validate_session_header",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "create_session",
+          "params": [
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "terminate_session",
+          "params": [
+            "$context"
+          ],
+          "exported": false,
+          "lineCount": 18
+        }
+      ],
+      "classes": [
+        {
+          "name": "HttpSessionValidator",
+          "methods": [
+            "validate_session",
+            "validate_session_header",
+            "create_session",
+            "terminate_session"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 112
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        }
+      ],
+      "exports": [
+        "HttpSessionValidator"
+      ],
+      "totalLines": 136,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/JsonRpcResponseBuilder.php": {
+      "filePath": "src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "contentHash": "ef86cc982a0fc25399a8e5ebe53f628bb147240c5400dbbf73bfc9f46c98bcd6",
+      "functions": [
+        {
+          "name": "create_success_response",
+          "params": [
+            "$request_id",
+            "$result"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "create_error_response",
+          "params": [
+            "$request_id",
+            "$error"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "process_messages",
+          "params": [
+            "$messages",
+            "$is_batch_request",
+            "$processor"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "is_batch_request",
+          "params": [
+            "$body"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "normalize_messages",
+          "params": [
+            "$body"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "JsonRpcResponseBuilder",
+          "methods": [
+            "create_success_response",
+            "create_error_response",
+            "process_messages",
+            "is_batch_request",
+            "normalize_messages"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 98
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "JsonRpcResponseBuilder"
+      ],
+      "totalLines": 120,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/McpTransportContext.php": {
+      "filePath": "src/Transport/Infrastructure/McpTransportContext.php",
+      "contentHash": "5d3cf949a7a5706008957007c60d8763a22acef4eaedd8722ead3715a50f7012",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$properties"
+          ],
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpTransportContext",
+          "methods": [
+            "__construct"
+          ],
+          "properties": [
+            "mcp_server",
+            "initialize_handler",
+            "tools_handler",
+            "resources_handler",
+            "prompts_handler",
+            "system_handler",
+            "observability_handler",
+            "error_handler",
+            "request_router",
+            "transport_permission_callback"
+          ],
+          "exported": true,
+          "lineCount": 114
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Initialize\\InitializeHandler",
+          "specifiers": [
+            "InitializeHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Prompts\\PromptsHandler",
+          "specifiers": [
+            "PromptsHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Resources\\ResourcesHandler",
+          "specifiers": [
+            "ResourcesHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\System\\SystemHandler",
+          "specifiers": [
+            "SystemHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Tools\\ToolsHandler",
+          "specifiers": [
+            "ToolsHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\Contracts\\McpErrorHandlerInterface",
+          "specifiers": [
+            "McpErrorHandlerInterface"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\Contracts\\McpObservabilityHandlerInterface",
+          "specifiers": [
+            "McpObservabilityHandlerInterface"
+          ]
+        }
+      ],
+      "exports": [
+        "McpTransportContext"
+      ],
+      "totalLines": 149,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/McpTransportHelperTrait.php": {
+      "filePath": "src/Transport/Infrastructure/McpTransportHelperTrait.php",
+      "contentHash": "a796724985ec4c653e459f36a21c56d0fd9ffebd137af88ce5178962c2ed29ed",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 44,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/OriginValidator.php": {
+      "filePath": "src/Transport/Infrastructure/OriginValidator.php",
+      "contentHash": "42f37cb752182faaba71330b777a28bb5b28190e91dabce5bdac4ad7f572f11c",
+      "functions": [
+        {
+          "name": "is_allowed",
+          "params": [
+            "$request"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 60
+        },
+        {
+          "name": "host_from",
+          "params": [
+            "$value"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "request_host",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "is_loopback",
+          "params": [
+            "$host"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "echoable_origin",
+          "params": [
+            "$request"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "OriginValidator",
+          "methods": [
+            "is_allowed",
+            "host_from",
+            "request_host",
+            "is_loopback",
+            "echoable_origin"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 152
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "OriginValidator"
+      ],
+      "totalLines": 182,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/RequestRouter.php": {
+      "filePath": "src/Transport/Infrastructure/RequestRouter.php",
+      "contentHash": "b2f205d798040c1951091a1bdc80f9363128782e905021f9a6090968b5e32c72",
+      "functions": [
+        {
+          "name": "__construct",
+          "params": [
+            "$context",
+            "$rate_limiter"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "route_request",
+          "params": [
+            "$method",
+            "$params",
+            "$request_id",
+            "$transport_name",
+            "$http_context"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 94
+        },
+        {
+          "name": "apply_rate_limit",
+          "params": [
+            "$method",
+            "$request_id",
+            "$common_tags",
+            "$start_time",
+            "$http_context"
+          ],
+          "returnType": "?array",
+          "exported": false,
+          "lineCount": 73
+        },
+        {
+          "name": "add_cursor_compatibility",
+          "params": [
+            "$result"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "handle_initialize_with_session",
+          "params": [
+            "$params",
+            "$request_id",
+            "$http_context"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "create_method_not_found_error",
+          "params": [
+            "$method"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "categorize_error",
+          "params": [
+            "$exception"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "sanitize_params_for_logging",
+          "params": [
+            "$params"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 32
+        }
+      ],
+      "classes": [
+        {
+          "name": "RequestRouter",
+          "methods": [
+            "__construct",
+            "route_request",
+            "apply_rate_limit",
+            "add_cursor_compatibility",
+            "handle_initialize_with_session",
+            "create_method_not_found_error",
+            "categorize_error",
+            "sanitize_params_for_logging"
+          ],
+          "properties": [
+            "context",
+            "rate_limiter"
+          ],
+          "exported": true,
+          "lineCount": 341
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\TrustedProxyResolver",
+          "specifiers": [
+            "TrustedProxyResolver"
+          ]
+        }
+      ],
+      "exports": [
+        "RequestRouter"
+      ],
+      "totalLines": 368,
+      "hasStructuralAnalysis": true
+    },
+    "src/Transport/Infrastructure/SessionManager.php": {
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "contentHash": "ae0ce53e7777c24bfa0207ffbc677d9e01622bf0070ccb993cfe4a5f25b90586",
+      "functions": [
+        {
+          "name": "acquire_lock",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "release_lock",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "get_config",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "clear_session",
+          "params": [
+            "$user_id",
+            "$session_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "create_session",
+          "params": [
+            "$user_id",
+            "$params"
+          ],
+          "exported": false,
+          "lineCount": 59
+        },
+        {
+          "name": "verify_session_token",
+          "params": [
+            "$user_id",
+            "$session_id",
+            "$client_token"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "get_session",
+          "params": [
+            "$user_id",
+            "$session_id"
+          ],
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "validate_session",
+          "params": [
+            "$user_id",
+            "$session_id"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "delete_session",
+          "params": [
+            "$user_id",
+            "$session_id"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "cleanup_expired_sessions",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "cleanup_expired_sessions_unlocked",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "int",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "get_all_user_sessions",
+          "params": [
+            "$user_id"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "SessionManager",
+          "methods": [
+            "acquire_lock",
+            "release_lock",
+            "get_config",
+            "clear_session",
+            "create_session",
+            "verify_session_token",
+            "get_session",
+            "validate_session",
+            "delete_session",
+            "cleanup_expired_sessions",
+            "cleanup_expired_sessions_unlocked",
+            "get_all_user_sessions"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 444
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SessionManager"
+      ],
+      "totalLines": 467,
+      "hasStructuralAnalysis": true
+    },
+    "tests/bootstrap.php": {
+      "filePath": "tests/bootstrap.php",
+      "contentHash": "e044fbe581859f4921e33a82e0acb80bca21110c166ed4eefe734f8b4743cd85",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 887,
+      "hasStructuralAnalysis": true
+    },
+    "tests/fixtures/live-catalog-snapshot.json": {
+      "filePath": "tests/fixtures/live-catalog-snapshot.json",
+      "contentHash": "1236ff53c17424edb59358ce4850aefe93a92d8fcda21d4ce03c88a7ca0308f1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 140,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php": {
+      "filePath": "tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "contentHash": "3429d7362369b3059b88866be929e2534a4ad9142a1cda0fcf2d4fb2b285b944",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "register",
+          "params": [
+            "$name",
+            "$category"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "register_many",
+          "params": [
+            "$category",
+            "$count",
+            "$prefix"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_no_args_defaults_to_compact_and_limit_100",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "test_second_page_has_no_more",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_explicit_verbose_unbounded_returns_prior_shape_plus_additive_blocks",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "test_explicit_compact_false_without_limit_does_not_auto_apply_limit",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_category_filter_sets_filtered_total_and_single_slug_histogram",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_histogram_counts_are_accurate_and_sorted_by_count_desc",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_non_public_and_non_tool_abilities_excluded_from_totals",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        }
+      ],
+      "classes": [
+        {
+          "name": "DiscoverAbilitiesDefaultsTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "register",
+            "register_many",
+            "test_no_args_defaults_to_compact_and_limit_100",
+            "test_second_page_has_no_more",
+            "test_explicit_verbose_unbounded_returns_prior_shape_plus_additive_blocks",
+            "test_explicit_compact_false_without_limit_does_not_auto_apply_limit",
+            "test_category_filter_sets_filtered_total_and_single_slug_histogram",
+            "test_histogram_counts_are_accurate_and_sorted_by_count_desc",
+            "test_non_public_and_non_tool_abilities_excluded_from_totals"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 178
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\DiscoverAbilitiesAbility",
+          "specifiers": [
+            "DiscoverAbilitiesAbility"
+          ]
+        }
+      ],
+      "exports": [
+        "DiscoverAbilitiesDefaultsTest"
+      ],
+      "totalLines": 195,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php": {
+      "filePath": "tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "contentHash": "7b1dd9d93920865e314b23142827a310d57dcb0da3def909fd35e3ef126ced7e",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "register_inner_ability",
+          "params": [
+            "$name"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "set_oauth_request",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_inner_ability_blocked_when_token_lacks_inner_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_inner_ability_runs_when_token_has_explicit_inner_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_non_oauth_request_runs_inner_ability",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "ExecuteAbilityScopeEnforcementTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "register_inner_ability",
+            "set_oauth_request",
+            "test_inner_ability_blocked_when_token_lacks_inner_scope",
+            "test_inner_ability_runs_when_token_has_explicit_inner_scope",
+            "test_non_oauth_request_runs_inner_ability"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 86
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\ExecuteAbilityAbility",
+          "specifiers": [
+            "ExecuteAbilityAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "ExecuteAbilityScopeEnforcementTest"
+      ],
+      "totalLines": 109,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php": {
+      "filePath": "tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "contentHash": "ff5ff08d123740a31812c8b643508e52f999312a447c453ebf83986f093bced0",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_execute_ability_register_resolves_to_read_not_delete",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_batch_execute_register_resolves_to_read_not_delete",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_destructive_alone_would_resolve_to_delete",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_meta_tools_keep_destructive_client_annotation",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "MetaToolPermissionAnnotationTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_execute_ability_register_resolves_to_read_not_delete",
+            "test_batch_execute_register_resolves_to_read_not_delete",
+            "test_destructive_alone_would_resolve_to_delete",
+            "test_meta_tools_keep_destructive_client_annotation"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 67
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\BatchExecuteAbility",
+          "specifiers": [
+            "BatchExecuteAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\ExecuteAbilityAbility",
+          "specifiers": [
+            "ExecuteAbilityAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        }
+      ],
+      "exports": [
+        "MetaToolPermissionAnnotationTest"
+      ],
+      "totalLines": 94,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php": {
+      "filePath": "tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "contentHash": "e5860e1ee9a42bc7064069f64184534a15f94aed5f6d2d8136474927958c245e",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_get_redaction_list_returns_full_state",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_add_redaction_keyword_strengthens_without_friction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_remove_default_bucket3_keyword_first_call_returns_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_remove_default_bucket3_keyword_with_valid_token_executes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_remove_default_bucket3_keyword_token_is_one_time",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_remove_default_bucket3_keyword_rejects_param_swap",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_exempt_ability_from_bucket3_first_call_returns_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_exempt_ability_from_bucket3_with_valid_token_succeeds",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_unexempt_strengthens_without_friction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_restore_defaults_strengthens_without_friction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_remove_custom_keyword_strengthens_without_friction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_b1_rejects_bucket2_card_number_without_minting_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_b1_rejects_bucket2_ssn_without_minting_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_b1_rejects_bucket2_tax_id_without_minting_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_b1_rejects_unknown_keyword_without_minting_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_b1_rejects_empty_keyword_without_minting_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_b1_happy_path_bucket3_keyword_still_mints_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_b1_bucket2_keyword_with_token_still_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_b1_bucket3_case_insensitive_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_b1_exempt_ability_rejects_empty_name",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "SettingsAbilitiesTest",
+          "methods": [
+            "setUp",
+            "test_get_redaction_list_returns_full_state",
+            "test_add_redaction_keyword_strengthens_without_friction",
+            "test_remove_default_bucket3_keyword_first_call_returns_token",
+            "test_remove_default_bucket3_keyword_with_valid_token_executes",
+            "test_remove_default_bucket3_keyword_token_is_one_time",
+            "test_remove_default_bucket3_keyword_rejects_param_swap",
+            "test_exempt_ability_from_bucket3_first_call_returns_token",
+            "test_exempt_ability_from_bucket3_with_valid_token_succeeds",
+            "test_unexempt_strengthens_without_friction",
+            "test_restore_defaults_strengthens_without_friction",
+            "test_remove_custom_keyword_strengthens_without_friction",
+            "test_b1_rejects_bucket2_card_number_without_minting_token",
+            "test_b1_rejects_bucket2_ssn_without_minting_token",
+            "test_b1_rejects_bucket2_tax_id_without_minting_token",
+            "test_b1_rejects_unknown_keyword_without_minting_token",
+            "test_b1_rejects_empty_keyword_without_minting_token",
+            "test_b1_happy_path_bucket3_keyword_still_mints_token",
+            "test_b1_bucket2_keyword_with_token_still_rejected",
+            "test_b1_bucket3_case_insensitive_match",
+            "test_b1_exempt_ability_rejects_empty_name"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 239
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\Settings\\SettingsAbilities",
+          "specifiers": [
+            "SettingsAbilities"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "SettingsAbilitiesTest"
+      ],
+      "totalLines": 257,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/AdapterAdminPageTest.php": {
+      "filePath": "tests/Unit/Admin/AdapterAdminPageTest.php",
+      "contentHash": "626ef3fb8514157c39c761c90e3eb5ad92f3f6b2f25267bf967bdb36d253cf49",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_tab_ids_lists_all_three_phase_2_tabs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_tab_is_abilities",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_active_tab_resolves_known_tabs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_active_tab_falls_back_when_unknown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_page_url_targets_top_level_admin_php",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_tab_url_appends_tab_query_arg",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_tab_url_preserves_extra_args",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_page_url_uses_network_admin_in_network_context",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_add_menu_page_registers_top_level_entry",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_add_menu_page_uses_network_capability_in_network_admin",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_tab_constants_match_documented_ids",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "AdapterAdminPageTest",
+          "methods": [
+            "set_up",
+            "test_tab_ids_lists_all_three_phase_2_tabs",
+            "test_default_tab_is_abilities",
+            "test_active_tab_resolves_known_tabs",
+            "test_active_tab_falls_back_when_unknown",
+            "test_page_url_targets_top_level_admin_php",
+            "test_tab_url_appends_tab_query_arg",
+            "test_tab_url_preserves_extra_args",
+            "test_page_url_uses_network_admin_in_network_context",
+            "test_add_menu_page_registers_top_level_entry",
+            "test_add_menu_page_uses_network_capability_in_network_admin",
+            "test_tab_constants_match_documented_ids"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 88
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "AdapterAdminPageTest"
+      ],
+      "totalLines": 103,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php": {
+      "filePath": "tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "contentHash": "cb944050e89f314de93b350b8f965c71eabdfbda9f0575e5e6fe33382ec406ca",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_returns_existing_when_no_observations_yet",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_returns_ok_when_all_recent_requests_had_header",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_returns_warn_when_no_recent_requests_had_header",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_returns_warn_when_some_recent_requests_were_missing_header",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_window_is_capped_at_100_observations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthHeaderProbeTest",
+          "methods": [
+            "setUp",
+            "test_returns_existing_when_no_observations_yet",
+            "test_returns_ok_when_all_recent_requests_had_header",
+            "test_returns_warn_when_no_recent_requests_had_header",
+            "test_returns_warn_when_some_recent_requests_were_missing_header",
+            "test_window_is_capped_at_100_observations"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 47
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\AuthHeaderProbe",
+          "specifiers": [
+            "AuthHeaderProbe"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthHeaderProbeTest"
+      ],
+      "totalLines": 62,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php": {
+      "filePath": "tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "contentHash": "40544cea5e597cf7cd0a040af714e6a27d9d6d3942894fde0fcbbae71c48a920",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_captures_oauth_events_to_buffer",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_ignores_non_oauth_events",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_buffer_is_bounded_to_max_entries",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_records_reason_and_error_code_when_present",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_handles_missing_optional_fields_gracefully",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "BoundaryAuditBufferTest",
+          "methods": [
+            "setUp",
+            "test_captures_oauth_events_to_buffer",
+            "test_ignores_non_oauth_events",
+            "test_buffer_is_bounded_to_max_entries",
+            "test_records_reason_and_error_code_when_present",
+            "test_handles_missing_optional_fields_gracefully"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 50
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\BoundaryAuditBuffer",
+          "specifiers": [
+            "BoundaryAuditBuffer"
+          ]
+        }
+      ],
+      "exports": [
+        "BoundaryAuditBufferTest"
+      ],
+      "totalLines": 66,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php": {
+      "filePath": "tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "contentHash": "5ec88ce2feb6aecadb0759d46d339bb1332b6d14684b47b93ce176b43f21c06a",
+      "functions": [
+        {
+          "name": "test_projects_basic_row",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "test_silent_warning_triggers_at_threshold_minus_30_days",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_silent_warning_false_when_no_last_consent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_handles_missing_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_software_string_omits_version_when_blank",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "BridgeRowProjectorTest",
+          "methods": [
+            "test_projects_basic_row",
+            "test_silent_warning_triggers_at_threshold_minus_30_days",
+            "test_silent_warning_false_when_no_last_consent",
+            "test_handles_missing_token",
+            "test_software_string_omits_version_when_blank"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 80
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\BridgeRowProjector",
+          "specifiers": [
+            "BridgeRowProjector"
+          ]
+        }
+      ],
+      "exports": [
+        "BridgeRowProjectorTest"
+      ],
+      "totalLines": 95,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/LegacyRedirectorsTest.php": {
+      "filePath": "tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "contentHash": "c2dcbd343bf94d104cfe0f780b372103727cb535255925ae93f948b78c7e2d27",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_legacy_slugs_are_preserved_for_external_callers",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_abilities_redirector_ignores_unrelated_pages",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_abilities_redirector_emits_301_to_new_tab",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_abilities_redirector_carries_license_subtab_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_safety_redirector_ignores_unrelated_pages",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_safety_redirector_emits_301_to_new_tab",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "LegacyRedirectorsTest",
+          "methods": [
+            "set_up",
+            "test_legacy_slugs_are_preserved_for_external_callers",
+            "test_abilities_redirector_ignores_unrelated_pages",
+            "test_abilities_redirector_emits_301_to_new_tab",
+            "test_abilities_redirector_carries_license_subtab_through",
+            "test_safety_redirector_ignores_unrelated_pages",
+            "test_safety_redirector_emits_301_to_new_tab"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 77
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AbilitySettingsPage",
+          "specifiers": [
+            "AbilitySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\AdapterAdminPage",
+          "specifiers": [
+            "AdapterAdminPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\SafetySettingsPage",
+          "specifiers": [
+            "SafetySettingsPage"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Tests\\RedirectException",
+          "specifiers": [
+            "RedirectException"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "LegacyRedirectorsTest"
+      ],
+      "totalLines": 100,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/PermissionManagerTest.php": {
+      "filePath": "tests/Unit/Admin/PermissionManagerTest.php",
+      "contentHash": "7ee711b26dca0521fac151b1025c4972c389d8d6a6908a806d9299f921920192",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_explicit_permission_read",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_explicit_permission_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_explicit_permission_delete",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_explicit_permission_overrides_annotations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_readonly_derives_read",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_destructive_derives_delete",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_not_readonly_not_destructive_derives_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_readonly_false_destructive_false_derives_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_no_annotations_defaults_to_read",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_meta_defaults_to_read",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_invalid_explicit_permission_falls_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_default_enabled_when_no_settings",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_set_enabled_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_set_enabled_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_different_abilities_independent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_valid_permissions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_invalid_permissions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_option_name_constant",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_valid_permissions_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_save_settings_updates_cache",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_clear_cache_reads_from_option_store",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_clear_cache_with_empty_store_defaults_enabled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "make_ability",
+          "params": [
+            "$annotations"
+          ],
+          "returnType": "\\WP_Ability",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "PermissionManagerTest",
+          "methods": [
+            "set_up",
+            "test_explicit_permission_read",
+            "test_explicit_permission_write",
+            "test_explicit_permission_delete",
+            "test_explicit_permission_overrides_annotations",
+            "test_readonly_derives_read",
+            "test_destructive_derives_delete",
+            "test_not_readonly_not_destructive_derives_write",
+            "test_readonly_false_destructive_false_derives_write",
+            "test_no_annotations_defaults_to_read",
+            "test_empty_meta_defaults_to_read",
+            "test_invalid_explicit_permission_falls_through",
+            "test_default_enabled_when_no_settings",
+            "test_set_enabled_true",
+            "test_set_enabled_false",
+            "test_different_abilities_independent",
+            "test_valid_permissions",
+            "test_invalid_permissions",
+            "test_option_name_constant",
+            "test_valid_permissions_array",
+            "test_save_settings_updates_cache",
+            "test_clear_cache_reads_from_option_store",
+            "test_clear_cache_with_empty_store_defaults_enabled",
+            "make_ability"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 166
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "PermissionManagerTest"
+      ],
+      "totalLines": 179,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php": {
+      "filePath": "tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "contentHash": "4d9e8d5835671a0d9bcb0e4dee0cda699b1ad0873c34101b2c72bf715acfb918",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_diagnostic_filter_name_is_documented_contract",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_render_emits_unknown_state_when_no_listener",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_render_uses_listener_status_when_filter_returns_ok",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_render_uses_warn_when_header_missing",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_unknown_state_value_collapses_to_unknown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_empty_state_shows_helpful_copy",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_table_renders_with_seeded_clients",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "test_handle_action_does_nothing_without_capability",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_handle_action_does_nothing_without_valid_nonce",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_handle_action_revokes_when_nonce_and_capability_present",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "capture_render",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "seed_client_list",
+          "params": [
+            "$clients"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "spy_revokes",
+          "params": [],
+          "returnType": "callable",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConnectedBridgesTabTest",
+          "methods": [
+            "set_up",
+            "test_diagnostic_filter_name_is_documented_contract",
+            "test_render_emits_unknown_state_when_no_listener",
+            "test_render_uses_listener_status_when_filter_returns_ok",
+            "test_render_uses_warn_when_header_missing",
+            "test_unknown_state_value_collapses_to_unknown",
+            "test_empty_state_shows_helpful_copy",
+            "test_table_renders_with_seeded_clients",
+            "test_handle_action_does_nothing_without_capability",
+            "test_handle_action_does_nothing_without_valid_nonce",
+            "test_handle_action_revokes_when_nonce_and_capability_present",
+            "capture_render",
+            "seed_client_list",
+            "spy_revokes"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 199
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Tabs\\ConnectedBridgesTab",
+          "specifiers": [
+            "ConnectedBridgesTab"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "ConnectedBridgesTabTest"
+      ],
+      "totalLines": 220,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "contentHash": "0f12910b8144ca0c242d8d1d540a8dae960c75ae6b5406674443d60e6af37d02",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "install_valid_token_row",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "test_no_op_on_wp_v2_users_even_with_valid_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_no_op_on_wp_v2_plugins_even_with_valid_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_no_op_on_oauth_token_endpoint_even_with_valid_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_authenticates_on_mcp_resource_with_valid_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_already_authenticated_user_passes_through_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthenticateBearerNarrowsToMcpResourceTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "install_valid_token_row",
+            "test_no_op_on_wp_v2_users_even_with_valid_token",
+            "test_no_op_on_wp_v2_plugins_even_with_valid_token",
+            "test_no_op_on_oauth_token_endpoint_even_with_valid_token",
+            "test_authenticates_on_mcp_resource_with_valid_token",
+            "test_already_authenticated_user_passes_through_unchanged"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 106
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthenticateBearerNarrowsToMcpResourceTest"
+      ],
+      "totalLines": 137,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "contentHash": "0f923a95b712eb5143617db2adfcdfe2bb6f924accda09bdeb59d4285bc4ef56",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "install_token_row",
+          "params": [
+            "$selected_role"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "test_populates_selected_role_into_request_context",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_empty_selected_role_yields_empty_context_role",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_missing_selected_role_property_defaults_to_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthenticateBearerSelectedRoleTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "install_token_row",
+            "test_populates_selected_role_into_request_context",
+            "test_empty_selected_role_yields_empty_context_role",
+            "test_missing_selected_role_property_defaults_to_empty"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 103
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthenticateBearerSelectedRoleTest"
+      ],
+      "totalLines": 129,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "contentHash": "2a05d2fa94b407130897e284074cf20d0cda1ef483dc0a95a0a0e6c88fdc93d3",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_probe_records_on_mcp_namespace_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_probe_does_not_record_on_stale_abilities_mcp_adapter_namespace",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_probe_does_not_record_on_unrelated_rest_routes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_probe_records_zero_when_authorization_header_absent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthHeaderProbeNamespaceGateTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_probe_records_on_mcp_namespace_request",
+            "test_probe_does_not_record_on_stale_abilities_mcp_adapter_namespace",
+            "test_probe_does_not_record_on_unrelated_rest_routes",
+            "test_probe_records_zero_when_authorization_header_absent"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 68
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\Bridges\\AuthHeaderProbe",
+          "specifiers": [
+            "AuthHeaderProbe"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthHeaderProbeNamespaceGateTest"
+      ],
+      "totalLines": 94,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "contentHash": "03dd93a6e53f3f567555c56288d88da363ba61509486940c24d0fe6fb7530cc0",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_store_persists_supplied_selected_role",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "test_store_persists_empty_selected_role_when_omitted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizationCodeStoreSelectedRoleTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_store_persists_supplied_selected_role",
+            "test_store_persists_empty_selected_role_when_omitted"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 69
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationCodeStore",
+          "specifiers": [
+            "AuthorizationCodeStore"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizationCodeStoreSelectedRoleTest"
+      ],
+      "totalLines": 88,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "contentHash": "bf162c1ff7c054281c7cc88ddb3c0611656c60aa4bcfca23496bdc977322583f",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_compute_challenge_matches_rfc7636_s256",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_compute_challenge_different_verifiers_produce_different_challenges",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_compute_challenge_is_base64url_without_padding",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_store_returns_true_on_successful_insert",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_store_returns_false_when_wpdb_insert_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_store_emits_boundary_event_with_client_id_and_wpdb_error_on_failure",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "test_store_does_not_emit_boundary_event_on_success",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 24
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizationCodeStoreTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_compute_challenge_matches_rfc7636_s256",
+            "test_compute_challenge_different_verifiers_produce_different_challenges",
+            "test_compute_challenge_is_base64url_without_padding",
+            "test_store_returns_true_on_successful_insert",
+            "test_store_returns_false_when_wpdb_insert_returns_false",
+            "test_store_emits_boundary_event_with_client_id_and_wpdb_error_on_failure",
+            "test_store_does_not_emit_boundary_event_on_success"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 133
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationCodeStore",
+          "specifiers": [
+            "AuthorizationCodeStore"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizationCodeStoreTest"
+      ],
+      "totalLines": 151,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "contentHash": "37c3c16c7ddc56cabfd038b2c176b4e7aa8f29ea0c151036ba2c47133a6c40c7",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "install_token_row_for_canonical",
+          "params": [
+            "$canonical_plaintext",
+            "$user_id"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 47
+        },
+        {
+          "name": "test_token_with_extra_leading_space_authenticates",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_token_with_trailing_whitespace_authenticates",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_token_with_tab_whitespace_authenticates",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_clean_bearer_header_still_authenticates",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "BearerHeaderTrimTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "install_token_row_for_canonical",
+            "test_token_with_extra_leading_space_authenticates",
+            "test_token_with_trailing_whitespace_authenticates",
+            "test_token_with_tab_whitespace_authenticates",
+            "test_clean_bearer_header_still_authenticates"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 113
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "BearerHeaderTrimTest"
+      ],
+      "totalLines": 146,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/ClientRegistryTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "contentHash": "d46fa943e434abb301dc46970b3858a3657a73da2db20e25b9835fa3ceafbe32",
+      "functions": [
+        {
+          "name": "client",
+          "params": [
+            "$uris"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_http_127_accepted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_with_different_port_accepted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_localhost_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_path_mismatch_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_https_non_loopback_exact_match_accepted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_https_non_loopback_path_mismatch_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_http_non_loopback_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_uri_not_in_registered_list_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_registered_list_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_requested_uri_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_ipv6_loopback_accepted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_multiple_registered_uris_finds_correct_one",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "ClientRegistryTest",
+          "methods": [
+            "client",
+            "test_loopback_http_127_accepted",
+            "test_loopback_with_different_port_accepted",
+            "test_loopback_localhost_rejected",
+            "test_loopback_path_mismatch_rejected",
+            "test_https_non_loopback_exact_match_accepted",
+            "test_https_non_loopback_path_mismatch_rejected",
+            "test_http_non_loopback_rejected",
+            "test_uri_not_in_registered_list_rejected",
+            "test_empty_registered_list_rejected",
+            "test_empty_requested_uri_rejected",
+            "test_ipv6_loopback_accepted",
+            "test_multiple_registered_uris_finds_correct_one"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 80
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ClientRegistryTest"
+      ],
+      "totalLines": 98,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "contentHash": "3cbb79718ebc26357cd365e7c74da61cddbad1b34fe9d28f4ee86464b69f2d7b",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_missing_client_id_returns_pre_redirect_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_unknown_client_id_returns_pre_redirect_error_even_with_valid_redirect_uri",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_unregistered_redirect_uri_returns_pre_redirect_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_missing_state_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_state_longer_than_256_chars_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_state_at_exactly_256_chars_is_accepted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_missing_code_challenge_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_unsupported_code_challenge_method_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_unsupported_response_type_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_unknown_scope_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_empty_scope_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_umbrella_scope_is_expanded_to_implicated_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_resource_mismatch_returns_redirectable_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_missing_resource_defaults_to_site_resource_indicator",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "register_client",
+          "params": [
+            "$client_id",
+            "$redirect_uris"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 42
+        }
+      ],
+      "classes": [
+        {
+          "name": "AuthorizeRequestValidatorTest",
+          "methods": [
+            "setUp",
+            "test_missing_client_id_returns_pre_redirect_error",
+            "test_unknown_client_id_returns_pre_redirect_error_even_with_valid_redirect_uri",
+            "test_unregistered_redirect_uri_returns_pre_redirect_error",
+            "test_missing_state_returns_redirectable_error",
+            "test_state_longer_than_256_chars_is_rejected",
+            "test_state_at_exactly_256_chars_is_accepted",
+            "test_missing_code_challenge_returns_redirectable_error",
+            "test_unsupported_code_challenge_method_returns_redirectable_error",
+            "test_unsupported_response_type_returns_redirectable_error",
+            "test_unknown_scope_returns_redirectable_error",
+            "test_empty_scope_returns_redirectable_error",
+            "test_umbrella_scope_is_expanded_to_implicated_scopes",
+            "test_resource_mismatch_returns_redirectable_error",
+            "test_missing_resource_defaults_to_site_resource_indicator",
+            "register_client"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 321
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\AuthorizeRequestValidator",
+          "specifiers": [
+            "AuthorizeRequestValidator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\AuthorizeValidationResult",
+          "specifiers": [
+            "AuthorizeValidationResult"
+          ]
+        }
+      ],
+      "exports": [
+        "AuthorizeRequestValidatorTest"
+      ],
+      "totalLines": 347,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "contentHash": "b407d25d061cc6fc83bd1742454c9e59a5a8385e3f72654c281602fc51ddc9e8",
+      "functions": [
+        {
+          "name": "test_auto_approves_when_scopes_unchanged_and_within_silent_cap",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_auto_approves_when_requested_is_subset_of_previously_granted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_renders_full_consent_when_no_prior_interactive_grant",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_renders_full_consent_when_silent_cap_exceeded_even_for_unchanged_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_renders_full_consent_when_silent_cap_exceeded_at_exact_boundary_plus_one_second",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_silent_cap_can_be_set_to_one_day_for_high_security_sites",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_renders_full_consent_when_sensitive_scope_requested_even_if_previously_granted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_renders_full_consent_when_any_one_scope_in_set_is_sensitive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_all_canonical_sensitive_modules_trigger_full_consent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_renders_incremental_when_only_new_non_sensitive_scopes_added",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_renders_full_when_new_scope_is_sensitive_and_others_are_not",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_decision_is_independent_of_input_order_or_duplicates",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_silent_cap_takes_precedence_over_sensitive_scope_check",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsentDecisionEvaluatorTest",
+          "methods": [
+            "test_auto_approves_when_scopes_unchanged_and_within_silent_cap",
+            "test_auto_approves_when_requested_is_subset_of_previously_granted",
+            "test_renders_full_consent_when_no_prior_interactive_grant",
+            "test_renders_full_consent_when_silent_cap_exceeded_even_for_unchanged_scopes",
+            "test_renders_full_consent_when_silent_cap_exceeded_at_exact_boundary_plus_one_second",
+            "test_silent_cap_can_be_set_to_one_day_for_high_security_sites",
+            "test_renders_full_consent_when_sensitive_scope_requested_even_if_previously_granted",
+            "test_renders_full_consent_when_any_one_scope_in_set_is_sensitive",
+            "test_all_canonical_sensitive_modules_trigger_full_consent",
+            "test_renders_incremental_when_only_new_non_sensitive_scopes_added",
+            "test_renders_full_when_new_scope_is_sensitive_and_others_are_not",
+            "test_decision_is_independent_of_input_order_or_duplicates",
+            "test_silent_cap_takes_precedence_over_sensitive_scope_check"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 193
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecision",
+          "specifiers": [
+            "ConsentDecision"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecisionEvaluator",
+          "specifiers": [
+            "ConsentDecisionEvaluator"
+          ]
+        }
+      ],
+      "exports": [
+        "ConsentDecisionEvaluatorTest"
+      ],
+      "totalLines": 214,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "contentHash": "0e62635b20fa6cbe4cd00c56c3050f5bb621b5f5c27d2ea9678a638df66ce461",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "params",
+          "params": [
+            "$overrides"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "test_html_contains_form_with_action_url",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_html_round_trips_oauth_flow_parameters_as_hidden_inputs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_html_contains_server_issued_scope_nonce",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_every_requested_scope_renders_as_toggleable_checkbox",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_previously_granted_scope_shows_granted_date_badge",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_sensitive_scope_shows_sensitive_badge_and_lock_icon",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_role_select_lists_only_provided_roles",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_role_with_one_option_renders_as_hidden_input_not_select",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_no_script_tags_in_consent_screen",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_dangerous_chars_in_client_name_are_escaped",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_dangerous_chars_in_state_are_escaped_in_hidden_input",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_html_renders_authorize_and_deny_buttons",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "collapse_ws",
+          "params": [
+            "$html"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_silent_cap_decision_shows_reauth_notice",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_incremental_decision_shows_incremental_notice",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_build_error_html_contains_title_and_detail",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_build_error_html_escapes_user_supplied_strings",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConsentScreenRendererTest",
+          "methods": [
+            "setUp",
+            "params",
+            "test_html_contains_form_with_action_url",
+            "test_html_round_trips_oauth_flow_parameters_as_hidden_inputs",
+            "test_html_contains_server_issued_scope_nonce",
+            "test_every_requested_scope_renders_as_toggleable_checkbox",
+            "test_previously_granted_scope_shows_granted_date_badge",
+            "test_sensitive_scope_shows_sensitive_badge_and_lock_icon",
+            "test_role_select_lists_only_provided_roles",
+            "test_role_with_one_option_renders_as_hidden_input_not_select",
+            "test_no_script_tags_in_consent_screen",
+            "test_dangerous_chars_in_client_name_are_escaped",
+            "test_dangerous_chars_in_state_are_escaped_in_hidden_input",
+            "test_html_renders_authorize_and_deny_buttons",
+            "collapse_ws",
+            "test_silent_cap_decision_shows_reauth_notice",
+            "test_incremental_decision_shows_incremental_notice",
+            "test_build_error_html_contains_title_and_detail",
+            "test_build_error_html_escapes_user_supplied_strings"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 186
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecision",
+          "specifiers": [
+            "ConsentDecision"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentScreenRenderer",
+          "specifiers": [
+            "ConsentScreenRenderer"
+          ]
+        }
+      ],
+      "exports": [
+        "ConsentScreenRendererTest"
+      ],
+      "totalLines": 213,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "contentHash": "a0a4d548aa1a86c4c5cd428371e8aca4e40f7806535fffdf62b4b0e922e6e4ac",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_returns_null_when_no_consent_recorded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_record_then_read_returns_same_timestamp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_record_is_per_pair",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_days_since_returns_floor_of_elapsed_days",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_days_since_returns_zero_for_future_consent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_returns_null_when_pre_option_filter_throws",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_days_since_returns_null_when_lookup_throws",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_throwing_lookup_routes_consent_decision_to_full_consent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "test_returns_null_when_stored_value_is_empty_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "LastConsentLookupTest",
+          "methods": [
+            "setUp",
+            "test_returns_null_when_no_consent_recorded",
+            "test_record_then_read_returns_same_timestamp",
+            "test_record_is_per_pair",
+            "test_days_since_returns_floor_of_elapsed_days",
+            "test_days_since_returns_zero_for_future_consent",
+            "test_returns_null_when_pre_option_filter_throws",
+            "test_days_since_returns_null_when_lookup_throws",
+            "test_throwing_lookup_routes_consent_decision_to_full_consent",
+            "test_returns_null_when_stored_value_is_empty_string"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 112
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecision",
+          "specifiers": [
+            "ConsentDecision"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ConsentDecisionEvaluator",
+          "specifiers": [
+            "ConsentDecisionEvaluator"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\LastConsentLookup",
+          "specifiers": [
+            "LastConsentLookup"
+          ]
+        }
+      ],
+      "exports": [
+        "LastConsentLookupTest"
+      ],
+      "totalLines": 129,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "contentHash": "6737bdd1e9f50a08e0ea784d574755324f2f348cbd42ac2c13f17df119c3dcec",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_default_when_no_option_or_filter",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_option_overrides_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_filter_overrides_option",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_clamped_below_min",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_clamped_above_max",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_clamp_helper_respects_floor_and_ceiling",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "PolicyStoreTest",
+          "methods": [
+            "setUp",
+            "test_default_when_no_option_or_filter",
+            "test_option_overrides_default",
+            "test_filter_overrides_option",
+            "test_clamped_below_min",
+            "test_clamped_above_max",
+            "test_clamp_helper_respects_floor_and_ceiling"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 42
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\PolicyStore",
+          "specifiers": [
+            "PolicyStore"
+          ]
+        }
+      ],
+      "exports": [
+        "PolicyStoreTest"
+      ],
+      "totalLines": 57,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "contentHash": "e686efd02dbdb2daf51d6c52e5e04768a7de5d7dbc253459beb439ff4766037c",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_issued_nonce_can_be_redeemed_with_matching_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_redeem_is_single_use",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_redeem_returns_null_for_unknown_nonce",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_redeem_returns_null_for_empty_nonce",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_subset_is_valid_when_submitted_equals_rendered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_subset_is_valid_when_submitted_is_proper_subset_of_rendered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_subset_is_invalid_when_submitted_contains_unrendered_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_subset_is_invalid_for_wrong_user",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_subset_is_invalid_for_wrong_client_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_subset_is_invalid_for_wrong_redirect_uri",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_subset_is_invalid_for_wrong_state",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "payload",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "RenderedScopeNonceTest",
+          "methods": [
+            "setUp",
+            "test_issued_nonce_can_be_redeemed_with_matching_request",
+            "test_redeem_is_single_use",
+            "test_redeem_returns_null_for_unknown_nonce",
+            "test_redeem_returns_null_for_empty_nonce",
+            "test_subset_is_valid_when_submitted_equals_rendered",
+            "test_subset_is_valid_when_submitted_is_proper_subset_of_rendered",
+            "test_subset_is_invalid_when_submitted_contains_unrendered_scope",
+            "test_subset_is_invalid_for_wrong_user",
+            "test_subset_is_invalid_for_wrong_client_id",
+            "test_subset_is_invalid_for_wrong_redirect_uri",
+            "test_subset_is_invalid_for_wrong_state",
+            "payload"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 105
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\RenderedScopeNonce",
+          "specifiers": [
+            "RenderedScopeNonce"
+          ]
+        }
+      ],
+      "exports": [
+        "RenderedScopeNonceTest"
+      ],
+      "totalLines": 126,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "contentHash": "7ba4c15a216724f9a46f8bfca69e434651d8758276fdc5940d51524f4fafc986",
+      "functions": [
+        {
+          "name": "test_returns_roles_from_resolver",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_drops_non_string_role_values_from_resolver",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_returns_empty_array_when_resolver_returns_non_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_user_holds_role_returns_true_for_role_in_user_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_user_holds_role_returns_false_for_role_not_in_user_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_user_holds_role_returns_false_for_empty_submitted_role",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_user_holds_role_falls_through_to_get_userdata_when_no_resolver",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_user_holds_role_returns_false_when_user_does_not_exist",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "RoleSelectorTest",
+          "methods": [
+            "test_returns_roles_from_resolver",
+            "test_drops_non_string_role_values_from_resolver",
+            "test_returns_empty_array_when_resolver_returns_non_array",
+            "test_user_holds_role_returns_true_for_role_in_user_set",
+            "test_user_holds_role_returns_false_for_role_not_in_user_set",
+            "test_user_holds_role_returns_false_for_empty_submitted_role",
+            "test_user_holds_role_falls_through_to_get_userdata_when_no_resolver",
+            "test_user_holds_role_returns_false_when_user_does_not_exist"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 43
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\RoleSelector",
+          "specifiers": [
+            "RoleSelector"
+          ]
+        }
+      ],
+      "exports": [
+        "RoleSelectorTest"
+      ],
+      "totalLines": 63,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "contentHash": "73b4bcd33199a17e412c9c099e181dc0682d44b2d12b2bf73a5ca73207318947",
+      "functions": [
+        {
+          "name": "test_groups_scopes_by_module",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_umbrella_scopes_group_under_umbrella_key",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_umbrella_renders_first_then_modules_alphabetically",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_group_is_sensitive_returns_true_when_any_scope_is_sensitive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_group_is_sensitive_returns_false_for_all_non_sensitive_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "ScopeGrouperTest",
+          "methods": [
+            "test_groups_scopes_by_module",
+            "test_umbrella_scopes_group_under_umbrella_key",
+            "test_umbrella_renders_first_then_modules_alphabetically",
+            "test_group_is_sensitive_returns_true_when_any_scope_is_sensitive",
+            "test_group_is_sensitive_returns_false_for_all_non_sensitive_scopes"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 37
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Consent\\ScopeGrouper",
+          "specifiers": [
+            "ScopeGrouper"
+          ]
+        }
+      ],
+      "exports": [
+        "ScopeGrouperTest"
+      ],
+      "totalLines": 52,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "contentHash": "513170f88e2fc2f51a4d87e5f041566f3cee800cd81c7596a5ffd461cd054df5",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_issuer_uses_http_when_not_ssl",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_issuer_strips_port",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_issuer_uses_https_when_ssl",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_resource_url_ends_with_mcp_path",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_resource_url_contains_issuer",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "DiscoveryEndpointsTest",
+          "methods": [
+            "setUp",
+            "test_issuer_uses_http_when_not_ssl",
+            "test_issuer_strips_port",
+            "test_issuer_uses_https_when_ssl",
+            "test_resource_url_ends_with_mcp_path",
+            "test_resource_url_contains_issuer"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 46
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\DiscoveryEndpoints",
+          "specifiers": [
+            "DiscoveryEndpoints"
+          ]
+        }
+      ],
+      "exports": [
+        "DiscoveryEndpointsTest"
+      ],
+      "totalLines": 64,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "contentHash": "dfd291b9115ea49185397b668b9617d880f6876da3cdb841b2f97f67fdf91228",
+      "functions": [
+        {
+          "name": "test_empty_string_yields_empty_valid_and_sensitive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_only_non_sensitive_scopes_have_no_sensitive_flag",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_single_sensitive_scope_appears_in_both_arrays",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_mixed_scopes_only_sensitive_subset_is_flagged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_unknown_scopes_dropped_from_both_arrays",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_arrays_are_zero_indexed_after_filtering",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "RegisterEndpointClassifyScopesTest",
+          "methods": [
+            "test_empty_string_yields_empty_valid_and_sensitive",
+            "test_only_non_sensitive_scopes_have_no_sensitive_flag",
+            "test_single_sensitive_scope_appears_in_both_arrays",
+            "test_mixed_scopes_only_sensitive_subset_is_flagged",
+            "test_unknown_scopes_dropped_from_both_arrays",
+            "test_arrays_are_zero_indexed_after_filtering"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 72
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\RegisterEndpoint",
+          "specifiers": [
+            "RegisterEndpoint"
+          ]
+        }
+      ],
+      "exports": [
+        "RegisterEndpointClassifyScopesTest"
+      ],
+      "totalLines": 92,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "contentHash": "a512e540d3cf207caf3139c06dade63028e05c5624d838f5718a5577dfe7abaa",
+      "functions": [
+        {
+          "name": "test_helper_exists_in_global_namespace",
+          "params": [
+            "$name"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_helper_not_in_oauth_namespace",
+          "params": [
+            "$name"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "helper_names",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "HelpersAreGlobalTest",
+          "methods": [
+            "test_helper_exists_in_global_namespace",
+            "test_helper_not_in_oauth_namespace",
+            "helper_names"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 35
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "HelpersAreGlobalTest"
+      ],
+      "totalLines": 57,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "contentHash": "6734182455339d266cc614cccd17224b39ffc9a98798024ce77deb916dfcd045",
+      "functions": [
+        {
+          "name": "call",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unset_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_string_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_non_string_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_root_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_well_known_oauth_resource_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_oauth_authorize_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_oauth_path_with_query_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_unrelated_path_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_path_starting_with_oauth_substring_but_not_oauth_prefix_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "IsWellKnownOrOAuthPathTest",
+          "methods": [
+            "call",
+            "tearDown",
+            "test_unset_request_uri_returns_false",
+            "test_empty_string_request_uri_returns_false",
+            "test_non_string_request_uri_returns_false",
+            "test_root_returns_false",
+            "test_well_known_oauth_resource_returns_true",
+            "test_oauth_authorize_returns_true",
+            "test_oauth_path_with_query_returns_true",
+            "test_unrelated_path_returns_false",
+            "test_path_starting_with_oauth_substring_but_not_oauth_prefix_returns_false"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 61
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        }
+      ],
+      "exports": [
+        "IsWellKnownOrOAuthPathTest"
+      ],
+      "totalLines": 81,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/McpResourcePathTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "contentHash": "ca5fdeb60de386eb4b21ab0efab9a655c5aa1ff7a47ab65b028981b1d57281d3",
+      "functions": [
+        {
+          "name": "test_rest_namespace_is_mcp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_route_is_mcp_adapter_default_server",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_path_is_namespace_slash_route_with_no_leading_slash",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_leading_slash_path_has_leading_slash",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpResourcePathTest",
+          "methods": [
+            "test_rest_namespace_is_mcp",
+            "test_route_is_mcp_adapter_default_server",
+            "test_path_is_namespace_slash_route_with_no_leading_slash",
+            "test_leading_slash_path_has_leading_slash"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 19
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\McpResourcePath",
+          "specifiers": [
+            "McpResourcePath"
+          ]
+        }
+      ],
+      "exports": [
+        "McpResourcePathTest"
+      ],
+      "totalLines": 40,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthCleanupTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "contentHash": "cdf1b064d724ba5023bd2e82652c5c6e75a7b1500791caa6f98e37473661b2b7",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_schedule_registers_cron_hook_when_not_scheduled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_schedule_is_idempotent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_unschedule_removes_cron_hook",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_unschedule_on_missing_hook_does_not_throw",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_cron_hook_name_is_abilities_oauth_cleanup_unused_clients",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "install_capturing_wpdb",
+          "params": [],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "test_run_issues_delete_for_used_or_expired_codes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_run_issues_delete_for_revoked_and_expired_access_tokens",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_run_issues_delete_for_revoked_and_expired_refresh_tokens",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_run_issues_delete_for_revoked_dcr_clients_past_ttl",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_run_uses_limit_in_batch_deletes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_row_alert_saved_as_option_when_threshold_exceeded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_row_alert_not_set_when_below_threshold",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_alert_threshold_constant_is_50000",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthCleanupTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_schedule_registers_cron_hook_when_not_scheduled",
+            "test_schedule_is_idempotent",
+            "test_unschedule_removes_cron_hook",
+            "test_unschedule_on_missing_hook_does_not_throw",
+            "test_cron_hook_name_is_abilities_oauth_cleanup_unused_clients",
+            "install_capturing_wpdb",
+            "test_run_issues_delete_for_used_or_expired_codes",
+            "test_run_issues_delete_for_revoked_and_expired_access_tokens",
+            "test_run_issues_delete_for_revoked_and_expired_refresh_tokens",
+            "test_run_issues_delete_for_revoked_dcr_clients_past_ttl",
+            "test_run_uses_limit_in_batch_deletes",
+            "test_row_alert_saved_as_option_when_threshold_exceeded",
+            "test_row_alert_not_set_when_below_threshold",
+            "test_alert_threshold_constant_is_50000"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 185
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthCleanup",
+          "specifiers": [
+            "OAuthCleanup"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthCleanupTest"
+      ],
+      "totalLines": 213,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "contentHash": "87f1c5279f76841d43f028210abaaf1d5cddf85f1acf117d71dda4d2754f04ad",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "configure_resolver_disabled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "configure_resolver_with_allowlist",
+          "params": [
+            "$cidrs"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_constant_undefined_returns_remote_addr_ignoring_xff",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_constant_on_resolver_disabled_returns_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_bypass_closure_remote_addr_not_in_allowlist_returns_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_real_proxy_remote_addr_in_allowlist_returns_forwarded_ip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_real_proxy_no_xff_returns_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_constant_undefined_no_xff_returns_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_remote_addr_falls_back_to_zero_with_constant_on",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_empty_remote_addr_falls_back_to_zero_with_constant_off",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_multi_value_xff_from_untrusted_source_collapses_to_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthClientIpTrustedProxyTest",
+          "methods": [
+            "setUp",
+            "configure_resolver_disabled",
+            "configure_resolver_with_allowlist",
+            "test_constant_undefined_returns_remote_addr_ignoring_xff",
+            "test_constant_on_resolver_disabled_returns_remote_addr",
+            "test_bypass_closure_remote_addr_not_in_allowlist_returns_remote_addr",
+            "test_real_proxy_remote_addr_in_allowlist_returns_forwarded_ip",
+            "test_real_proxy_no_xff_returns_remote_addr",
+            "test_constant_undefined_no_xff_returns_remote_addr",
+            "test_empty_remote_addr_falls_back_to_zero_with_constant_on",
+            "test_empty_remote_addr_falls_back_to_zero_with_constant_off",
+            "test_multi_value_xff_from_untrusted_source_collapses_to_remote_addr"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 108
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthClientIpTrustedProxyTest"
+      ],
+      "totalLines": 143,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "contentHash": "f2e8c2574f0aedb47168286fe7799d11815f2c94f42951a9e92f37fb395cc0e4",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_override_allows_injected_host",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_host_not_in_override_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_port_is_stripped_before_check",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_empty_host_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_reset_clears_override_and_rebuild_from_env",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthHostAllowlistTest",
+          "methods": [
+            "setUp",
+            "test_override_allows_injected_host",
+            "test_host_not_in_override_is_rejected",
+            "test_port_is_stripped_before_check",
+            "test_empty_host_rejected",
+            "test_reset_clears_override_and_rebuild_from_env"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 43
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthHostAllowlist",
+          "specifiers": [
+            "OAuthHostAllowlist"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthHostAllowlistTest"
+      ],
+      "totalLines": 58,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "contentHash": "0ba66a6581042bb8c39373b104a002c1d96d8c074353b1b0daefad5e0e4c1abb",
+      "functions": [
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unset_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_empty_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_non_string_request_uri_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_root_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_wp_v2_users_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_wp_v2_posts_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_wp_v2_plugins_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_oauth_token_endpoint_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_oauth_register_endpoint_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_oauth_revoke_endpoint_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_pretty_permalink_mcp_resource_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_pretty_permalink_mcp_resource_with_query_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_pretty_permalink_mcp_resource_with_subpath_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_plain_permalink_mcp_resource_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_plain_permalink_other_route_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_resource_prefix_with_extra_chars_is_not_a_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_oauth_authorize_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_well_known_resource_metadata_returns_false",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_subdir_install_uses_rest_url_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthIsMcpResourceRequestTest",
+          "methods": [
+            "tearDown",
+            "test_unset_request_uri_returns_false",
+            "test_empty_request_uri_returns_false",
+            "test_non_string_request_uri_returns_false",
+            "test_root_returns_false",
+            "test_wp_v2_users_returns_false",
+            "test_wp_v2_posts_returns_false",
+            "test_wp_v2_plugins_returns_false",
+            "test_oauth_token_endpoint_returns_false",
+            "test_oauth_register_endpoint_returns_false",
+            "test_oauth_revoke_endpoint_returns_false",
+            "test_pretty_permalink_mcp_resource_returns_true",
+            "test_pretty_permalink_mcp_resource_with_query_returns_true",
+            "test_pretty_permalink_mcp_resource_with_subpath_returns_true",
+            "test_plain_permalink_mcp_resource_returns_true",
+            "test_plain_permalink_other_route_returns_false",
+            "test_resource_prefix_with_extra_chars_is_not_a_match",
+            "test_oauth_authorize_returns_false",
+            "test_well_known_resource_metadata_returns_false",
+            "test_subdir_install_uses_rest_url_prefix"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 128
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthIsMcpResourceRequestTest"
+      ],
+      "totalLines": 147,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "contentHash": "041cf5e5514561265e7b04992e5113a95fc8000f0ee7907ea03be83097921bd2",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_reset_is_wired_to_init_priority_zero",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_reset_is_still_wired_to_rest_api_init",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_reset_clears_set_context",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthRequestContextResetTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_reset_is_wired_to_init_priority_zero",
+            "test_reset_is_still_wired_to_rest_api_init",
+            "test_reset_clears_set_context"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 68
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthRequestContextResetTest"
+      ],
+      "totalLines": 93,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthRequestContextTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "contentHash": "4a9ccf3beb9c09eac8090654ea2f885f3693d5cc3b7ecd536b0581dab7d5fc0d",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_is_not_oauth_request_before_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_oauth_has_scope_returns_false_when_not_oauth",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_granted_scopes_empty_before_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_set_populates_context",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_oauth_has_scope_exact_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_oauth_has_scope_does_not_expand_umbrella_grants",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_reset_clears_context",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_selected_role_empty_before_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_selected_role_defaults_empty_when_not_supplied_at_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_selected_role_round_trips_through_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_selected_role_cleared_by_reset",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthRequestContextTest",
+          "methods": [
+            "setUp",
+            "test_is_not_oauth_request_before_set",
+            "test_oauth_has_scope_returns_false_when_not_oauth",
+            "test_granted_scopes_empty_before_set",
+            "test_set_populates_context",
+            "test_oauth_has_scope_exact_match",
+            "test_oauth_has_scope_does_not_expand_umbrella_grants",
+            "test_reset_clears_context",
+            "test_selected_role_empty_before_set",
+            "test_selected_role_defaults_empty_when_not_supplied_at_set",
+            "test_selected_role_round_trips_through_set",
+            "test_selected_role_cleared_by_reset"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 118
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthRequestContextTest"
+      ],
+      "totalLines": 133,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "contentHash": "a418c799b86256773b1cd69e6181a5e7ad2ba607d01d8d5f255a9d5050beeb81",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_oauth_request",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_non_oauth_request_is_noop",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_direct_match_allows",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_missing_scope_denies_with_required_in_payload",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_umbrella_grant_covers_non_sensitive_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_check_delegates_to_check_scope_for_ability_derived_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthScopeEnforcerCheckScopeTest",
+          "methods": [
+            "setUp",
+            "set_oauth_request",
+            "test_non_oauth_request_is_noop",
+            "test_direct_match_allows",
+            "test_missing_scope_denies_with_required_in_payload",
+            "test_umbrella_grant_covers_non_sensitive_scope",
+            "test_check_delegates_to_check_scope_for_ability_derived_scope"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 59
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthScopeEnforcerCheckScopeTest"
+      ],
+      "totalLines": 78,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "contentHash": "f188ce1b22db79f4300dd0b491207d456ee5614710edb31277b9aae3994d976e",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "ability",
+          "params": [
+            "$name",
+            "$category",
+            "$annotations"
+          ],
+          "returnType": "WP_Ability",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "set_oauth_request",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_abilities_read_allows_content_list",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_abilities_read_denies_content_create",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_abilities_write_umbrella_allows_non_sensitive_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_abilities_write_umbrella_denies_sensitive_users_create",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_umbrella_only_token_still_denies_sensitive_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_umbrella_only_token_allows_non_sensitive_via_umbrella_fallback",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_explicit_sensitive_scope_allows_users_create",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_oauth_request_is_noop",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_required_scope_for_maps_category_and_permission",
+          "params": [
+            "$category",
+            "$annotations",
+            "$expected"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "mapping_cases",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "OAuthScopeEnforcerTest",
+          "methods": [
+            "setUp",
+            "ability",
+            "set_oauth_request",
+            "test_abilities_read_allows_content_list",
+            "test_abilities_read_denies_content_create",
+            "test_abilities_write_umbrella_allows_non_sensitive_write",
+            "test_abilities_write_umbrella_denies_sensitive_users_create",
+            "test_umbrella_only_token_still_denies_sensitive_scope",
+            "test_umbrella_only_token_allows_non_sensitive_via_umbrella_fallback",
+            "test_explicit_sensitive_scope_allows_users_create",
+            "test_non_oauth_request_is_noop",
+            "test_required_scope_for_maps_category_and_permission",
+            "mapping_cases"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 157
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthScopeEnforcer",
+          "specifiers": [
+            "OAuthScopeEnforcer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        },
+        {
+          "source": "WP_Ability",
+          "specifiers": [
+            "WP_Ability"
+          ]
+        }
+      ],
+      "exports": [
+        "OAuthScopeEnforcerTest"
+      ],
+      "totalLines": 177,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "contentHash": "ef581cceac9a804d4837a6209b3e60428a516a6e10cbaee5a9bc5a5669e724c6",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_extract_authorize_prefix_root_path_yields_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_authorize_prefix_single_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_extract_authorize_prefix_multi_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_extract_authorize_prefix_suffix_substring_does_not_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_authorize_prefix_trailing_slash_does_not_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_authorize_prefix_no_leading_slash_yields_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_authorize_prefix_unrelated_path_yields_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_authorize_prefix_prefix_containing_oauth_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_self_url_without_prefix_returns_root_authorize_url",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_self_url_with_path_prefix_includes_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_self_url_with_multi_segment_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_resource_indicator_without_prefix_uses_rest_url",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_resource_indicator_with_path_prefix_uses_discovery_resource_url",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_resource_indicator_empty_prefix_treated_as_no_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "call_self_url",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "call_resource_indicator",
+          "params": [
+            "$path_prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "PathStyleMultisiteAuthorizeRoutingTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_extract_authorize_prefix_root_path_yields_null",
+            "test_extract_authorize_prefix_single_segment",
+            "test_extract_authorize_prefix_multi_segment",
+            "test_extract_authorize_prefix_suffix_substring_does_not_match",
+            "test_extract_authorize_prefix_trailing_slash_does_not_match",
+            "test_extract_authorize_prefix_no_leading_slash_yields_null",
+            "test_extract_authorize_prefix_unrelated_path_yields_null",
+            "test_extract_authorize_prefix_prefix_containing_oauth_segment",
+            "test_self_url_without_prefix_returns_root_authorize_url",
+            "test_self_url_with_path_prefix_includes_prefix",
+            "test_self_url_with_multi_segment_prefix",
+            "test_resource_indicator_without_prefix_uses_rest_url",
+            "test_resource_indicator_with_path_prefix_uses_discovery_resource_url",
+            "test_resource_indicator_empty_prefix_treated_as_no_prefix",
+            "call_self_url",
+            "call_resource_indicator"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 165
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\AuthorizeEndpoint",
+          "specifiers": [
+            "AuthorizeEndpoint"
+          ]
+        }
+      ],
+      "exports": [
+        "PathStyleMultisiteAuthorizeRoutingTest"
+      ],
+      "totalLines": 206,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "contentHash": "438ba52377610037dfc640393835c9fee69731ddbb00f6e9188fe44ae20a9b20",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_issuer_without_prefix_returns_plain_origin",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_issuer_with_null_prefix_returns_plain_origin",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_issuer_with_path_prefix_appends_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_issuer_strips_leading_slash_from_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_issuer_empty_string_prefix_treated_as_root",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_issuer_single_slash_prefix_treated_as_root",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_issuer_deep_path_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_resource_url_includes_path_prefix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_resource_url_without_prefix_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_path_prefix_root_path_yields_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_path_prefix_trailing_slash_only_yields_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_path_prefix_single_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_path_prefix_multi_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_path_prefix_openid_configuration",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_path_prefix_protected_resource",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_is_well_known_matches_path_style_probe",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_is_well_known_matches_root_probe",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_is_well_known_matches_openid_path_style",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_is_well_known_does_not_match_arbitrary_path",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "call_extract_path_prefix",
+          "params": [
+            "$full_path",
+            "$known_prefix"
+          ],
+          "returnType": "?string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "call_is_well_known_or_oauth_path",
+          "params": [],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "PathStyleMultisiteDiscoveryTest",
+          "methods": [
+            "setUp",
+            "test_issuer_without_prefix_returns_plain_origin",
+            "test_issuer_with_null_prefix_returns_plain_origin",
+            "test_issuer_with_path_prefix_appends_prefix",
+            "test_issuer_strips_leading_slash_from_prefix",
+            "test_issuer_empty_string_prefix_treated_as_root",
+            "test_issuer_single_slash_prefix_treated_as_root",
+            "test_issuer_deep_path_prefix",
+            "test_resource_url_includes_path_prefix",
+            "test_resource_url_without_prefix_unchanged",
+            "test_extract_path_prefix_root_path_yields_null",
+            "test_extract_path_prefix_trailing_slash_only_yields_null",
+            "test_extract_path_prefix_single_segment",
+            "test_extract_path_prefix_multi_segment",
+            "test_extract_path_prefix_openid_configuration",
+            "test_extract_path_prefix_protected_resource",
+            "test_is_well_known_matches_path_style_probe",
+            "test_is_well_known_matches_root_probe",
+            "test_is_well_known_matches_openid_path_style",
+            "test_is_well_known_does_not_match_arbitrary_path",
+            "call_extract_path_prefix",
+            "call_is_well_known_or_oauth_path"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 167
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\DiscoveryEndpoints",
+          "specifiers": [
+            "DiscoveryEndpoints"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        }
+      ],
+      "exports": [
+        "PathStyleMultisiteDiscoveryTest"
+      ],
+      "totalLines": 201,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "contentHash": "bf328cd085287153850ff4e1e96d36dd139458b2c418fb711609c96592ace9ce",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_site_transient_path_increments_network_wide_counter",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_site_transient_path_does_not_write_per_blog_transient",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_site_transient_limit_blocks_at_threshold",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_object_cache_path_uses_wp_cache_add_and_incr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_object_cache_path_check_reads_from_cache",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_object_cache_path_does_not_write_site_transient",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_record_revoke_increments_site_transient",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_record_revoke_uses_object_cache_when_available",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "RateLimiterAtomicTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_site_transient_path_increments_network_wide_counter",
+            "test_site_transient_path_does_not_write_per_blog_transient",
+            "test_site_transient_limit_blocks_at_threshold",
+            "test_object_cache_path_uses_wp_cache_add_and_incr",
+            "test_object_cache_path_check_reads_from_cache",
+            "test_object_cache_path_does_not_write_site_transient",
+            "test_record_revoke_increments_site_transient",
+            "test_record_revoke_uses_object_cache_when_available"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 116
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        }
+      ],
+      "exports": [
+        "RateLimiterAtomicTest"
+      ],
+      "totalLines": 140,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/RateLimiterTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "contentHash": "39a65fd1d2cc83d8115b80f2931aa541a8ed49328e84a43a9d057f2731cbc4a7",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_first_request_from_ip_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_after_record_second_request_still_allowed_within_limit",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_record_increments_both_windows",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_exceeded_hour_limit_returns_3600",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_exceeded_minute_limit_returns_60",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "RateLimiterTest",
+          "methods": [
+            "setUp",
+            "test_first_request_from_ip_is_allowed",
+            "test_after_record_second_request_still_allowed_within_limit",
+            "test_record_increments_both_windows",
+            "test_exceeded_hour_limit_returns_3600",
+            "test_exceeded_minute_limit_returns_60"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 53
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        }
+      ],
+      "exports": [
+        "RateLimiterTest"
+      ],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "contentHash": "aea836d243755990faee67f80d5337db0db4c8d16f8cd3ce0dc771ba113ca42d",
+      "functions": [
+        {
+          "name": "client",
+          "params": [
+            "$registered"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_query_param_order_normalized",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_three_param_order_normalized",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_space_encoded_as_percent20_or_plus_equivalent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_percent_encoded_punctuation_normalized",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_no_query_matches_empty_query",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_different_value_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_extra_param_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_missing_param_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_different_key_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_path_trailing_slash_still_distinct",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_candidate_with_fragment_rejected_loopback",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_candidate_with_fragment_rejected_https",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_candidate_with_empty_fragment_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_registered_with_fragment_does_not_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_port_still_ignored",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_loopback_port_ignored_with_query",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_ipv6",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_https_exact_match_still_required",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_https_non_normalized_compare",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "RedirectUriNormalizeTest",
+          "methods": [
+            "client",
+            "test_loopback_query_param_order_normalized",
+            "test_loopback_three_param_order_normalized",
+            "test_loopback_space_encoded_as_percent20_or_plus_equivalent",
+            "test_loopback_percent_encoded_punctuation_normalized",
+            "test_loopback_no_query_matches_empty_query",
+            "test_loopback_different_value_rejected",
+            "test_loopback_extra_param_rejected",
+            "test_loopback_missing_param_rejected",
+            "test_loopback_different_key_rejected",
+            "test_loopback_path_trailing_slash_still_distinct",
+            "test_candidate_with_fragment_rejected_loopback",
+            "test_candidate_with_fragment_rejected_https",
+            "test_candidate_with_empty_fragment_rejected",
+            "test_registered_with_fragment_does_not_match",
+            "test_loopback_port_still_ignored",
+            "test_loopback_port_ignored_with_query",
+            "test_loopback_ipv6",
+            "test_https_exact_match_still_required",
+            "test_https_non_normalized_compare"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 150
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ClientRegistry",
+          "specifiers": [
+            "ClientRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "RedirectUriNormalizeTest"
+      ],
+      "totalLines": 179,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "contentHash": "89224c13e26685590216f2f696ac814f065ca4a99f7f2afb74bc5541bbf02861",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "set_mcp_request",
+          "params": [
+            "$token"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "install_row",
+          "params": [
+            "$row"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "get_registered_challenge_description",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "make_revoked_row",
+          "params": [],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_revoked_token_returns_same_error_description_as_invalid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_old_revoked_description_never_appears",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_expired_token_description_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResponseDifferentialHardeningTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "set_mcp_request",
+            "install_row",
+            "get_registered_challenge_description",
+            "make_revoked_row",
+            "test_revoked_token_returns_same_error_description_as_invalid",
+            "test_old_revoked_description_never_appears",
+            "test_expired_token_description_unchanged"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 120
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "ResponseDifferentialHardeningTest"
+      ],
+      "totalLines": 147,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "contentHash": "1fc77557b211d06a26d4001103ef025487eb4ff0229c6c810354291f2c64bd65",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_gate_allows_request_from_allowed_host",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_gate_rejects_request_from_unknown_host",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_gate_returns_404_status_on_rejection",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_gate_emits_boundary_event_on_rejection",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_gate_does_not_emit_boundary_event_on_allow",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_gate_with_missing_http_host_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "RestRouteHostAllowlistTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_gate_allows_request_from_allowed_host",
+            "test_gate_rejects_request_from_unknown_host",
+            "test_gate_returns_404_status_on_rejection",
+            "test_gate_emits_boundary_event_on_rejection",
+            "test_gate_does_not_emit_boundary_event_on_allow",
+            "test_gate_with_missing_http_host_is_rejected"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 90
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthHostAllowlist",
+          "specifiers": [
+            "OAuthHostAllowlist"
+          ]
+        }
+      ],
+      "exports": [
+        "RestRouteHostAllowlistTest"
+      ],
+      "totalLines": 116,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "contentHash": "93005826ad5fb212e289b93f12301f6add57a77b11a7234ff15b4cf08b044a72",
+      "functions": [
+        {
+          "name": "load_snapshot",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_every_snapshot_category_has_a_scope_in_registry",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_snapshot_includes_the_two_categories_the_hotfix_added",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_snapshot_categories_are_sorted_and_unique",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_site_scopes_are_registered_after_101_fix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_site_scope_is_implied_by_umbrella_read_after_101_fix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_site_is_read_only_module_in_registry",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_surecart_ecommerce_scopes_are_registered_after_102_fix",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_surecart_ecommerce_scope_is_NOT_implied_by_global_umbrella",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_registry_derived_categories_are_all_covered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_categories_from_registry_returns_sorted_unique_slugs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_uncategorized_synthetic_category_fails_coverage",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_synthetic_uncovered_category_in_fixture_would_fail_coverage_test",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_empty_category_falls_back_to_mcp_adapter_and_is_covered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "ScopeCoverageDriftTest",
+          "methods": [
+            "load_snapshot",
+            "test_every_snapshot_category_has_a_scope_in_registry",
+            "test_snapshot_includes_the_two_categories_the_hotfix_added",
+            "test_snapshot_categories_are_sorted_and_unique",
+            "test_site_scopes_are_registered_after_101_fix",
+            "test_site_scope_is_implied_by_umbrella_read_after_101_fix",
+            "test_site_is_read_only_module_in_registry",
+            "test_surecart_ecommerce_scopes_are_registered_after_102_fix",
+            "test_surecart_ecommerce_scope_is_NOT_implied_by_global_umbrella",
+            "test_registry_derived_categories_are_all_covered",
+            "test_categories_from_registry_returns_sorted_unique_slugs",
+            "test_uncategorized_synthetic_category_fails_coverage",
+            "test_synthetic_uncovered_category_in_fixture_would_fail_coverage_test",
+            "test_empty_category_falls_back_to_mcp_adapter_and_is_covered"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 209
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ScopeCoverageDriftTest"
+      ],
+      "totalLines": 252,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/ScopeRegistryTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "contentHash": "9eb104571c3c1c12692c94e78e2a1c7ae78cf3cd056724efa9430cd07f420393",
+      "functions": [
+        {
+          "name": "test_all_scopes_returns_non_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_all_scopes_contains_umbrella_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_all_scopes_are_unique",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_sensitive_scopes_are_flagged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_sensitive_scope_not_flagged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_expand_umbrella_read_implies_non_sensitive_reads",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_expand_umbrella_read_does_not_imply_sensitive_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_expand_umbrella_write_does_not_imply_sensitive_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_expand_explicit_sensitive_scope_is_passed_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_expand_multiple_umbrellas",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_expand_deduplicates_result",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_unknown_scopes_returns_empty_for_valid_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_unknown_scopes_returns_unknown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_fluent_per_module_scopes_are_registered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_fluent_cross_module_scopes_are_registered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_fluent_scopes_are_not_sensitive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_global_umbrella_does_not_imply_fluent_scopes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "ScopeRegistryTest",
+          "methods": [
+            "test_all_scopes_returns_non_empty_array",
+            "test_all_scopes_contains_umbrella_scopes",
+            "test_all_scopes_are_unique",
+            "test_sensitive_scopes_are_flagged",
+            "test_non_sensitive_scope_not_flagged",
+            "test_expand_umbrella_read_implies_non_sensitive_reads",
+            "test_expand_umbrella_read_does_not_imply_sensitive_scopes",
+            "test_expand_umbrella_write_does_not_imply_sensitive_write",
+            "test_expand_explicit_sensitive_scope_is_passed_through",
+            "test_expand_multiple_umbrellas",
+            "test_expand_deduplicates_result",
+            "test_unknown_scopes_returns_empty_for_valid_scopes",
+            "test_unknown_scopes_returns_unknown",
+            "test_fluent_per_module_scopes_are_registered",
+            "test_fluent_cross_module_scopes_are_registered",
+            "test_fluent_scopes_are_not_sensitive",
+            "test_global_umbrella_does_not_imply_fluent_scopes"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 139
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\ScopeRegistry",
+          "specifiers": [
+            "ScopeRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "ScopeRegistryTest"
+      ],
+      "totalLines": 154,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "contentHash": "e81c6526ae98aa07638f634f057b964f788767afe47dd0cc6ade45d765f26cd0",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_passthrough_when_not_an_oauth_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_passthrough_when_selected_role_is_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_passthrough_when_checked_user_is_not_oauth_bound_user",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_passthrough_when_user_id_unresolvable",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_downgrades_oauth_bound_user_caps_to_selected_role",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_downgrade_is_deterministic_across_repeated_calls",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_downgrade_resolves_user_id_from_numeric_argument",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_unknown_role_yields_empty_caps_not_full_caps",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_role_with_empty_capabilities_yields_empty_caps",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_custom_resolver_overrides_wp_roles_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_resolver_returning_non_array_falls_back_to_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_role_capabilities_returns_role_caps_for_known_slug",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_role_capabilities_empty_string_returns_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_role_capabilities_unknown_role_returns_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "SelectedRoleEnforcerTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_passthrough_when_not_an_oauth_request",
+            "test_passthrough_when_selected_role_is_empty",
+            "test_passthrough_when_checked_user_is_not_oauth_bound_user",
+            "test_passthrough_when_user_id_unresolvable",
+            "test_downgrades_oauth_bound_user_caps_to_selected_role",
+            "test_downgrade_is_deterministic_across_repeated_calls",
+            "test_downgrade_resolves_user_id_from_numeric_argument",
+            "test_unknown_role_yields_empty_caps_not_full_caps",
+            "test_role_with_empty_capabilities_yields_empty_caps",
+            "test_custom_resolver_overrides_wp_roles_default",
+            "test_resolver_returning_non_array_falls_back_to_empty",
+            "test_role_capabilities_returns_role_caps_for_known_slug",
+            "test_role_capabilities_empty_string_returns_empty_array",
+            "test_role_capabilities_unknown_role_returns_empty_array"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 213
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\SelectedRoleEnforcer",
+          "specifiers": [
+            "SelectedRoleEnforcer"
+          ]
+        }
+      ],
+      "exports": [
+        "SelectedRoleEnforcerTest"
+      ],
+      "totalLines": 246,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "contentHash": "ad6b345d268187b2b7bc5305da69fab6d05a561ad7a944f1b22943499e825ac4",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_consume_succeeds_with_unmutated_raw_redirect_uri",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "test_chosen_redirect_uri_would_be_mutated_by_esc_url_raw",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "install_consume_wpdb",
+          "params": [
+            "$code",
+            "$expected_redirect",
+            "$challenge"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 56
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenEndpointRedirectUriRawTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_consume_succeeds_with_unmutated_raw_redirect_uri",
+            "test_chosen_redirect_uri_would_be_mutated_by_esc_url_raw",
+            "install_consume_wpdb"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 135
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationCodeStore",
+          "specifiers": [
+            "AuthorizationCodeStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\TokenEndpoint",
+          "specifiers": [
+            "TokenEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Tests\\TokenResponseSentinel",
+          "specifiers": [
+            "TokenResponseSentinel"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenEndpointRedirectUriRawTest"
+      ],
+      "totalLines": 169,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "contentHash": "7f5d605e813c67efdd4df357097b530e72f137f7225657d31b7058d6c66245aa",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "install_stub_wpdb",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_issue_includes_token_type_bearer",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_token_type_is_case_correct_Bearer",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_issue_still_returns_access_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_issue_still_returns_refresh_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_issue_still_returns_expires_in",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_issue_returns_granted_scope_verbatim",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_scope_returned_is_the_stored_expanded_set",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_issue_response_has_exactly_five_keys",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreIssueResponseTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "install_stub_wpdb",
+            "test_issue_includes_token_type_bearer",
+            "test_token_type_is_case_correct_Bearer",
+            "test_issue_still_returns_access_token",
+            "test_issue_still_returns_refresh_token",
+            "test_issue_still_returns_expires_in",
+            "test_issue_returns_granted_scope_verbatim",
+            "test_scope_returned_is_the_stored_expanded_set",
+            "test_issue_response_has_exactly_five_keys"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 116
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreIssueResponseTest"
+      ],
+      "totalLines": 146,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "contentHash": "293d4a98d68a17c4e7e89f55f3ae258299a98c523778916cfebb9e3bc3afcdfb",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_initial_rotation_writes_replay_blob_and_iv",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "test_idempotent_retry_returns_original_plaintext_pair",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "test_idempotent_retry_wipes_blob_after_delivery",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "test_grace_retry_without_blob_returns_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_replay_outside_grace_revokes_family",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "test_grace_retry_with_wrong_plaintext_returns_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_tampered_ciphertext_fails_decryption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "encrypt_pair",
+          "params": [
+            "$pair",
+            "$old_refresh_plaintext"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "make_normal_rotate_wpdb",
+          "params": [
+            "$old_hash",
+            "$family_id",
+            "$updates"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "make_grace_retry_wpdb",
+          "params": [
+            "$old_hash",
+            "$family_id",
+            "$blob",
+            "$rotated_age",
+            "$updates",
+            "$query_capture"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 70
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreReplayBlobTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_initial_rotation_writes_replay_blob_and_iv",
+            "test_idempotent_retry_returns_original_plaintext_pair",
+            "test_idempotent_retry_wipes_blob_after_delivery",
+            "test_grace_retry_without_blob_returns_null",
+            "test_replay_outside_grace_revokes_family",
+            "test_grace_retry_with_wrong_plaintext_returns_null",
+            "test_tampered_ciphertext_fails_decryption",
+            "encrypt_pair",
+            "make_normal_rotate_wpdb",
+            "make_grace_retry_wpdb"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 367
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreReplayBlobTest"
+      ],
+      "totalLines": 409,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "contentHash": "8b72d0dbcb44d902302fdceac840b4f8765e470fdb04920e365d1d24f2ad8239",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_find_token_meta_returns_null_when_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_find_token_meta_returns_access_meta_when_access_token_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "test_find_token_meta_returns_refresh_meta_when_refresh_token_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_revoking_refresh_token_calls_revoke_family",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 52
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreRevocationCascadeTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_find_token_meta_returns_null_when_not_found",
+            "test_find_token_meta_returns_access_meta_when_access_token_found",
+            "test_find_token_meta_returns_refresh_meta_when_refresh_token_found",
+            "test_revoking_refresh_token_calls_revoke_family"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 134
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreRevocationCascadeTest"
+      ],
+      "totalLines": 160,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "contentHash": "4dd30aec53c5fcea24aa2c7b346c6f2cb630eb1d69afe6ce62d13ef1fc87dbaa",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_issue_generates_family_id_when_not_supplied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_issue_uses_supplied_family_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_two_independent_issues_have_distinct_family_ids",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_rotate_preserves_family_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_grace_retry_without_blob_returns_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_replay_outside_grace_revokes_correct_family",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "make_capturing_wpdb",
+          "params": [
+            "$capture"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "make_rotate_wpdb",
+          "params": [
+            "$token_hash",
+            "$parent_family",
+            "$capture"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 59
+        },
+        {
+          "name": "make_already_rotated_wpdb",
+          "params": [
+            "$token_hash",
+            "$parent_family",
+            "$rotated_age"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 54
+        },
+        {
+          "name": "make_replay_wpdb",
+          "params": [
+            "$token_hash",
+            "$parent_family",
+            "$rotated_age",
+            "$revoked_family_out"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 45
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreRotationFamilyTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_issue_generates_family_id_when_not_supplied",
+            "test_issue_uses_supplied_family_id",
+            "test_two_independent_issues_have_distinct_family_ids",
+            "test_rotate_preserves_family_id",
+            "test_grace_retry_without_blob_returns_null",
+            "test_replay_outside_grace_revokes_correct_family",
+            "make_capturing_wpdb",
+            "make_rotate_wpdb",
+            "make_already_rotated_wpdb",
+            "make_replay_wpdb"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 339
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreRotationFamilyTest"
+      ],
+      "totalLines": 364,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "contentHash": "ec8ae1eaa15271b1b8aa6fbc2e37c2b6dccc9eebcb6701c01a061f5cd97263ec",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_issue_persists_selected_role_on_both_rows",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "test_issue_defaults_selected_role_to_empty_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "test_rotate_inherits_selected_role_from_old_refresh_row",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 62
+        },
+        {
+          "name": "test_rotate_inherits_empty_selected_role_when_old_row_had_none",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 50
+        },
+        {
+          "name": "test_rotate_handles_old_row_missing_selected_role_property",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 52
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreSelectedRoleTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_issue_persists_selected_role_on_both_rows",
+            "test_issue_defaults_selected_role_to_empty_string",
+            "test_rotate_inherits_selected_role_from_old_refresh_row",
+            "test_rotate_inherits_empty_selected_role_when_old_row_had_none",
+            "test_rotate_handles_old_row_missing_selected_role_property"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 250
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreSelectedRoleTest"
+      ],
+      "totalLines": 274,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "contentHash": "029dd1435a6b0da887433e5d14c8bce7148ad89e7efca0a2998c3119e7ad87ab",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "install_capturing_wpdb",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_touch_does_not_issue_immediate_db_write",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_repeat_touch_for_same_token_flushes_one_update",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_touches_for_distinct_tokens_flush_separately",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_flush_is_idempotent_after_buffer_drained",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_flush_with_empty_buffer_is_noop",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_empty_token_hash_is_noop",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_touch_after_flush_buffers_the_next_request_window",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        }
+      ],
+      "classes": [
+        {
+          "name": "TokenStoreTouchDeferredTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "install_capturing_wpdb",
+            "test_touch_does_not_issue_immediate_db_write",
+            "test_repeat_touch_for_same_token_flushes_one_update",
+            "test_touches_for_distinct_tokens_flush_separately",
+            "test_flush_is_idempotent_after_buffer_drained",
+            "test_flush_with_empty_buffer_is_noop",
+            "test_empty_token_hash_is_noop",
+            "test_touch_after_flush_buffers_the_next_request_window"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 141
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\TokenStore",
+          "specifiers": [
+            "TokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenStoreTouchDeferredTest"
+      ],
+      "totalLines": 167,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php": {
+      "filePath": "tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "contentHash": "4a909e02be93de550baf2279e0824cccb3f851cf0305beef56a46d6d22d38d03",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_bare_challenge_scheduled_for_mcp_resource_with_no_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_no_challenge_scheduled_for_non_mcp_route_with_no_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_bare_challenge_closure_has_empty_error_code",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_challenge_with_invalid_token_format_is_scheduled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "WwwAuthenticateBareChallengeCTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_bare_challenge_scheduled_for_mcp_resource_with_no_token",
+            "test_no_challenge_scheduled_for_non_mcp_route_with_no_token",
+            "test_bare_challenge_closure_has_empty_error_code",
+            "test_challenge_with_invalid_token_format_is_scheduled"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 92
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\AuthorizationServer",
+          "specifiers": [
+            "AuthorizationServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        }
+      ],
+      "exports": [
+        "WwwAuthenticateBareChallengeCTest"
+      ],
+      "totalLines": 121,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Cli/RequestIdStateTest.php": {
+      "filePath": "tests/Unit/Cli/RequestIdStateTest.php",
+      "contentHash": "4d2b35b370613bb1243059675c62526e144d87a5c443003a9ba22518f6753e54",
+      "functions": [
+        {
+          "name": "test_absent_id_is_notification",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_explicit_null_id_is_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_int_id_is_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_string_id_is_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_zero_id_is_request_not_notification",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_empty_string_id_is_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_bool_false_id_is_treated_as_request_value",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "RequestIdStateTest",
+          "methods": [
+            "test_absent_id_is_notification",
+            "test_explicit_null_id_is_request",
+            "test_int_id_is_request",
+            "test_string_id_is_request",
+            "test_zero_id_is_request_not_notification",
+            "test_empty_string_id_is_request",
+            "test_bool_false_id_is_treated_as_request_value"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 53
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Cli\\StdioServerBridge",
+          "specifiers": [
+            "StdioServerBridge"
+          ]
+        }
+      ],
+      "exports": [
+        "RequestIdStateTest"
+      ],
+      "totalLines": 78,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Cli/StdioServerBridgeIdNullTest.php": {
+      "filePath": "tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "contentHash": "6708235a60195b680875c264164d1d188be46be8376bb67e6ef4a27b17ed4fd4",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 46
+        },
+        {
+          "name": "call_handle",
+          "params": [
+            "$json"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_notification_no_id_key_returns_empty_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_explicit_null_id_returns_response_with_null_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_string_id_returns_response_with_same_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_int_id_returns_response_with_same_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_zero_id_returns_response",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "StdioServerBridgeIdNullTest",
+          "methods": [
+            "setUp",
+            "call_handle",
+            "test_notification_no_id_key_returns_empty_string",
+            "test_explicit_null_id_returns_response_with_null_id",
+            "test_string_id_returns_response_with_same_id",
+            "test_int_id_returns_response_with_same_id",
+            "test_zero_id_returns_response"
+          ],
+          "properties": [
+            "bridge"
+          ],
+          "exported": true,
+          "lineCount": 98
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Cli\\StdioServerBridge",
+          "specifiers": [
+            "StdioServerBridge"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\NullMcpObservabilityHandler",
+          "specifiers": [
+            "NullMcpObservabilityHandler"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\RequestRouter",
+          "specifiers": [
+            "RequestRouter"
+          ]
+        }
+      ],
+      "exports": [
+        "StdioServerBridgeIdNullTest"
+      ],
+      "totalLines": 133,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Core/McpServerConfigTest.php": {
+      "filePath": "tests/Unit/Core/McpServerConfigTest.php",
+      "contentHash": "33158e284bf1e5c6d1e198470494b042a6bdca244c37785389f321e787c4156d",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_from_array_creates_valid_config",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_get_server_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_server_route_namespace",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_server_route",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_server_name",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_server_description",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_server_version",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_mcp_transports",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_error_handler",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_observability_handler",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_tools",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_resources",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_prompts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_get_transport_permission_callback",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_default_error_handler_is_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_observability_handler_is_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_tools_is_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_resources_is_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_prompts_is_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_transports_is_empty_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_transport_permission_callback_is_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_from_array_with_only_required_fields",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_from_array_with_empty_array_defaults_strings_to_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpServerConfigTest",
+          "methods": [
+            "setUp",
+            "test_from_array_creates_valid_config",
+            "test_get_server_id",
+            "test_get_server_route_namespace",
+            "test_get_server_route",
+            "test_get_server_name",
+            "test_get_server_description",
+            "test_get_server_version",
+            "test_get_mcp_transports",
+            "test_get_error_handler",
+            "test_get_observability_handler",
+            "test_get_tools",
+            "test_get_resources",
+            "test_get_prompts",
+            "test_get_transport_permission_callback",
+            "test_default_error_handler_is_null",
+            "test_default_observability_handler_is_null",
+            "test_default_tools_is_empty_array",
+            "test_default_resources_is_empty_array",
+            "test_default_prompts_is_empty_array",
+            "test_default_transports_is_empty_array",
+            "test_default_transport_permission_callback_is_null",
+            "test_from_array_with_only_required_fields",
+            "test_from_array_with_empty_array_defaults_strings_to_empty"
+          ],
+          "properties": [
+            "full_config"
+          ],
+          "exported": true,
+          "lineCount": 192
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServerConfig",
+          "specifiers": [
+            "McpServerConfig"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpServerConfigTest"
+      ],
+      "totalLines": 207,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Prompts/McpPromptValidatorTest.php": {
+      "filePath": "tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "contentHash": "a6bc8eb498982b3d7bc2d6e13f3f219b9ccc7af338af9a6f47d6bae4c7a4e541",
+      "functions": [
+        {
+          "name": "valid_prompt_data",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_valid_prompt_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_valid_prompt_with_arguments_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_missing_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_empty_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_invalid_name_chars_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_prompt_without_description_is_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_non_string_description_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_string_title_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_title_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_array_arguments_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_argument_without_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_argument_with_invalid_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_argument_non_string_description_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_argument_non_bool_required_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_non_array_argument_item_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_annotations_pass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_array_annotations_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_invalid_annotations_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_context_included_in_error_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_valid_text_message_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_invalid_role_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_missing_role_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_missing_content_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_unsupported_content_type_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_non_array_message_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpPromptValidatorTest",
+          "methods": [
+            "valid_prompt_data",
+            "test_valid_prompt_returns_true",
+            "test_valid_prompt_with_arguments_returns_true",
+            "test_missing_name_returns_wp_error",
+            "test_empty_name_returns_wp_error",
+            "test_invalid_name_chars_returns_wp_error",
+            "test_prompt_without_description_is_valid",
+            "test_non_string_description_returns_wp_error",
+            "test_non_string_title_returns_wp_error",
+            "test_valid_title_passes",
+            "test_non_array_arguments_returns_wp_error",
+            "test_argument_without_name_returns_wp_error",
+            "test_argument_with_invalid_name_returns_wp_error",
+            "test_argument_non_string_description_returns_wp_error",
+            "test_argument_non_bool_required_returns_wp_error",
+            "test_non_array_argument_item_returns_wp_error",
+            "test_valid_annotations_pass",
+            "test_non_array_annotations_returns_wp_error",
+            "test_invalid_annotations_returns_wp_error",
+            "test_context_included_in_error_message",
+            "test_valid_text_message_passes",
+            "test_invalid_role_returns_error",
+            "test_missing_role_returns_error",
+            "test_missing_content_returns_error",
+            "test_unsupported_content_type_returns_error",
+            "test_non_array_message_returns_error"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 256
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\McpPromptValidator",
+          "specifiers": [
+            "McpPromptValidator"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpPromptValidatorTest"
+      ],
+      "totalLines": 266,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Resources/McpResourceValidatorTest.php": {
+      "filePath": "tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "contentHash": "2c65d37e9d1d2930f49487b44c02e49eea247d9d12d72130e6379655bda00c88",
+      "functions": [
+        {
+          "name": "valid_resource_data",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_resource_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_valid_resource_with_blob_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_missing_uri_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_empty_uri_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_invalid_uri_format_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_no_text_or_blob_is_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_both_text_and_blob_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_invalid_mime_type_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_mime_type_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_string_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_string_description_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_annotations_pass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_array_annotations_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_invalid_annotations_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_context_included_in_error_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_non_string_text_content_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_non_string_blob_content_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_non_string_mime_type_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpResourceValidatorTest",
+          "methods": [
+            "valid_resource_data",
+            "test_valid_resource_returns_true",
+            "test_valid_resource_with_blob_returns_true",
+            "test_missing_uri_returns_wp_error",
+            "test_empty_uri_returns_wp_error",
+            "test_invalid_uri_format_returns_wp_error",
+            "test_no_text_or_blob_is_valid",
+            "test_both_text_and_blob_returns_wp_error",
+            "test_invalid_mime_type_returns_wp_error",
+            "test_valid_mime_type_passes",
+            "test_non_string_name_returns_wp_error",
+            "test_non_string_description_returns_wp_error",
+            "test_valid_annotations_pass",
+            "test_non_array_annotations_returns_wp_error",
+            "test_invalid_annotations_returns_wp_error",
+            "test_context_included_in_error_message",
+            "test_non_string_text_content_returns_error",
+            "test_non_string_blob_content_returns_error",
+            "test_non_string_mime_type_returns_error"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 177
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\McpResourceValidator",
+          "specifiers": [
+            "McpResourceValidator"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpResourceValidatorTest"
+      ],
+      "totalLines": 187,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Tools/McpToolValidatorTest.php": {
+      "filePath": "tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "contentHash": "c8a41d693cdf320432d37a656a461afd97e76dbd4d195faa433e84ffb25586a7",
+      "functions": [
+        {
+          "name": "valid_tool_data",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_valid_tool_data_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_valid_tool_with_empty_schema_returns_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_missing_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_empty_name_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_invalid_name_chars_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_missing_description_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_empty_description_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_array_input_schema_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_input_schema_with_non_object_type_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_missing_input_schema_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_context_included_in_error_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_annotations_pass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_invalid_annotations_return_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_non_array_annotations_return_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_title_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_non_string_title_returns_wp_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_array_properties_in_schema_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_non_array_property_definition_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_required_field_not_in_properties_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_non_array_required_field_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_stdclass_properties_at_schema_root_is_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_stdclass_sub_property_value_is_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpToolValidatorTest",
+          "methods": [
+            "valid_tool_data",
+            "test_valid_tool_data_returns_true",
+            "test_valid_tool_with_empty_schema_returns_true",
+            "test_missing_name_returns_wp_error",
+            "test_empty_name_returns_wp_error",
+            "test_invalid_name_chars_returns_wp_error",
+            "test_missing_description_returns_wp_error",
+            "test_empty_description_returns_wp_error",
+            "test_non_array_input_schema_returns_wp_error",
+            "test_input_schema_with_non_object_type_returns_wp_error",
+            "test_missing_input_schema_returns_wp_error",
+            "test_context_included_in_error_message",
+            "test_valid_annotations_pass",
+            "test_invalid_annotations_return_wp_error",
+            "test_non_array_annotations_return_wp_error",
+            "test_valid_title_passes",
+            "test_non_string_title_returns_wp_error",
+            "test_non_array_properties_in_schema_returns_error",
+            "test_non_array_property_definition_returns_error",
+            "test_required_field_not_in_properties_returns_error",
+            "test_non_array_required_field_returns_error",
+            "test_stdclass_properties_at_schema_root_is_valid",
+            "test_stdclass_sub_property_value_is_valid"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 260
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\McpToolValidator",
+          "specifiers": [
+            "McpToolValidator"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpToolValidatorTest"
+      ],
+      "totalLines": 270,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php": {
+      "filePath": "tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "contentHash": "f720f46a1875157c5b9662a10fa66914b5024619833264fcc2427cc9de155f3c",
+      "functions": [
+        {
+          "name": "make_tool",
+          "params": [
+            "$output_schema"
+          ],
+          "returnType": "McpTool",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_output_schema_included_in_tool_data",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_output_schema_omitted_when_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_output_schema_getter_setter",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_output_schema_validated_by_tool_validator",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "OutputSchemaPassthroughTest",
+          "methods": [
+            "make_tool",
+            "test_output_schema_included_in_tool_data",
+            "test_output_schema_omitted_when_null",
+            "test_output_schema_getter_setter",
+            "test_output_schema_validated_by_tool_validator"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 71
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Tools\\McpTool",
+          "specifiers": [
+            "McpTool"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "OutputSchemaPassthroughTest"
+      ],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php": {
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "contentHash": "40fe4b85d178f12a0bbaa68db25dabe1fffa25a747ba9c8299f0a55605842a56",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_injects_category_from_ability_when_not_in_annotations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_injects_tier_from_meta_when_not_in_annotations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_injects_bridge_hints_from_meta_when_not_in_annotations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_injects_permission_read_for_readonly_ability",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_injects_permission_write_for_non_readonly_non_destructive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_injects_permission_delete_for_destructive_ability",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_injects_enabled_true_by_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_explicit_category_in_annotations_not_overridden",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_explicit_tier_in_annotations_not_overridden",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_explicit_bridge_hints_in_annotations_not_overridden",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_returns_empty_array_when_ability_has_no_annotations_and_no_category",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpAnnotationMapperBuildTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "test_injects_category_from_ability_when_not_in_annotations",
+            "test_injects_tier_from_meta_when_not_in_annotations",
+            "test_injects_bridge_hints_from_meta_when_not_in_annotations",
+            "test_injects_permission_read_for_readonly_ability",
+            "test_injects_permission_write_for_non_readonly_non_destructive",
+            "test_injects_permission_delete_for_destructive_ability",
+            "test_injects_enabled_true_by_default",
+            "test_explicit_category_in_annotations_not_overridden",
+            "test_explicit_tier_in_annotations_not_overridden",
+            "test_explicit_bridge_hints_in_annotations_not_overridden",
+            "test_returns_empty_array_when_ability_has_no_annotations_and_no_category"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 209
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Admin\\PermissionManager",
+          "specifiers": [
+            "PermissionManager"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpAnnotationMapper",
+          "specifiers": [
+            "McpAnnotationMapper"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpAnnotationMapperBuildTest"
+      ],
+      "totalLines": 225,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Utils/McpAnnotationMapperTest.php": {
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "contentHash": "4ba63f634c31b6bd5a30043146160ad46cfe1d4a136439b0db7080902798e9f8",
+      "functions": [
+        {
+          "name": "test_map_readonly_annotation_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_destructive_annotation_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_idempotent_annotation_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_category_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_tier_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_bridge_hints_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_shared_annotations_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_map_open_world_hint_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_title_for_tool",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_excludes_tool_only_annotations_for_resource",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_map_excludes_tool_only_annotations_for_prompt",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_map_shared_annotations_available_for_resource",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_map_ignores_unknown_annotations",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_map_casts_boolean_from_truthy",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_casts_string_trims_whitespace",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_string_empty_after_trim_excluded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_array_empty_excluded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_number_cast_to_float",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_number_non_numeric_excluded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_map_null_values_excluded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_map_ability_property_overrides_mcp_field",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_map_falls_back_to_mcp_field_name",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpAnnotationMapperTest",
+          "methods": [
+            "test_map_readonly_annotation_for_tool",
+            "test_map_destructive_annotation_for_tool",
+            "test_map_idempotent_annotation_for_tool",
+            "test_map_category_for_tool",
+            "test_map_tier_for_tool",
+            "test_map_bridge_hints_for_tool",
+            "test_map_shared_annotations_for_tool",
+            "test_map_open_world_hint_for_tool",
+            "test_map_title_for_tool",
+            "test_map_excludes_tool_only_annotations_for_resource",
+            "test_map_excludes_tool_only_annotations_for_prompt",
+            "test_map_shared_annotations_available_for_resource",
+            "test_map_ignores_unknown_annotations",
+            "test_map_casts_boolean_from_truthy",
+            "test_map_casts_string_trims_whitespace",
+            "test_map_string_empty_after_trim_excluded",
+            "test_map_array_empty_excluded",
+            "test_map_number_cast_to_float",
+            "test_map_number_non_numeric_excluded",
+            "test_map_null_values_excluded",
+            "test_map_ability_property_overrides_mcp_field",
+            "test_map_falls_back_to_mcp_field_name"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 215
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpAnnotationMapper",
+          "specifiers": [
+            "McpAnnotationMapper"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpAnnotationMapperTest"
+      ],
+      "totalLines": 225,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Utils/McpValidatorTest.php": {
+      "filePath": "tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "contentHash": "aa0b6c4e164f1ec5e8ce16f22885609434eb8f042f9fdedaee3f3a8facfb6141",
+      "functions": [
+        {
+          "name": "test_validate_name_rejects_empty_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_name_rejects_too_long_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_name_accepts_max_length_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_name_accepts_valid_chars",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_name_rejects_spaces",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_name_rejects_special_chars",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_name_respects_custom_max_length",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_tool_or_prompt_name_delegates_with_255_max",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_ability_name_accepts_two_segments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_accepts_three_segments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_accepts_four_segments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_rejects_one_segment",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_rejects_five_segments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_rejects_uppercase",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_rejects_special_chars",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_ability_name_rejects_empty_segments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_ability_name_rejects_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_ability_name_rejects_too_long",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_validate_argument_name_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_argument_name_max_64",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_mime_type_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_mime_type_rejects_invalid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_validate_resource_uri_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_resource_uri_rejects_invalid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_validate_resource_uri_rejects_too_long",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_role_accepts_user_and_assistant",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_role_rejects_invalid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_roles_array_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_roles_array_rejects_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_roles_array_rejects_invalid_role",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_roles_array_rejects_non_string",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_priority_accepts_valid_range",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_validate_priority_rejects_out_of_range",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_priority_rejects_non_numeric",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_iso8601_accepts_utc",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_iso8601_accepts_timezone_offset",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_iso8601_rejects_invalid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_base64_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_base64_rejects_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_image_mime_type_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_validate_image_mime_type_rejects_non_image",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_audio_mime_type_accepts_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_validate_audio_mime_type_rejects_non_audio",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_tool_annotation_errors_empty_for_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_tool_annotation_errors_for_non_bool_hints",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_tool_annotation_errors_for_empty_title",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_tool_annotation_errors_for_non_string_title",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_tool_annotation_errors_ignores_unknown_fields",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_annotation_errors_empty_for_valid",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_annotation_errors_for_non_array_audience",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_annotation_errors_for_empty_audience",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_annotation_errors_for_invalid_roles_in_audience",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_annotation_errors_for_invalid_last_modified",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_annotation_errors_for_empty_last_modified",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_annotation_errors_for_non_numeric_priority",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_annotation_errors_for_out_of_range_priority",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_annotation_errors_ignores_unknown_fields",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpValidatorTest",
+          "methods": [
+            "test_validate_name_rejects_empty_string",
+            "test_validate_name_rejects_too_long_string",
+            "test_validate_name_accepts_max_length_string",
+            "test_validate_name_accepts_valid_chars",
+            "test_validate_name_rejects_spaces",
+            "test_validate_name_rejects_special_chars",
+            "test_validate_name_respects_custom_max_length",
+            "test_validate_tool_or_prompt_name_delegates_with_255_max",
+            "test_validate_ability_name_accepts_two_segments",
+            "test_validate_ability_name_accepts_three_segments",
+            "test_validate_ability_name_accepts_four_segments",
+            "test_validate_ability_name_rejects_one_segment",
+            "test_validate_ability_name_rejects_five_segments",
+            "test_validate_ability_name_rejects_uppercase",
+            "test_validate_ability_name_rejects_special_chars",
+            "test_validate_ability_name_rejects_empty_segments",
+            "test_validate_ability_name_rejects_empty",
+            "test_validate_ability_name_rejects_too_long",
+            "test_validate_argument_name_accepts_valid",
+            "test_validate_argument_name_max_64",
+            "test_validate_mime_type_accepts_valid",
+            "test_validate_mime_type_rejects_invalid",
+            "test_validate_resource_uri_accepts_valid",
+            "test_validate_resource_uri_rejects_invalid",
+            "test_validate_resource_uri_rejects_too_long",
+            "test_validate_role_accepts_user_and_assistant",
+            "test_validate_role_rejects_invalid",
+            "test_validate_roles_array_accepts_valid",
+            "test_validate_roles_array_rejects_empty",
+            "test_validate_roles_array_rejects_invalid_role",
+            "test_validate_roles_array_rejects_non_string",
+            "test_validate_priority_accepts_valid_range",
+            "test_validate_priority_rejects_out_of_range",
+            "test_validate_priority_rejects_non_numeric",
+            "test_validate_iso8601_accepts_utc",
+            "test_validate_iso8601_accepts_timezone_offset",
+            "test_validate_iso8601_rejects_invalid",
+            "test_validate_base64_accepts_valid",
+            "test_validate_base64_rejects_empty",
+            "test_validate_image_mime_type_accepts_valid",
+            "test_validate_image_mime_type_rejects_non_image",
+            "test_validate_audio_mime_type_accepts_valid",
+            "test_validate_audio_mime_type_rejects_non_audio",
+            "test_tool_annotation_errors_empty_for_valid",
+            "test_tool_annotation_errors_for_non_bool_hints",
+            "test_tool_annotation_errors_for_empty_title",
+            "test_tool_annotation_errors_for_non_string_title",
+            "test_tool_annotation_errors_ignores_unknown_fields",
+            "test_annotation_errors_empty_for_valid",
+            "test_annotation_errors_for_non_array_audience",
+            "test_annotation_errors_for_empty_audience",
+            "test_annotation_errors_for_invalid_roles_in_audience",
+            "test_annotation_errors_for_invalid_last_modified",
+            "test_annotation_errors_for_empty_last_modified",
+            "test_annotation_errors_for_non_numeric_priority",
+            "test_annotation_errors_for_out_of_range_priority",
+            "test_annotation_errors_ignores_unknown_fields"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 327
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\McpValidator",
+          "specifiers": [
+            "McpValidator"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpValidatorTest"
+      ],
+      "totalLines": 337,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Domain/Utils/SchemaTransformerTest.php": {
+      "filePath": "tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "contentHash": "a83bc535769d2fa9de143561ce41b05bc6863438e9c507038ec6f2a1db9c65e4",
+      "functions": [
+        {
+          "name": "test_null_schema_returns_minimal_object",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_empty_array_returns_minimal_object",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_object_type_schema_returned_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_string_type_schema_wrapped_in_object",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_array_type_schema_wrapped_in_object",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_custom_wrapper_key",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_schema_without_type_returned_as_is",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_boolean_type_schema_wrapped",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_integer_type_schema_wrapped",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "SchemaTransformerTest",
+          "methods": [
+            "test_null_schema_returns_minimal_object",
+            "test_empty_array_returns_minimal_object",
+            "test_object_type_schema_returned_unchanged",
+            "test_string_type_schema_wrapped_in_object",
+            "test_array_type_schema_wrapped_in_object",
+            "test_custom_wrapper_key",
+            "test_schema_without_type_returned_as_is",
+            "test_boolean_type_schema_wrapped",
+            "test_integer_type_schema_wrapped"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 91
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Utils\\SchemaTransformer",
+          "specifiers": [
+            "SchemaTransformer"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "SchemaTransformerTest"
+      ],
+      "totalLines": 101,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php": {
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "contentHash": "d93c76b6b3d6aa0d131e28fc872af6959e8236c699aa0a00984f8d1b751e74c4",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "make_request",
+          "params": [
+            "$params"
+          ],
+          "returnType": "\\WP_REST_Request",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "install_access_token_meta",
+          "params": [
+            "$client_id"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 58
+        },
+        {
+          "name": "test_correct_client_id_allows_revocation",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_wrong_client_id_silently_succeeds_but_does_not_revoke",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_missing_client_id_silently_succeeds_but_does_not_revoke",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_missing_token_returns_200_immediately",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_unknown_token_silently_succeeds",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "RevokeEndpointClientAuthTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "make_request",
+            "install_access_token_meta",
+            "test_correct_client_id_allows_revocation",
+            "test_wrong_client_id_silently_succeeds_but_does_not_revoke",
+            "test_missing_client_id_silently_succeeds_but_does_not_revoke",
+            "test_missing_token_returns_200_immediately",
+            "test_unknown_token_silently_succeeds"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 175
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\RevokeEndpoint",
+          "specifiers": [
+            "RevokeEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Tests\\TokenResponseSentinel",
+          "specifiers": [
+            "TokenResponseSentinel"
+          ]
+        }
+      ],
+      "exports": [
+        "RevokeEndpointClientAuthTest"
+      ],
+      "totalLines": 206,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php": {
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "contentHash": "7f4cd5158f8b3f6f7bb1fb790cdd931597c041a8d196360886e64f4d45c90211",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "make_request",
+          "params": [
+            "$params"
+          ],
+          "returnType": "\\WP_REST_Request",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "install_null_wpdb",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_first_request_from_ip_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_rate_limit_enforced_when_per_minute_exceeded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_rate_limit_enforced_when_per_hour_exceeded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_successful_revoke_increments_rate_limit_counters",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_revoke_rate_limit_is_separate_from_dcr_rate_limit",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        }
+      ],
+      "classes": [
+        {
+          "name": "RevokeEndpointRateLimitTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "make_request",
+            "install_null_wpdb",
+            "test_first_request_from_ip_is_allowed",
+            "test_rate_limit_enforced_when_per_minute_exceeded",
+            "test_rate_limit_enforced_when_per_hour_exceeded",
+            "test_successful_revoke_increments_rate_limit_counters",
+            "test_revoke_rate_limit_is_separate_from_dcr_rate_limit"
+          ],
+          "properties": [
+            "original_wpdb"
+          ],
+          "exported": true,
+          "lineCount": 128
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\Endpoints\\RevokeEndpoint",
+          "specifiers": [
+            "RevokeEndpoint"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Tests\\TokenResponseSentinel",
+          "specifiers": [
+            "TokenResponseSentinel"
+          ]
+        }
+      ],
+      "exports": [
+        "RevokeEndpointRateLimitTest"
+      ],
+      "totalLines": 151,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Handlers/HandlerHelperTraitTest.php": {
+      "filePath": "tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "contentHash": "d1596c1115aed3e73410c11ca217ac6c0ef6db1b562952eb7767ff33fe0e729f",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_extract_params_with_nested_params",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_extract_params_with_root_params",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_extract_params_prefers_nested_over_root",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_create_error_response_format",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_create_error_response_default_request_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_extract_error_unwraps_factory_response",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_extract_error_returns_as_is_without_error_key",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_create_success_response_format",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_create_success_response_with_scalar",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_create_success_response_with_null",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "HandlerHelperTraitConsumer",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 8
+        },
+        {
+          "name": "HandlerHelperTraitTest",
+          "methods": [
+            "setUp",
+            "test_extract_params_with_nested_params",
+            "test_extract_params_with_root_params",
+            "test_extract_params_prefers_nested_over_root",
+            "test_create_error_response_format",
+            "test_create_error_response_default_request_id",
+            "test_extract_error_unwraps_factory_response",
+            "test_extract_error_returns_as_is_without_error_key",
+            "test_create_success_response_format",
+            "test_create_success_response_with_scalar",
+            "test_create_success_response_with_null"
+          ],
+          "properties": [
+            "helper"
+          ],
+          "exported": true,
+          "lineCount": 121
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\HandlerHelperTrait",
+          "specifiers": [
+            "HandlerHelperTrait"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "HandlerHelperTraitConsumer",
+        "HandlerHelperTraitTest"
+      ],
+      "totalLines": 148,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php": {
+      "filePath": "tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "contentHash": "03b165b6cb98d9bca79b8d655c70b1d830342f43eef8e26d7989816cf8172eed",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "register_writeable_ability",
+          "params": [
+            "$name"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "handler_with_prompt",
+          "params": [
+            "$prompt"
+          ],
+          "returnType": "PromptsHandler",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "set_oauth_request",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_ability_based_oauth_without_scope_denies",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_ability_based_oauth_with_required_scope_runs_execute",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_ability_based_non_oauth_runs_execute",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "builder_prompt",
+          "params": [],
+          "returnType": "McpPrompt",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_builder_oauth_without_baseline_scope_denies",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_builder_oauth_with_baseline_scope_runs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_builder_non_oauth_runs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "PromptsHandlerScopeEnforcementTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "register_writeable_ability",
+            "handler_with_prompt",
+            "set_oauth_request",
+            "test_ability_based_oauth_without_scope_denies",
+            "test_ability_based_oauth_with_required_scope_runs_execute",
+            "test_ability_based_non_oauth_runs_execute",
+            "builder_prompt",
+            "test_builder_oauth_without_baseline_scope_denies",
+            "test_builder_oauth_with_baseline_scope_runs",
+            "test_builder_non_oauth_runs"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 139
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Prompts\\McpPrompt",
+          "specifiers": [
+            "McpPrompt"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Prompts\\PromptsHandler",
+          "specifiers": [
+            "PromptsHandler"
+          ]
+        }
+      ],
+      "exports": [
+        "PromptsHandlerScopeEnforcementTest"
+      ],
+      "totalLines": 162,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php": {
+      "filePath": "tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "contentHash": "33a6b345487ff708fbbcf381c5fcffb4da8bdefbe28cbd845b757b9eefefe39a",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "register_writeable_ability",
+          "params": [
+            "$name"
+          ],
+          "returnType": "object",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "handler_with_resource",
+          "params": [
+            "$resource"
+          ],
+          "returnType": "ResourcesHandler",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "set_oauth_request",
+          "params": [
+            "$scopes"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_oauth_request_without_required_scope_denies_with_insufficient_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_non_oauth_request_runs_execute_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_oauth_request_with_required_scope_proceeds_to_execute",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResourcesHandlerScopeEnforcementTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "register_writeable_ability",
+            "handler_with_resource",
+            "set_oauth_request",
+            "test_oauth_request_without_required_scope_denies_with_insufficient_scope",
+            "test_non_oauth_request_runs_execute_unchanged",
+            "test_oauth_request_with_required_scope_proceeds_to_execute"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 96
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Core\\McpServer",
+          "specifiers": [
+            "McpServer"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Domain\\Resources\\McpResource",
+          "specifiers": [
+            "McpResource"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Handlers\\Resources\\ResourcesHandler",
+          "specifiers": [
+            "ResourcesHandler"
+          ]
+        }
+      ],
+      "exports": [
+        "ResourcesHandlerScopeEnforcementTest"
+      ],
+      "totalLines": 120,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php": {
+      "filePath": "tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "contentHash": "2349f68f291a9a0c6da454b0f187e6d01d1f1b2beffb99b233ec7ec3056cae66",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "render_permission_failure",
+          "params": [
+            "$wp_error"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "register_ability",
+          "params": [
+            "$name",
+            "$meta"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_execute_ability_bad_name_renders_not_found_not_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_get_ability_info_bad_name_renders_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_exists_but_not_public_renders_not_exposed_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_genuine_permission_denial_keeps_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_inner_scope_denial_carries_insufficient_scope_reason",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 33
+        }
+      ],
+      "classes": [
+        {
+          "name": "PermissionErrorRemediationTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "render_permission_failure",
+            "register_ability",
+            "test_execute_ability_bad_name_renders_not_found_not_permission_denied",
+            "test_get_ability_info_bad_name_renders_not_found",
+            "test_exists_but_not_public_renders_not_exposed_permission_denied",
+            "test_genuine_permission_denial_keeps_permission_denied",
+            "test_inner_scope_denial_carries_insufficient_scope_reason"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 134
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\ExecuteAbilityAbility",
+          "specifiers": [
+            "ExecuteAbilityAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Abilities\\GetAbilityInfoAbility",
+          "specifiers": [
+            "GetAbilityInfoAbility"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Auth\\OAuth\\OAuthRequestContext",
+          "specifiers": [
+            "OAuthRequestContext"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorMapper",
+          "specifiers": [
+            "McpErrorMapper"
+          ]
+        }
+      ],
+      "exports": [
+        "PermissionErrorRemediationTest"
+      ],
+      "totalLines": 167,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php": {
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "contentHash": "6dcde6d23de1647e0895538da6e545b0b0a76f0feb622eac1ba6953d519a84a0",
+      "functions": [
+        {
+          "name": "test_error_code_constants_have_expected_values",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_create_error_response_structure",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_create_error_response_with_data",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_create_error_response_with_null_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_create_error_response_with_string_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_parse_error_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_parse_error_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_invalid_request_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_invalid_request_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_method_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_invalid_params_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_invalid_params_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_internal_error_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_internal_error_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_mcp_disabled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_validation_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_missing_parameter",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_resource_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_tool_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_ability_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_prompt_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_permission_denied_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_permission_denied_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_unauthorized_without_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_unauthorized_with_details",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_parse_error_maps_to_400",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_invalid_request_maps_to_400",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unauthorized_maps_to_401",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_permission_denied_maps_to_403",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_not_found_errors_map_to_404",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_server_errors_map_to_500",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_timeout_maps_to_504",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_rate_limited_maps_to_429",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_rate_limited_factory_carries_data_payload",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_invalid_params_maps_to_200",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unknown_code_maps_to_200",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_get_http_status_for_error_extracts_code",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_get_http_status_for_error_missing_code_returns_500",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_valid_request_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_valid_notification_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_valid_response_message",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_non_array_message_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_missing_jsonrpc_field_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_wrong_jsonrpc_version_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_message_without_method_or_result_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_response_without_id_returns_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpErrorFactoryTest",
+          "methods": [
+            "test_error_code_constants_have_expected_values",
+            "test_create_error_response_structure",
+            "test_create_error_response_with_data",
+            "test_create_error_response_with_null_id",
+            "test_create_error_response_with_string_id",
+            "test_parse_error_without_details",
+            "test_parse_error_with_details",
+            "test_invalid_request_without_details",
+            "test_invalid_request_with_details",
+            "test_method_not_found",
+            "test_invalid_params_without_details",
+            "test_invalid_params_with_details",
+            "test_internal_error_without_details",
+            "test_internal_error_with_details",
+            "test_mcp_disabled",
+            "test_validation_error",
+            "test_missing_parameter",
+            "test_resource_not_found",
+            "test_tool_not_found",
+            "test_ability_not_found",
+            "test_prompt_not_found",
+            "test_permission_denied_without_details",
+            "test_permission_denied_with_details",
+            "test_unauthorized_without_details",
+            "test_unauthorized_with_details",
+            "test_parse_error_maps_to_400",
+            "test_invalid_request_maps_to_400",
+            "test_unauthorized_maps_to_401",
+            "test_permission_denied_maps_to_403",
+            "test_not_found_errors_map_to_404",
+            "test_server_errors_map_to_500",
+            "test_timeout_maps_to_504",
+            "test_rate_limited_maps_to_429",
+            "test_rate_limited_factory_carries_data_payload",
+            "test_invalid_params_maps_to_200",
+            "test_unknown_code_maps_to_200",
+            "test_get_http_status_for_error_extracts_code",
+            "test_get_http_status_for_error_missing_code_returns_500",
+            "test_valid_request_message",
+            "test_valid_notification_message",
+            "test_valid_response_message",
+            "test_non_array_message_returns_error",
+            "test_missing_jsonrpc_field_returns_error",
+            "test_wrong_jsonrpc_version_returns_error",
+            "test_message_without_method_or_result_returns_error",
+            "test_response_without_id_returns_error"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 338
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpErrorFactoryTest"
+      ],
+      "totalLines": 348,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php": {
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "contentHash": "d6a2522c2470635fd74c0a622d42b079694f77a9a1d4c7e2fe63d40bd686d40c",
+      "functions": [
+        {
+          "name": "test_map_rest_forbidden_to_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_rest_unauthorized_to_unauthorized",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_rest_no_route_to_method_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_rest_invalid_param_to_invalid_params",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_ability_not_found_to_tool_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_ability_invalid_permissions_to_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_ability_not_public_mcp_to_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_map_ability_invalid_input_to_invalid_params",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_ability_missing_input_schema_to_internal_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_forbidden_to_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_map_not_found_to_resource_not_found",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unknown_code_defaults_to_internal_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_unknown_code_with_custom_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_from_wp_error_creates_proper_response",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_from_wp_error_with_data",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_from_wp_error_with_null_id",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_from_wp_error_unknown_code_uses_internal_error",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_from_wp_error_without_data_omits_data_key",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_permission_default_keeps_unmapped_code_at_permission_denied",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_permission_default_does_not_override_explicit_not_found_mapping",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_permission_default_maps_not_public_to_permission_denied_with_reason",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "McpErrorMapperTest",
+          "methods": [
+            "test_map_rest_forbidden_to_permission_denied",
+            "test_map_rest_unauthorized_to_unauthorized",
+            "test_map_rest_no_route_to_method_not_found",
+            "test_map_rest_invalid_param_to_invalid_params",
+            "test_map_ability_not_found_to_tool_not_found",
+            "test_map_ability_invalid_permissions_to_permission_denied",
+            "test_map_ability_not_public_mcp_to_permission_denied",
+            "test_map_ability_invalid_input_to_invalid_params",
+            "test_map_ability_missing_input_schema_to_internal_error",
+            "test_map_forbidden_to_permission_denied",
+            "test_map_not_found_to_resource_not_found",
+            "test_unknown_code_defaults_to_internal_error",
+            "test_unknown_code_with_custom_default",
+            "test_from_wp_error_creates_proper_response",
+            "test_from_wp_error_with_data",
+            "test_from_wp_error_with_null_id",
+            "test_from_wp_error_unknown_code_uses_internal_error",
+            "test_from_wp_error_without_data_omits_data_key",
+            "test_permission_default_keeps_unmapped_code_at_permission_denied",
+            "test_permission_default_does_not_override_explicit_not_found_mapping",
+            "test_permission_default_maps_not_public_to_permission_denied_with_reason"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 149
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorFactory",
+          "specifiers": [
+            "McpErrorFactory"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\ErrorHandling\\McpErrorMapper",
+          "specifiers": [
+            "McpErrorMapper"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "McpErrorMapperTest"
+      ],
+      "totalLines": 160,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "contentHash": "10a69ba1aecc5d898f7929c67ca3b838eaf90ed35095f6ba930e3c5d12c5f5d1",
+      "functions": [
+        {
+          "name": "test_raw_api_key_is_dropped_from_sanitized_tags",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_raw_api_key_is_replaced_with_sha256_hash",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_explicit_api_key_hash_wins_over_derived",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_empty_api_key_does_not_produce_hash",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_non_string_api_key_does_not_produce_hash",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_other_allowlisted_tags_pass_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_unknown_tags_still_dropped",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "BoundaryEventEmitterTest",
+          "methods": [
+            "test_raw_api_key_is_dropped_from_sanitized_tags",
+            "test_raw_api_key_is_replaced_with_sha256_hash",
+            "test_explicit_api_key_hash_wins_over_derived",
+            "test_empty_api_key_does_not_produce_hash",
+            "test_non_string_api_key_does_not_produce_hash",
+            "test_other_allowlisted_tags_pass_through",
+            "test_unknown_tags_still_dropped"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 67
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Observability\\BoundaryEventEmitter",
+          "specifiers": [
+            "BoundaryEventEmitter"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "BoundaryEventEmitterTest"
+      ],
+      "totalLines": 82,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "contentHash": "29f63764760e77cdc406aa70ab2f018c99e1c6947b69a61372f4ef957aa46529",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "emailFamilyVariantProvider",
+          "params": [],
+          "returnType": "iterable",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "test_email_family_variant_redacts_under_default_settings",
+          "params": [
+            "$field",
+            "$value"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_negative_control_master_off_passes_email_family_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_negative_control_per_ability_exempt_passes_email_family_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_email_family_redacts_under_meta_list_post_meta_path",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_token_match_does_not_match_unrelated_substrings",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_blog_body_with_email_word_in_text_still_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_email_family_redaction_increments_bucket3_counter",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_cold_ai_replay_multisite_get_site_admin_email_redacts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_cold_ai_replay_comments_list_author_email_redacts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_cold_ai_replay_settings_list_admin_email_redacts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_cold_ai_replay_get_network_settings_admin_email_redacts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "Bucket3EmailFamilyTest",
+          "methods": [
+            "set_up",
+            "emailFamilyVariantProvider",
+            "test_email_family_variant_redacts_under_default_settings",
+            "test_negative_control_master_off_passes_email_family_through",
+            "test_negative_control_per_ability_exempt_passes_email_family_through",
+            "test_email_family_redacts_under_meta_list_post_meta_path",
+            "test_token_match_does_not_match_unrelated_substrings",
+            "test_blog_body_with_email_word_in_text_still_passes_through",
+            "test_email_family_redaction_increments_bucket3_counter",
+            "test_cold_ai_replay_multisite_get_site_admin_email_redacts",
+            "test_cold_ai_replay_comments_list_author_email_redacts",
+            "test_cold_ai_replay_settings_list_admin_email_redacts",
+            "test_cold_ai_replay_get_network_settings_admin_email_redacts"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 236
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionConfig",
+          "specifiers": [
+            "RedactionConfig"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactor",
+          "specifiers": [
+            "ResponseRedactor"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "Bucket3EmailFamilyTest"
+      ],
+      "totalLines": 258,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "contentHash": "8bc8c148cb54b88a5a7facc80e84fa787ce8ee82cc5428c79742f91d3bd57936",
+      "functions": [
+        {
+          "name": "test_password_hash_phpass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_password_hash_bcrypt",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_password_hash_modern",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_password_hash_negatives",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_known_api_key_stripe",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_known_api_key_slack",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_known_api_key_github",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_known_api_key_aws",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_known_api_key_google",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_known_api_key_negatives",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_luhn_valid_test_pans",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_luhn_invalid_inputs",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_luhn_minimum_length_13",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "PatternMatchersTest",
+          "methods": [
+            "test_password_hash_phpass",
+            "test_password_hash_bcrypt",
+            "test_password_hash_modern",
+            "test_password_hash_negatives",
+            "test_known_api_key_stripe",
+            "test_known_api_key_slack",
+            "test_known_api_key_github",
+            "test_known_api_key_aws",
+            "test_known_api_key_google",
+            "test_known_api_key_negatives",
+            "test_luhn_valid_test_pans",
+            "test_luhn_invalid_inputs",
+            "test_luhn_minimum_length_13"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 98
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\PatternMatchers",
+          "specifiers": [
+            "PatternMatchers"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "PatternMatchersTest"
+      ],
+      "totalLines": 108,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "contentHash": "ed0417d065bbe36adb4b520c62b1bde126641a6970c6ffb183d0af359ed0fc49",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_master_enabled_default_true",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_master_enabled_can_be_turned_off",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_bucket1_keywords_include_credentials",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_bucket3_default_includes_public_key",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_bucket3_keywords_merges_custom_additions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_ability_exemption_bucket1_never_exempt",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_ability_exemption_bucket3",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_ability_exemption_bucket2_independent_of_bucket3",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [
+        {
+          "name": "RedactionConfigTest",
+          "methods": [
+            "set_up",
+            "test_master_enabled_default_true",
+            "test_master_enabled_can_be_turned_off",
+            "test_bucket1_keywords_include_credentials",
+            "test_bucket3_default_includes_public_key",
+            "test_bucket3_keywords_merges_custom_additions",
+            "test_ability_exemption_bucket1_never_exempt",
+            "test_ability_exemption_bucket3",
+            "test_ability_exemption_bucket2_independent_of_bucket3"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 67
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionConfig",
+          "specifiers": [
+            "RedactionConfig"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "RedactionConfigTest"
+      ],
+      "totalLines": 77,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "contentHash": "2b63174dbabcf74b137f0ce950c17f8adb0685c98c6b14c5e98d771ff77d441e",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "register_ability",
+          "params": [
+            "$slash_name"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "customer_response",
+          "params": [],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_direct_tools_call_redacts_when_no_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_direct_tools_call_skips_bucket3_when_ability_exempt",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_execute_ability_wrapper_redacts_when_no_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_execute_ability_wrapper_honours_inner_ability_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "test_execute_ability_wrapper_with_other_ability_does_not_borrow_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "test_execute_ability_wrapper_missing_ability_name_redacts_normally",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_batch_execute_does_not_apply_per_ability_exemptions",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "test_unexempting_clears_correctly",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_bucket3_exemption_does_not_affect_bucket1_redaction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "test_non_tools_call_methods_have_no_ability_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_protocol_error_envelope_is_not_redacted",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_round2_dash_form_meta_tool_unwraps_inner_ability",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "test_round2_dash_form_batch_execute_returns_null_scope",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "test_round2_direct_call_dash_form_translates_to_slash_for_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_round2_unregistered_dash_name_falls_back_safely",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_round2_translator_returns_slash_input_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_round2_translator_maps_dash_to_slash_when_registered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_round2_translator_returns_input_when_unregistered",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_round2_translator_handles_nested_namespaces",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_round2_translator_first_write_wins_on_dash_collision",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_round2_dash_form_cross_bucket_safety_preserved",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "tools_call_response",
+          "params": [
+            "$result_payload"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_text_channel_dual_channel_text_regenerates_from_redacted_structured",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "test_text_channel_via_execute_ability_meta_tool_dash_form",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "test_text_channel_exemption_passes_email_through_both_channels",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "test_text_channel_image_response_untouched",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "test_text_channel_text_only_response_decoded_redacted_re_encoded",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "test_text_channel_plain_string_text_left_alone",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "test_text_channel_multiple_text_parts_all_regenerate",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "test_text_channel_non_tools_call_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_text_channel_response_without_content_unchanged",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_text_channel_metadata_preserved_through_reconciliation",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 22
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResponseRedactionGateTest",
+          "methods": [
+            "set_up",
+            "register_ability",
+            "customer_response",
+            "test_direct_tools_call_redacts_when_no_exemption",
+            "test_direct_tools_call_skips_bucket3_when_ability_exempt",
+            "test_execute_ability_wrapper_redacts_when_no_exemption",
+            "test_execute_ability_wrapper_honours_inner_ability_exemption",
+            "test_execute_ability_wrapper_with_other_ability_does_not_borrow_exemption",
+            "test_execute_ability_wrapper_missing_ability_name_redacts_normally",
+            "test_batch_execute_does_not_apply_per_ability_exemptions",
+            "test_unexempting_clears_correctly",
+            "test_bucket3_exemption_does_not_affect_bucket1_redaction",
+            "test_non_tools_call_methods_have_no_ability_scope",
+            "test_protocol_error_envelope_is_not_redacted",
+            "test_round2_dash_form_meta_tool_unwraps_inner_ability",
+            "test_round2_dash_form_batch_execute_returns_null_scope",
+            "test_round2_direct_call_dash_form_translates_to_slash_for_exemption",
+            "test_round2_unregistered_dash_name_falls_back_safely",
+            "test_round2_translator_returns_slash_input_unchanged",
+            "test_round2_translator_maps_dash_to_slash_when_registered",
+            "test_round2_translator_returns_input_when_unregistered",
+            "test_round2_translator_handles_nested_namespaces",
+            "test_round2_translator_first_write_wins_on_dash_collision",
+            "test_round2_dash_form_cross_bucket_safety_preserved",
+            "tools_call_response",
+            "test_text_channel_dual_channel_text_regenerates_from_redacted_structured",
+            "test_text_channel_via_execute_ability_meta_tool_dash_form",
+            "test_text_channel_exemption_passes_email_through_both_channels",
+            "test_text_channel_image_response_untouched",
+            "test_text_channel_text_only_response_decoded_redacted_re_encoded",
+            "test_text_channel_plain_string_text_left_alone",
+            "test_text_channel_multiple_text_parts_all_regenerate",
+            "test_text_channel_non_tools_call_unchanged",
+            "test_text_channel_response_without_content_unchanged",
+            "test_text_channel_metadata_preserved_through_reconciliation"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 760
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactionGate",
+          "specifiers": [
+            "ResponseRedactionGate"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "ResponseRedactionGateTest"
+      ],
+      "totalLines": 781,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "contentHash": "2766fdc3d4624ec093829ead20df2cd4c50ab98311dc9bff5b42c4e515798581",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_users_list_default_redacts_email_and_user_login",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_fluent_cart_list_customers_redacts_email_passes_lifetime_value",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_user_meta_redacts_session_tokens_and_user_pass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_master_toggle_off_keeps_bucket_1_active_and_passes_bucket_3",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_per_ability_bucket3_exemption_unblocks_email_keeps_bucket2",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_string_email_redacts_to_scalar_string_marker",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_object_address_redacts_to_object_marker",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_array_of_phones_redacts_to_single_element_array",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_custom_keyword_added_to_bucket3_list",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_type_detection_handles_six_type_cases",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "test_recursive_traversal_through_nested_arrays",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_max_nodes_guard_throws",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_max_depth_guard_throws",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_pattern_matcher_only_runs_on_scalar_strings",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "test_case_insensitive_field_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_no_regex_over_full_json_document",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_meta_key_field_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_cache_key_field_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_blog_post_body_with_word_password_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_comment_body_with_email_in_text_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_bucket1_cannot_be_disabled_via_master_toggle",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_bucket1_cannot_be_disabled_via_per_ability_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_counts_reflect_redactions_per_bucket",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        }
+      ],
+      "classes": [
+        {
+          "name": "ResponseRedactorTest",
+          "methods": [
+            "set_up",
+            "test_users_list_default_redacts_email_and_user_login",
+            "test_fluent_cart_list_customers_redacts_email_passes_lifetime_value",
+            "test_user_meta_redacts_session_tokens_and_user_pass",
+            "test_master_toggle_off_keeps_bucket_1_active_and_passes_bucket_3",
+            "test_per_ability_bucket3_exemption_unblocks_email_keeps_bucket2",
+            "test_string_email_redacts_to_scalar_string_marker",
+            "test_object_address_redacts_to_object_marker",
+            "test_array_of_phones_redacts_to_single_element_array",
+            "test_custom_keyword_added_to_bucket3_list",
+            "test_type_detection_handles_six_type_cases",
+            "test_recursive_traversal_through_nested_arrays",
+            "test_max_nodes_guard_throws",
+            "test_max_depth_guard_throws",
+            "test_pattern_matcher_only_runs_on_scalar_strings",
+            "test_case_insensitive_field_match",
+            "test_no_regex_over_full_json_document",
+            "test_meta_key_field_passes_through",
+            "test_cache_key_field_passes_through",
+            "test_blog_post_body_with_word_password_passes_through",
+            "test_comment_body_with_email_in_text_passes_through",
+            "test_bucket1_cannot_be_disabled_via_master_toggle",
+            "test_bucket1_cannot_be_disabled_via_per_ability_exemption",
+            "test_counts_reflect_redactions_per_bucket"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 333
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionConfig",
+          "specifiers": [
+            "RedactionConfig"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionLimitExceeded",
+          "specifiers": [
+            "RedactionLimitExceeded"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactor",
+          "specifiers": [
+            "ResponseRedactor"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "ResponseRedactorTest"
+      ],
+      "totalLines": 345,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "contentHash": "a4eb01118b9b7f45e69a79592993b09515e6e4b56220a4a8c6a593b221350ee4",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "ability_info_response",
+          "params": [
+            "$name",
+            "$properties"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "test_users_create_input_schema_username_email_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_users_update_input_schema_email_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_comments_create_input_schema_author_email_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_multisite_create_site_input_schema_admin_email_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_users_create_app_password_schema_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_output_schema_subtree_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "test_users_list_data_payload_email_still_redacts",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_meta_list_post_meta_with_input_schema_named_meta_value_does_not_bypass_redaction",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "test_no_ability_name_disables_schema_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_bucket1_secrets_inside_schema_subtree_still_redact",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "test_max_nodes_guard_still_fires_on_oversized_schema",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_max_depth_guard_still_fires_on_deeply_nested_schema",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_schema_subtree_does_not_increment_redaction_counters",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        }
+      ],
+      "classes": [
+        {
+          "name": "SchemaPathExemptionTest",
+          "methods": [
+            "set_up",
+            "ability_info_response",
+            "test_users_create_input_schema_username_email_passes_through",
+            "test_users_update_input_schema_email_passes_through",
+            "test_comments_create_input_schema_author_email_passes_through",
+            "test_multisite_create_site_input_schema_admin_email_passes_through",
+            "test_users_create_app_password_schema_passes_through",
+            "test_output_schema_subtree_passes_through",
+            "test_users_list_data_payload_email_still_redacts",
+            "test_meta_list_post_meta_with_input_schema_named_meta_value_does_not_bypass_redaction",
+            "test_no_ability_name_disables_schema_exemption",
+            "test_bucket1_secrets_inside_schema_subtree_still_redact",
+            "test_max_nodes_guard_still_fires_on_oversized_schema",
+            "test_max_depth_guard_still_fires_on_deeply_nested_schema",
+            "test_schema_subtree_does_not_increment_redaction_counters"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 279
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionLimitExceeded",
+          "specifiers": [
+            "RedactionLimitExceeded"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactor",
+          "specifiers": [
+            "ResponseRedactor"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "SchemaPathExemptionTest"
+      ],
+      "totalLines": 302,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php": {
+      "filePath": "tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "contentHash": "d8c507faf021079fe49fab56b64bfe5ff418aaa29956b8aee3e26a985f62f519",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "tools_list_response",
+          "params": [
+            "$tools"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_tools_list_pii_keyed_property_schema_passes_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "test_tools_list_input_and_output_schema_pass_through_for_all_known_pii_property_families",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "test_tools_list_all_variant_also_passes_schemas_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "test_tools_list_clean_payload_remains_clean",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "test_tools_list_redaction_counts_stay_zero_on_schema_payload",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "test_negative_control_tools_call_users_list_still_redacts_email",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 34
+        },
+        {
+          "name": "test_negative_control_other_method_does_not_inherit_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "test_negative_control_runtime_payload_with_inputSchema_named_key_does_not_bypass",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "test_redactor_constructed_with_tools_list_method_activates_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "test_redactor_constructed_with_unrelated_method_does_not_activate_exemption",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_redactor_with_null_method_preserves_pre_113_behaviour",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "test_max_nodes_guard_still_fires_on_oversized_tools_list_payload",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 16
+        }
+      ],
+      "classes": [
+        {
+          "name": "ToolsListSchemaExemptionTest",
+          "methods": [
+            "set_up",
+            "tools_list_response",
+            "test_tools_list_pii_keyed_property_schema_passes_through",
+            "test_tools_list_input_and_output_schema_pass_through_for_all_known_pii_property_families",
+            "test_tools_list_all_variant_also_passes_schemas_through",
+            "test_tools_list_clean_payload_remains_clean",
+            "test_tools_list_redaction_counts_stay_zero_on_schema_payload",
+            "test_negative_control_tools_call_users_list_still_redacts_email",
+            "test_negative_control_other_method_does_not_inherit_exemption",
+            "test_negative_control_runtime_payload_with_inputSchema_named_key_does_not_bypass",
+            "test_redactor_constructed_with_tools_list_method_activates_exemption",
+            "test_redactor_constructed_with_unrelated_method_does_not_activate_exemption",
+            "test_redactor_with_null_method_preserves_pre_113_behaviour",
+            "test_max_nodes_guard_still_fires_on_oversized_tools_list_payload"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 364
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\RedactionLimitExceeded",
+          "specifiers": [
+            "RedactionLimitExceeded"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactionGate",
+          "specifiers": [
+            "ResponseRedactionGate"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Infrastructure\\Redaction\\ResponseRedactor",
+          "specifiers": [
+            "ResponseRedactor"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "ToolsListSchemaExemptionTest"
+      ],
+      "totalLines": 394,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/RateLimit/BurstHarnessTest.php": {
+      "filePath": "tests/Unit/RateLimit/BurstHarnessTest.php",
+      "contentHash": "300cda22bfd20537b79e25722ebf9c3afa0f9720e678afe78d1dcdde26d0ff8c",
+      "functions": [
+        {
+          "name": "test_parse_response_extracts_status_headers_and_body",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_parse_response_lowercases_header_names",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_parse_response_skips_100_continue",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_parse_response_preserves_body_with_blank_lines",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_extract_session_pulls_id_and_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_extract_session_returns_nulls_when_headers_absent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_merge_session_prefers_observed_over_current",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_merge_session_keeps_current_when_observed_omits_value",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "ok",
+          "params": [
+            "$count"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "denied",
+          "params": [
+            "$count",
+            "$retry"
+          ],
+          "returnType": "array",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_classify_clean_trip_at_threshold_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_classify_no_trip_fails",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_classify_premature_trip_fails",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_classify_429_without_retry_after_fails",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_classify_initialize_threshold_30_passes",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_build_tools_call_body_is_valid_jsonrpc",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_build_initialize_body_is_valid_jsonrpc",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "BurstHarnessTest",
+          "methods": [
+            "test_parse_response_extracts_status_headers_and_body",
+            "test_parse_response_lowercases_header_names",
+            "test_parse_response_skips_100_continue",
+            "test_parse_response_preserves_body_with_blank_lines",
+            "test_extract_session_pulls_id_and_token",
+            "test_extract_session_returns_nulls_when_headers_absent",
+            "test_merge_session_prefers_observed_over_current",
+            "test_merge_session_keeps_current_when_observed_omits_value",
+            "ok",
+            "denied",
+            "test_classify_clean_trip_at_threshold_passes",
+            "test_classify_no_trip_fails",
+            "test_classify_premature_trip_fails",
+            "test_classify_429_without_retry_after_fails",
+            "test_classify_initialize_threshold_30_passes",
+            "test_build_tools_call_body_is_valid_jsonrpc",
+            "test_build_initialize_body_is_valid_jsonrpc"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 168
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\BurstHarness",
+          "specifiers": [
+            "BurstHarness"
+          ]
+        }
+      ],
+      "exports": [
+        "BurstHarnessTest"
+      ],
+      "totalLines": 188,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/RateLimit/CounterStoreTest.php": {
+      "filePath": "tests/Unit/RateLimit/CounterStoreTest.php",
+      "contentHash": "144f3ad481b0f28330f04c115deb5616e49af4b80a6786fb858597da6120969d",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_transient_backend_increments",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_object_cache_backend_used_when_external_cache_present",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_object_cache_falls_back_when_no_external_cache",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "CounterStoreTest",
+          "methods": [
+            "set_up",
+            "test_transient_backend_increments",
+            "test_object_cache_backend_used_when_external_cache_present",
+            "test_object_cache_falls_back_when_no_external_cache"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 31
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\CounterStore",
+          "specifiers": [
+            "CounterStore"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "CounterStoreTest"
+      ],
+      "totalLines": 44,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/RateLimit/RateLimiterTest.php": {
+      "filePath": "tests/Unit/RateLimit/RateLimiterTest.php",
+      "contentHash": "97782551013a89f3bb88ac54ea5725fd14037d959f5b3eeddc92c4719eaccab1",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "make_limiter",
+          "params": [],
+          "returnType": "RateLimiter",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_61st_request_from_one_ip_returns_deny",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_two_ips_each_50_both_succeed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_one_user_two_ips_trips_user_window",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "test_per_site_keys_are_independent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_filter_allow_short_circuits_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_filter_deny_short_circuits_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_filter_returning_null_falls_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_filter_lowers_ip_limit",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_empty_ip_skips_ip_window",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_knowledge_layer_initial_read_does_not_trip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_initialize_window_denies_31st_request",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "test_initialize_window_isolated_from_main_ip_window",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_initialize_window_per_ip_isolated",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_initialize_filter_lowers_limit",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_initialize_request_filter_can_override",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_initialize_with_empty_ip_allows_through",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "RateLimiterTest",
+          "methods": [
+            "set_up",
+            "make_limiter",
+            "test_61st_request_from_one_ip_returns_deny",
+            "test_two_ips_each_50_both_succeed",
+            "test_one_user_two_ips_trips_user_window",
+            "test_per_site_keys_are_independent",
+            "test_filter_allow_short_circuits_default",
+            "test_filter_deny_short_circuits_default",
+            "test_filter_returning_null_falls_through",
+            "test_filter_lowers_ip_limit",
+            "test_empty_ip_skips_ip_window",
+            "test_knowledge_layer_initial_read_does_not_trip",
+            "test_initialize_window_denies_31st_request",
+            "test_initialize_window_isolated_from_main_ip_window",
+            "test_initialize_window_per_ip_isolated",
+            "test_initialize_filter_lowers_limit",
+            "test_initialize_request_filter_can_override",
+            "test_initialize_with_empty_ip_allows_through"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 201
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\CounterStore",
+          "specifiers": [
+            "CounterStore"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\RateLimiter",
+          "specifiers": [
+            "RateLimiter"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "RateLimiterTest"
+      ],
+      "totalLines": 215,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/RateLimit/TrustedProxyResolverTest.php": {
+      "filePath": "tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "contentHash": "fe6137b32c9ce49d7dcdcd5f762971d7e75501bd224321edf53e3173917cd140",
+      "functions": [
+        {
+          "name": "set_up",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_default_falls_back_to_remote_addr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_default_ignores_cf_connecting_ip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_cloudflare_preset_honors_cf_header_when_remote_addr_is_cloudflare",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_cloudflare_preset_ignores_cf_header_when_remote_addr_is_not_cloudflare",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_custom_allowlist_honors_xff_when_remote_addr_matches",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_custom_allowlist_ignores_xff_when_remote_addr_does_not_match",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_invalid_remote_addr_returns_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_loopback_treated_as_normal",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_ip_in_cidr_v4",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_ip_in_cidr_v6",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_ip_in_cidr_bare_ip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_ip_in_cidr_address_family_mismatch",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_is_valid_cidr",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_truncate_ipv4",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_truncate_ipv6",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_truncate_invalid_returns_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_cloudflare_ips_populate_from_bundled_on_first_call",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_settings_round_trip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "TrustedProxyResolverTest",
+          "methods": [
+            "set_up",
+            "test_default_falls_back_to_remote_addr",
+            "test_default_ignores_cf_connecting_ip",
+            "test_cloudflare_preset_honors_cf_header_when_remote_addr_is_cloudflare",
+            "test_cloudflare_preset_ignores_cf_header_when_remote_addr_is_not_cloudflare",
+            "test_custom_allowlist_honors_xff_when_remote_addr_matches",
+            "test_custom_allowlist_ignores_xff_when_remote_addr_does_not_match",
+            "test_invalid_remote_addr_returns_empty",
+            "test_loopback_treated_as_normal",
+            "test_ip_in_cidr_v4",
+            "test_ip_in_cidr_v6",
+            "test_ip_in_cidr_bare_ip",
+            "test_ip_in_cidr_address_family_mismatch",
+            "test_is_valid_cidr",
+            "test_truncate_ipv4",
+            "test_truncate_ipv6",
+            "test_truncate_invalid_returns_empty",
+            "test_cloudflare_ips_populate_from_bundled_on_first_call",
+            "test_settings_round_trip"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 162
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\RateLimit\\TrustedProxyResolver",
+          "specifiers": [
+            "TrustedProxyResolver"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "TrustedProxyResolverTest"
+      ],
+      "totalLines": 175,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Servers/DefaultServerFactoryBootContractTest.php": {
+      "filePath": "tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "contentHash": "4c84e8088b375034ce14441147674d24d58f045637c4efb706ee0d7deaa059a1",
+      "functions": [
+        {
+          "name": "factory_source",
+          "params": [],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_advertised_boot_first_tool_is_in_the_tools_allowlist",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 29
+        }
+      ],
+      "classes": [
+        {
+          "name": "DefaultServerFactoryBootContractTest",
+          "methods": [
+            "factory_source",
+            "test_advertised_boot_first_tool_is_in_the_tools_allowlist"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 38
+        }
+      ],
+      "imports": [
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "DefaultServerFactoryBootContractTest"
+      ],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Settings/ConfirmationTokenStoreTest.php": {
+      "filePath": "tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "contentHash": "8133da2506658e3b239ce410d662d12c87b08bc7caed183be81b32966f764aa2",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_mint_returns_non_empty_token",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_consume_valid_token_succeeds",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_token_is_one_time",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "test_missing_token_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_session_mismatch_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_ability_mismatch_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_params_mismatch_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_failed_lookup_invalidates_token_anyway",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "ConfirmationTokenStoreTest",
+          "methods": [
+            "setUp",
+            "test_mint_returns_non_empty_token",
+            "test_consume_valid_token_succeeds",
+            "test_token_is_one_time",
+            "test_missing_token_rejected",
+            "test_session_mismatch_rejected",
+            "test_ability_mismatch_rejected",
+            "test_params_mismatch_rejected",
+            "test_failed_lookup_invalidates_token_anyway"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 78
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\ConfirmationTokenStore",
+          "specifiers": [
+            "ConfirmationTokenStore"
+          ]
+        }
+      ],
+      "exports": [
+        "ConfirmationTokenStoreTest"
+      ],
+      "totalLines": 93,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Settings/SafetySettingsRepositoryTest.php": {
+      "filePath": "tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "contentHash": "872da0d51b299dc597332923ad18d263db6d3c3e0fee570344d3ad818bd2974b",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_master_toggle_default_on",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_master_toggle_can_be_disabled_then_re_enabled",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_bucket1_keywords_are_hardcoded_and_non_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_add_custom_bucket3_keyword",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_add_custom_bucket2_keyword",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_cannot_add_keyword_to_bucket1",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_invalid_bucket_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_empty_keyword_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_remove_custom_keyword_returns_false_for_unknown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_remove_custom_keyword_removes_added_entry",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_remove_default_bucket3_keyword_marks_as_removed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_remove_default_rejects_non_default",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_re_adding_removed_default_restores_it",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_restore_defaults_clears_customs_and_removed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "test_keyword_sanitisation_lowercases_and_strips_invalid_chars",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_exemption_add_remove",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_exemption_idempotent",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_exemption_invalid_bucket_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_trusted_proxy_defaults",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_trusted_proxy_round_trip",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "test_trusted_proxy_mode_falls_back_to_cloudflare_for_unknown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "SafetySettingsRepositoryTest",
+          "methods": [
+            "setUp",
+            "test_master_toggle_default_on",
+            "test_master_toggle_can_be_disabled_then_re_enabled",
+            "test_bucket1_keywords_are_hardcoded_and_non_empty",
+            "test_add_custom_bucket3_keyword",
+            "test_add_custom_bucket2_keyword",
+            "test_cannot_add_keyword_to_bucket1",
+            "test_invalid_bucket_rejected",
+            "test_empty_keyword_rejected",
+            "test_remove_custom_keyword_returns_false_for_unknown",
+            "test_remove_custom_keyword_removes_added_entry",
+            "test_remove_default_bucket3_keyword_marks_as_removed",
+            "test_remove_default_rejects_non_default",
+            "test_re_adding_removed_default_restores_it",
+            "test_restore_defaults_clears_customs_and_removed",
+            "test_keyword_sanitisation_lowercases_and_strips_invalid_chars",
+            "test_exemption_add_remove",
+            "test_exemption_idempotent",
+            "test_exemption_invalid_bucket_rejected",
+            "test_trusted_proxy_defaults",
+            "test_trusted_proxy_round_trip",
+            "test_trusted_proxy_mode_falls_back_to_cloudflare_for_unknown"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 146
+        }
+      ],
+      "imports": [
+        {
+          "source": "PHPUnit\\Framework\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        },
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Settings\\SafetySettingsRepository",
+          "specifiers": [
+            "SafetySettingsRepository"
+          ]
+        }
+      ],
+      "exports": [
+        "SafetySettingsRepositoryTest"
+      ],
+      "totalLines": 161,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Transport/HttpTransportTest.php": {
+      "filePath": "tests/Unit/Transport/HttpTransportTest.php",
+      "contentHash": "3f4897a0cb26427b3f8ff6789f34a6e7ad2de7bc8b40029f6e30d2779a9a67a0",
+      "functions": [
+        {
+          "name": "test_truncate_ipv4_to_slash_24",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_truncate_ipv4_loopback",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_truncate_ipv6_to_slash_48",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_truncate_invalid_returns_empty",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_auth_deny_enum_constants_are_distinct",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 21
+        }
+      ],
+      "classes": [
+        {
+          "name": "HttpTransportTest",
+          "methods": [
+            "test_truncate_ipv4_to_slash_24",
+            "test_truncate_ipv4_loopback",
+            "test_truncate_ipv6_to_slash_48",
+            "test_truncate_invalid_returns_empty",
+            "test_auth_deny_enum_constants_are_distinct"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 41
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\HttpTransport",
+          "specifiers": [
+            "HttpTransport"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "HttpTransportTest"
+      ],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    },
+    "tests/Unit/Transport/Infrastructure/OriginValidatorTest.php": {
+      "filePath": "tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "contentHash": "bad734f960bad1eb864f0e13faa21bbbac4d6481f901cfa22b2617428821ed04",
+      "functions": [
+        {
+          "name": "setUp",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "tearDown",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "request_with_origin",
+          "params": [
+            "$origin"
+          ],
+          "returnType": "\\WP_REST_Request",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_no_origin_header_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_empty_origin_header_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_same_origin_browser_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_same_origin_with_port_in_request_host_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_same_origin_case_insensitive",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_localhost_with_port_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_loopback_v4_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_loopback_v6_is_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_default_allowlist_includes_home_url",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "test_filter_can_add_extra_allowed_origin",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "test_filter_can_revoke_default_allowlist",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "test_non_array_filter_return_rejects",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "test_evil_domain_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_subdomain_of_allowed_host_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_malformed_origin_is_rejected",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "test_echoable_origin_returns_exact_string_when_allowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_echoable_origin_returns_empty_when_disallowed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "test_echoable_origin_returns_empty_when_no_origin",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "test_wildcard_origin_string_is_never_echoed",
+          "params": [],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "OriginValidatorTest",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "request_with_origin",
+            "test_no_origin_header_is_allowed",
+            "test_empty_origin_header_is_allowed",
+            "test_same_origin_browser_is_allowed",
+            "test_same_origin_with_port_in_request_host_is_allowed",
+            "test_same_origin_case_insensitive",
+            "test_localhost_with_port_is_allowed",
+            "test_loopback_v4_is_allowed",
+            "test_loopback_v6_is_allowed",
+            "test_default_allowlist_includes_home_url",
+            "test_filter_can_add_extra_allowed_origin",
+            "test_filter_can_revoke_default_allowlist",
+            "test_non_array_filter_return_rejects",
+            "test_evil_domain_is_rejected",
+            "test_subdomain_of_allowed_host_is_rejected",
+            "test_malformed_origin_is_rejected",
+            "test_echoable_origin_returns_exact_string_when_allowed",
+            "test_echoable_origin_returns_empty_when_disallowed",
+            "test_echoable_origin_returns_empty_when_no_origin",
+            "test_wildcard_origin_string_is_never_echoed"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 139
+        }
+      ],
+      "imports": [
+        {
+          "source": "WickedEvolutions\\McpAdapter\\Transport\\Infrastructure\\OriginValidator",
+          "specifiers": [
+            "OriginValidator"
+          ]
+        },
+        {
+          "source": "Yoast\\PHPUnitPolyfills\\TestCases\\TestCase",
+          "specifiers": [
+            "TestCase"
+          ]
+        }
+      ],
+      "exports": [
+        "OriginValidatorTest"
+      ],
+      "totalLines": 149,
+      "hasStructuralAnalysis": true
+    }
+  }
+}

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,19183 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "abilities-mcp-adapter",
+    "languages": [
+      "css",
+      "json",
+      "jsonl",
+      "markdown",
+      "php",
+      "txt",
+      "xml",
+      "yaml"
+    ],
+    "frameworks": [
+      "Model Context Protocol (MCP)",
+      "WordPress Abilities API",
+      "OAuth 2.1",
+      "PHPUnit",
+      "GitHub Actions"
+    ],
+    "description": "Abilities MCP Adapter — exposes WordPress abilities as MCP (Model Context Protocol) tools, resources, and prompts.",
+    "analyzedAt": "2026-06-07T12:36:25Z",
+    "gitCommitHash": "05fcd5a13d4da9cf0ba1eae81860f81c24fb38e8"
+  },
+  "nodes": [
+    {
+      "id": "file:src/Handlers/HandlerHelperTrait.php",
+      "type": "file",
+      "name": "HandlerHelperTrait.php",
+      "filePath": "src/Handlers/HandlerHelperTrait.php",
+      "summary": "Shared trait giving MCP handlers helpers for extracting params, building success/error responses, and producing standard error responses via McpErrorFactory.",
+      "tags": [
+        "trait",
+        "utility",
+        "handler",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "type": "file",
+      "name": "InitializeHandler.php",
+      "filePath": "src/Handlers/Initialize/InitializeHandler.php",
+      "summary": "Handles the MCP initialize request, negotiating protocol version and returning server capabilities and identity metadata.",
+      "tags": [
+        "api-handler",
+        "mcp-handler",
+        "initialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Handlers/Initialize/InitializeHandler.php:InitializeHandler",
+      "type": "class",
+      "name": "InitializeHandler",
+      "filePath": "src/Handlers/Initialize/InitializeHandler.php",
+      "lineRange": [
+        22,
+        88
+      ],
+      "summary": "Responds to MCP initialize by negotiating the protocol version and reporting server name, version, and description.",
+      "tags": [
+        "mcp-handler",
+        "initialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Handlers/Initialize/InitializeHandler.php:handle",
+      "type": "function",
+      "name": "handle",
+      "filePath": "src/Handlers/Initialize/InitializeHandler.php",
+      "lineRange": [
+        58,
+        87
+      ],
+      "summary": "Negotiates the requested protocol version and returns the server's capabilities and identity for the initialize response.",
+      "tags": [
+        "mcp-handler",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "type": "file",
+      "name": "PromptsHandler.php",
+      "filePath": "src/Handlers/Prompts/PromptsHandler.php",
+      "summary": "MCP handler for prompts/list and prompts/get, enforcing OAuth scope and ability permissions before executing the prompt's backing ability and shaping the result.",
+      "tags": [
+        "api-handler",
+        "mcp-handler",
+        "prompts",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Handlers/Prompts/PromptsHandler.php:PromptsHandler",
+      "type": "class",
+      "name": "PromptsHandler",
+      "filePath": "src/Handlers/Prompts/PromptsHandler.php",
+      "lineRange": [
+        24,
+        299
+      ],
+      "summary": "Lists registered prompts and resolves a single prompt, running permission and scope checks then executing the prompt or its ability.",
+      "tags": [
+        "mcp-handler",
+        "prompts",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Prompts/PromptsHandler.php:get_prompt",
+      "type": "function",
+      "name": "get_prompt",
+      "filePath": "src/Handlers/Prompts/PromptsHandler.php",
+      "lineRange": [
+        75,
+        298
+      ],
+      "summary": "Resolves a prompt by name, enforces permission and OAuth scope, executes the backing ability or builder, and returns prompt messages or an error.",
+      "tags": [
+        "mcp-handler",
+        "prompts",
+        "permission-check",
+        "execution"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Prompts/PromptsHandler.php:list_prompts",
+      "type": "function",
+      "name": "list_prompts",
+      "filePath": "src/Handlers/Prompts/PromptsHandler.php",
+      "lineRange": [
+        51,
+        65
+      ],
+      "summary": "Returns the array of registered prompts serialized for the prompts/list response.",
+      "tags": [
+        "mcp-handler",
+        "prompts",
+        "listing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "type": "file",
+      "name": "ResourcesHandler.php",
+      "filePath": "src/Handlers/Resources/ResourcesHandler.php",
+      "summary": "MCP handler for resources/list and resources/read that enforces OAuth scope and ability permissions before resolving a resource's content via its backing ability.",
+      "tags": [
+        "api-handler",
+        "mcp-handler",
+        "resources",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Handlers/Resources/ResourcesHandler.php:ResourcesHandler",
+      "type": "class",
+      "name": "ResourcesHandler",
+      "filePath": "src/Handlers/Resources/ResourcesHandler.php",
+      "lineRange": [
+        24,
+        245
+      ],
+      "summary": "Lists registered resources and reads a single resource, running permission and scope checks before executing the resource's ability to produce content.",
+      "tags": [
+        "mcp-handler",
+        "resources",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Resources/ResourcesHandler.php:read_resource",
+      "type": "function",
+      "name": "read_resource",
+      "filePath": "src/Handlers/Resources/ResourcesHandler.php",
+      "lineRange": [
+        79,
+        244
+      ],
+      "summary": "Resolves a resource by URI, enforces permission and OAuth scope, executes the backing ability, and returns the resource contents or an error.",
+      "tags": [
+        "mcp-handler",
+        "resources",
+        "permission-check",
+        "execution"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Resources/ResourcesHandler.php:list_resources",
+      "type": "function",
+      "name": "list_resources",
+      "filePath": "src/Handlers/Resources/ResourcesHandler.php",
+      "lineRange": [
+        51,
+        69
+      ],
+      "summary": "Returns the array of registered resources serialized for the resources/list response.",
+      "tags": [
+        "mcp-handler",
+        "resources",
+        "listing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Handlers/System/SystemHandler.php",
+      "type": "file",
+      "name": "SystemHandler.php",
+      "filePath": "src/Handlers/System/SystemHandler.php",
+      "summary": "Handles MCP system/protocol methods (ping, logging level, completion, roots listing) and produces method-not-found errors for unsupported requests.",
+      "tags": [
+        "api-handler",
+        "mcp-handler",
+        "system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Handlers/System/SystemHandler.php:SystemHandler",
+      "type": "class",
+      "name": "SystemHandler",
+      "filePath": "src/Handlers/System/SystemHandler.php",
+      "lineRange": [
+        21,
+        94
+      ],
+      "summary": "Implements lightweight MCP system methods and the fallback method-not-found responder.",
+      "tags": [
+        "mcp-handler",
+        "system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Handlers/Tools/ToolsHandler.php",
+      "type": "file",
+      "name": "ToolsHandler.php",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "summary": "MCP handler for tools/list and tools/call that sanitizes tool data, enforces permission/scope, executes the backing ability, and shapes the result into MCP tool content.",
+      "tags": [
+        "api-handler",
+        "mcp-handler",
+        "tools",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Handlers/Tools/ToolsHandler.php:ToolsHandler",
+      "type": "class",
+      "name": "ToolsHandler",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "lineRange": [
+        27,
+        546
+      ],
+      "summary": "Lists tools and handles tool calls end-to-end: validation, permission and OAuth scope enforcement, ability execution, and result/error formatting.",
+      "tags": [
+        "mcp-handler",
+        "tools",
+        "permission-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Tools/ToolsHandler.php:handle_tool_call",
+      "type": "function",
+      "name": "handle_tool_call",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "lineRange": [
+        274,
+        545
+      ],
+      "summary": "Resolves a tool, checks PermissionManager state, ability permissions, and OAuth scope, executes the ability, and maps results or WP_Errors to MCP responses.",
+      "tags": [
+        "mcp-handler",
+        "tools",
+        "permission-check",
+        "execution"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Tools/ToolsHandler.php:call_tool",
+      "type": "function",
+      "name": "call_tool",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "lineRange": [
+        105,
+        226
+      ],
+      "summary": "Entry point for tools/call: extracts the tool name and arguments, delegates to handle_tool_call, and normalizes the response content.",
+      "tags": [
+        "mcp-handler",
+        "tools",
+        "execution"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Handlers/Tools/ToolsHandler.php:sanitize_tool_data",
+      "type": "function",
+      "name": "sanitize_tool_data",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "lineRange": [
+        235,
+        264
+      ],
+      "summary": "Serializes a tool to array and strips internal-only fields before exposing it in tools/list responses.",
+      "tags": [
+        "serialization",
+        "tools",
+        "sanitization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Handlers/Tools/ToolsHandler.php:list_tools",
+      "type": "function",
+      "name": "list_tools",
+      "filePath": "src/Handlers/Tools/ToolsHandler.php",
+      "lineRange": [
+        53,
+        68
+      ],
+      "summary": "Returns sanitized registered tools for the tools/list response.",
+      "tags": [
+        "mcp-handler",
+        "tools",
+        "listing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "file",
+      "name": "McpErrorFactory.php",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "summary": "Factory producing standardized JSON-RPC/MCP error responses for all error categories and mapping MCP error codes to HTTP statuses.",
+      "tags": [
+        "error-handling",
+        "factory",
+        "json-rpc",
+        "utility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Infrastructure/ErrorHandling/McpErrorFactory.php:McpErrorFactory",
+      "type": "class",
+      "name": "McpErrorFactory",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "lineRange": [
+        22,
+        459
+      ],
+      "summary": "Static error factory with named constructors for each MCP error type, HTTP-status mapping, and JSON-RPC message validation.",
+      "tags": [
+        "error-handling",
+        "factory",
+        "json-rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:create_error_response",
+      "type": "function",
+      "name": "create_error_response",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "lineRange": [
+        56,
+        71
+      ],
+      "summary": "Builds the canonical JSON-RPC error envelope from an id, code, message, and optional data.",
+      "tags": [
+        "error-handling",
+        "json-rpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:mcp_error_to_http_status",
+      "type": "function",
+      "name": "mcp_error_to_http_status",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "lineRange": [
+        366,
+        406
+      ],
+      "summary": "Maps an MCP/JSON-RPC error code to the appropriate HTTP status code for transport responses.",
+      "tags": [
+        "error-handling",
+        "http",
+        "mapping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:validate_jsonrpc_message",
+      "type": "function",
+      "name": "validate_jsonrpc_message",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "lineRange": [
+        434,
+        458
+      ],
+      "summary": "Validates that an incoming message conforms to JSON-RPC structure, returning an invalid_request error otherwise.",
+      "tags": [
+        "validation",
+        "json-rpc",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:rate_limited",
+      "type": "function",
+      "name": "rate_limited",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "lineRange": [
+        341,
+        353
+      ],
+      "summary": "Produces a rate-limit error response carrying retry-after, limit, window, and dimension details.",
+      "tags": [
+        "error-handling",
+        "rate-limit"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "type": "file",
+      "name": "McpErrorMapper.php",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "summary": "Maps WordPress WP_Error codes onto MCP error codes and converts a WP_Error into a standardized MCP error response via McpErrorFactory.",
+      "tags": [
+        "error-handling",
+        "mapper",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/ErrorHandling/McpErrorMapper.php:McpErrorMapper",
+      "type": "class",
+      "name": "McpErrorMapper",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "lineRange": [
+        22,
+        77
+      ],
+      "summary": "Static mapper translating WP_Error codes to MCP error codes and producing MCP error responses from WP_Errors.",
+      "tags": [
+        "error-handling",
+        "mapper"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Infrastructure/ErrorHandling/McpErrorMapper.php:from_wp_error",
+      "type": "function",
+      "name": "from_wp_error",
+      "filePath": "src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "lineRange": [
+        70,
+        76
+      ],
+      "summary": "Converts a WP_Error into an MCP error response, mapping its code and forwarding message and data.",
+      "tags": [
+        "error-handling",
+        "mapper",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Transport/Contracts/McpTransportInterface.php",
+      "type": "file",
+      "name": "McpTransportInterface.php",
+      "filePath": "src/Transport/Contracts/McpTransportInterface.php",
+      "summary": "Contract that MCP transport implementations must satisfy, declaring construction with a transport context and route registration.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "transport",
+        "contract"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Transport/Contracts/McpTransportInterface.php:McpTransportInterface",
+      "type": "class",
+      "name": "McpTransportInterface",
+      "filePath": "src/Transport/Contracts/McpTransportInterface.php",
+      "lineRange": [
+        26,
+        42
+      ],
+      "summary": "Interface defining the constructor and register_routes contract for transports.",
+      "tags": [
+        "interface",
+        "contract",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+      "type": "file",
+      "name": "HttpSessionValidator.php",
+      "filePath": "src/Transport/Infrastructure/HttpSessionValidator.php",
+      "summary": "Validates, creates, and terminates MCP HTTP sessions, delegating to SessionManager and returning MCP errors for unauthorized or invalid sessions.",
+      "tags": [
+        "transport",
+        "session",
+        "validation",
+        "http"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/HttpSessionValidator.php:HttpSessionValidator",
+      "type": "class",
+      "name": "HttpSessionValidator",
+      "filePath": "src/Transport/Infrastructure/HttpSessionValidator.php",
+      "lineRange": [
+        24,
+        135
+      ],
+      "summary": "Provides session validation, header validation, creation, and termination for the HTTP transport using SessionManager.",
+      "tags": [
+        "transport",
+        "session",
+        "http"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/HttpSessionValidator.php:validate_session",
+      "type": "function",
+      "name": "validate_session",
+      "filePath": "src/Transport/Infrastructure/HttpSessionValidator.php",
+      "lineRange": [
+        36,
+        62
+      ],
+      "summary": "Validates an MCP session for the request, checking the logged-in user and verifying the session token via SessionManager.",
+      "tags": [
+        "session",
+        "validation",
+        "permission-check"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "type": "file",
+      "name": "McpTransportContext.php",
+      "filePath": "src/Transport/Infrastructure/McpTransportContext.php",
+      "summary": "Immutable context object bundling the MCP server, all request handlers, observability/error handlers, request router, and permission callback for transports.",
+      "tags": [
+        "transport",
+        "context",
+        "data-model",
+        "dependency-injection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/McpTransportContext.php:McpTransportContext",
+      "type": "class",
+      "name": "McpTransportContext",
+      "filePath": "src/Transport/Infrastructure/McpTransportContext.php",
+      "lineRange": [
+        35,
+        148
+      ],
+      "summary": "Holds the wired-together handlers and dependencies a transport needs, populated from a properties array in its constructor.",
+      "tags": [
+        "transport",
+        "context",
+        "dependency-injection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "type": "file",
+      "name": "OutputSchemaPassthroughTest.php",
+      "filePath": "tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "summary": "Unit tests verifying McpTool serializes its output schema into tool data, omits it when null, and validates it via McpToolValidator.",
+      "tags": [
+        "test",
+        "tools",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php:OutputSchemaPassthroughTest",
+      "type": "class",
+      "name": "OutputSchemaPassthroughTest",
+      "filePath": "tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "lineRange": [
+        13,
+        83
+      ],
+      "summary": "Test case asserting output-schema passthrough behavior of McpTool's to_array and validation.",
+      "tags": [
+        "test",
+        "tools"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "type": "file",
+      "name": "McpAnnotationMapperTest.php",
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "summary": "Comprehensive unit tests for McpAnnotationMapper::map covering per-feature-type filtering, value casting, exclusion of empty/null values, and field overrides.",
+      "tags": [
+        "test",
+        "annotations",
+        "mapper"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php:McpAnnotationMapperTest",
+      "type": "class",
+      "name": "McpAnnotationMapperTest",
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "lineRange": [
+        10,
+        224
+      ],
+      "summary": "Test case exercising annotation mapping and normalization rules for tools, resources, and prompts.",
+      "tags": [
+        "test",
+        "annotations"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "type": "file",
+      "name": "SchemaTransformerTest.php",
+      "filePath": "tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "summary": "Unit tests for SchemaTransformer covering minimal object output, object passthrough, and wrapping of scalar/array/typed schemas under a wrapper key.",
+      "tags": [
+        "test",
+        "schema",
+        "transformation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Domain/Utils/SchemaTransformerTest.php:SchemaTransformerTest",
+      "type": "class",
+      "name": "SchemaTransformerTest",
+      "filePath": "tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "lineRange": [
+        10,
+        100
+      ],
+      "summary": "Test case validating SchemaTransformer::transform_to_object_schema across schema shapes.",
+      "tags": [
+        "test",
+        "schema"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "type": "file",
+      "name": "HandlerHelperTraitTest.php",
+      "filePath": "tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "summary": "Unit tests for HandlerHelperTrait via a consumer stub, covering param extraction, error/success response formatting, and factory-response unwrapping.",
+      "tags": [
+        "test",
+        "trait",
+        "handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Handlers/HandlerHelperTraitTest.php:HandlerHelperTraitTest",
+      "type": "class",
+      "name": "HandlerHelperTraitTest",
+      "filePath": "tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "lineRange": [
+        27,
+        147
+      ],
+      "summary": "Test case exercising the handler helper trait's param extraction and response helpers.",
+      "tags": [
+        "test",
+        "handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "type": "file",
+      "name": "PromptsHandlerScopeEnforcementTest.php",
+      "filePath": "tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "summary": "Unit tests verifying PromptsHandler enforces OAuth scope on prompts/get using the OAuthRequestContext and rejects out-of-scope requests.",
+      "tags": [
+        "test",
+        "prompts",
+        "permission-check",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php:PromptsHandlerScopeEnforcementTest",
+      "type": "class",
+      "name": "PromptsHandlerScopeEnforcementTest",
+      "filePath": "tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "lineRange": [
+        1,
+        161
+      ],
+      "summary": "Test case asserting OAuth scope enforcement behavior of the PromptsHandler.",
+      "tags": [
+        "test",
+        "prompts",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "type": "file",
+      "name": "ResourcesHandlerScopeEnforcementTest.php",
+      "filePath": "tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "summary": "Unit tests verifying ResourcesHandler enforces OAuth scope on resources/read via the OAuthRequestContext.",
+      "tags": [
+        "test",
+        "resources",
+        "permission-check",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php:ResourcesHandlerScopeEnforcementTest",
+      "type": "class",
+      "name": "ResourcesHandlerScopeEnforcementTest",
+      "filePath": "tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "lineRange": [
+        1,
+        119
+      ],
+      "summary": "Test case asserting OAuth scope enforcement behavior of the ResourcesHandler.",
+      "tags": [
+        "test",
+        "resources",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "type": "file",
+      "name": "PermissionErrorRemediationTest.php",
+      "filePath": "tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "summary": "Unit tests checking that permission-denied errors from tool execution carry remediation guidance, exercising meta-abilities and the error factory/mapper.",
+      "tags": [
+        "test",
+        "tools",
+        "permission-check",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php:PermissionErrorRemediationTest",
+      "type": "class",
+      "name": "PermissionErrorRemediationTest",
+      "filePath": "tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "lineRange": [
+        1,
+        166
+      ],
+      "summary": "Test case asserting permission errors include remediation hints across abilities and error mapping.",
+      "tags": [
+        "test",
+        "permission-check",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "type": "file",
+      "name": "McpErrorFactoryTest.php",
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "summary": "Unit tests for McpErrorFactory covering each error constructor, HTTP-status mapping, and JSON-RPC message validation.",
+      "tags": [
+        "test",
+        "error-handling",
+        "json-rpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php:McpErrorFactoryTest",
+      "type": "class",
+      "name": "McpErrorFactoryTest",
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "lineRange": [
+        1,
+        347
+      ],
+      "summary": "Test case exercising the full surface of the MCP error factory.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "type": "file",
+      "name": "McpErrorMapperTest.php",
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "summary": "Unit tests for McpErrorMapper verifying WP_Error code mapping and conversion into MCP error responses.",
+      "tags": [
+        "test",
+        "error-handling",
+        "mapper"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php:McpErrorMapperTest",
+      "type": "class",
+      "name": "McpErrorMapperTest",
+      "filePath": "tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "lineRange": [
+        1,
+        159
+      ],
+      "summary": "Test case validating WP_Error-to-MCP error mapping.",
+      "tags": [
+        "test",
+        "error-handling",
+        "mapper"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "type": "file",
+      "name": "GetAbilityInfoAbility.php",
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "summary": "Meta-ability that registers a WordPress ability returning metadata (name, label, schema, meta) about another registered ability, gated by permission and MCP-exposure checks.",
+      "tags": [
+        "api-handler",
+        "wp-ability",
+        "introspection",
+        "permission-check"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Abilities/GetAbilityInfoAbility.php:GetAbilityInfoAbility",
+      "type": "class",
+      "name": "GetAbilityInfoAbility",
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "lineRange": [
+        29,
+        197
+      ],
+      "summary": "Registers and executes the get-ability-info meta-ability, validating user access and returning a target ability's descriptor.",
+      "tags": [
+        "wp-ability",
+        "introspection",
+        "permission-check"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/GetAbilityInfoAbility.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "lineRange": [
+        35,
+        88
+      ],
+      "summary": "Registers the get-ability-info ability with WordPress, declaring its input schema, permission callback, and execute callback.",
+      "tags": [
+        "registration",
+        "wp-ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/GetAbilityInfoAbility.php:execute",
+      "type": "function",
+      "name": "execute",
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "lineRange": [
+        150,
+        196
+      ],
+      "summary": "Looks up the requested ability and returns a structured array of its name, label, description, category, schemas, and meta.",
+      "tags": [
+        "execution",
+        "introspection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/GetAbilityInfoAbility.php:validate_user_access",
+      "type": "function",
+      "name": "validate_user_access",
+      "filePath": "src/Abilities/GetAbilityInfoAbility.php",
+      "lineRange": [
+        122,
+        139
+      ],
+      "summary": "Verifies the current user is logged in and holds the capability required to introspect abilities.",
+      "tags": [
+        "validation",
+        "permission-check"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Core/McpComponentRegistry.php",
+      "type": "file",
+      "name": "McpComponentRegistry.php",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "summary": "Central registry that converts WordPress abilities into MCP tools, resources, and prompts, validating each and recording observability events on success and failure.",
+      "tags": [
+        "registry",
+        "factory",
+        "validation",
+        "observability"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Core/McpComponentRegistry.php:McpComponentRegistry",
+      "type": "class",
+      "name": "McpComponentRegistry",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "lineRange": [
+        30,
+        584
+      ],
+      "summary": "Builds and stores MCP tool/resource/prompt instances from ability names, delegating creation to Register* factories and validation to domain validators.",
+      "tags": [
+        "registry",
+        "factory",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpComponentRegistry.php:register_tools",
+      "type": "function",
+      "name": "register_tools",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "lineRange": [
+        118,
+        218
+      ],
+      "summary": "Resolves each ability name into an MCP tool via RegisterAbilityAsMcpTool, validating and recording success/failure events.",
+      "tags": [
+        "registration",
+        "tools",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpComponentRegistry.php:add_tool",
+      "type": "function",
+      "name": "add_tool",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "lineRange": [
+        227,
+        288
+      ],
+      "summary": "Adds a pre-built McpTool instance to the registry after binding the server and validating the tool.",
+      "tags": [
+        "registration",
+        "tools",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpComponentRegistry.php:register_resources",
+      "type": "function",
+      "name": "register_resources",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "lineRange": [
+        297,
+        370
+      ],
+      "summary": "Converts ability names into MCP resources via RegisterAbilityAsMcpResource, recording registration outcomes.",
+      "tags": [
+        "registration",
+        "resources",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpComponentRegistry.php:register_prompts",
+      "type": "function",
+      "name": "register_prompts",
+      "filePath": "src/Core/McpComponentRegistry.php",
+      "lineRange": [
+        379,
+        523
+      ],
+      "summary": "Registers prompts from either prompt-builder classes or ability names, validating each prompt instance before storing it.",
+      "tags": [
+        "registration",
+        "prompts",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Core/McpServer.php",
+      "type": "file",
+      "name": "McpServer.php",
+      "filePath": "src/Core/McpServer.php",
+      "summary": "Core MCP server aggregate that holds server identity/config, wires up the component registry and transport factory, and exposes accessors for tools, resources, prompts, and handlers.",
+      "tags": [
+        "service",
+        "core",
+        "aggregate-root",
+        "configuration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Core/McpServer.php:McpServer",
+      "type": "class",
+      "name": "McpServer",
+      "filePath": "src/Core/McpServer.php",
+      "lineRange": [
+        28,
+        409
+      ],
+      "summary": "Represents a configured MCP server: stores identity and route metadata, initializes handlers/components/transports, and provides getters used throughout the request pipeline.",
+      "tags": [
+        "service",
+        "core",
+        "aggregate-root"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpServer.php:__construct",
+      "type": "function",
+      "name": "__construct",
+      "filePath": "src/Core/McpServer.php",
+      "lineRange": [
+        133,
+        164
+      ],
+      "summary": "Builds the server from identity, route, handler, and component arguments, then triggers handler and component setup.",
+      "tags": [
+        "constructor",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Core/McpServer.php:setup_components",
+      "type": "function",
+      "name": "setup_components",
+      "filePath": "src/Core/McpServer.php",
+      "lineRange": [
+        202,
+        219
+      ],
+      "summary": "Registers MCP components into the registry and initializes the configured transports via the transport factory.",
+      "tags": [
+        "initialization",
+        "registry",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpServer.php:register_mcp_components",
+      "type": "function",
+      "name": "register_mcp_components",
+      "filePath": "src/Core/McpServer.php",
+      "lineRange": [
+        228,
+        245
+      ],
+      "summary": "Delegates tool, resource, and prompt registration to the component registry when each collection is non-empty.",
+      "tags": [
+        "registration",
+        "registry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Core/McpTransportFactory.php",
+      "type": "file",
+      "name": "McpTransportFactory.php",
+      "filePath": "src/Core/McpTransportFactory.php",
+      "summary": "Factory that validates and initializes configured transport classes against the MCP transport interface and assembles the shared transport context with all request handlers.",
+      "tags": [
+        "factory",
+        "transport",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Core/McpTransportFactory.php:McpTransportFactory",
+      "type": "class",
+      "name": "McpTransportFactory",
+      "filePath": "src/Core/McpTransportFactory.php",
+      "lineRange": [
+        27,
+        123
+      ],
+      "summary": "Instantiates transport implementations for an MCP server and creates the transport context wiring handlers, observability, and the permission callback.",
+      "tags": [
+        "factory",
+        "transport"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Core/McpTransportFactory.php:initialize_transports",
+      "type": "function",
+      "name": "initialize_transports",
+      "filePath": "src/Core/McpTransportFactory.php",
+      "lineRange": [
+        49,
+        93
+      ],
+      "summary": "Iterates configured transport classes, verifying each exists and implements McpTransportInterface before constructing it with the transport context.",
+      "tags": [
+        "transport",
+        "validation",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Core/McpTransportFactory.php:create_transport_context",
+      "type": "function",
+      "name": "create_transport_context",
+      "filePath": "src/Core/McpTransportFactory.php",
+      "lineRange": [
+        100,
+        122
+      ],
+      "summary": "Assembles an McpTransportContext from the server's handlers, observability handler, error handler, and permission callback.",
+      "tags": [
+        "transport",
+        "context",
+        "factory"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "type": "file",
+      "name": "McpPromptBuilderInterface.php",
+      "filePath": "src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "summary": "Contract for fluent prompt builders defining the build, metadata accessor, handle, and permission methods an MCP prompt builder must implement.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "prompts",
+        "contract"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php:McpPromptBuilderInterface",
+      "type": "class",
+      "name": "McpPromptBuilderInterface",
+      "filePath": "src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "lineRange": [
+        24,
+        78
+      ],
+      "summary": "Interface declaring the build/handle/permission surface for prompt builder implementations.",
+      "tags": [
+        "interface",
+        "contract",
+        "prompts"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Domain/Prompts/McpPrompt.php",
+      "type": "file",
+      "name": "McpPrompt.php",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "summary": "Domain value object representing an MCP prompt with arguments and annotations, supporting serialization, validation, and optional builder-based direct execution.",
+      "tags": [
+        "data-model",
+        "prompts",
+        "serialization",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Domain/Prompts/McpPrompt.php:McpPrompt",
+      "type": "class",
+      "name": "McpPrompt",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "lineRange": [
+        26,
+        465
+      ],
+      "summary": "Encapsulates a prompt's name, title, description, arguments, and annotations with getters/setters, to_array/to_json, from_array hydration, and validation against the server.",
+      "tags": [
+        "data-model",
+        "prompts",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPrompt.php:to_array",
+      "type": "function",
+      "name": "to_array",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "lineRange": [
+        297,
+        320
+      ],
+      "summary": "Serializes the prompt to an associative array, omitting null/empty optional fields.",
+      "tags": [
+        "serialization",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPrompt.php:from_array",
+      "type": "function",
+      "name": "from_array",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "lineRange": [
+        340,
+        353
+      ],
+      "summary": "Hydrates an McpPrompt from array data, binds the MCP server, and validates the resulting instance.",
+      "tags": [
+        "factory",
+        "deserialization",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPrompt.php:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "lineRange": [
+        362,
+        382
+      ],
+      "summary": "Validates the prompt instance against the server when MCP validation is enabled, returning a WP_Error on failure.",
+      "tags": [
+        "validation",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPrompt.php:get_ability",
+      "type": "function",
+      "name": "get_ability",
+      "filePath": "src/Domain/Prompts/McpPrompt.php",
+      "lineRange": [
+        153,
+        166
+      ],
+      "summary": "Resolves and returns the backing WordPress ability for this prompt, erroring if it is not registered.",
+      "tags": [
+        "wp-ability",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Prompts/McpPromptBuilder.php",
+      "type": "file",
+      "name": "McpPromptBuilder.php",
+      "filePath": "src/Domain/Prompts/McpPromptBuilder.php",
+      "summary": "Abstract fluent base class for code-defined prompts, providing argument/annotation helpers and lazily configuring metadata via a subclass configure() hook.",
+      "tags": [
+        "builder",
+        "prompts",
+        "abstract-class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Domain/Prompts/McpPromptBuilder.php:McpPromptBuilder",
+      "type": "class",
+      "name": "McpPromptBuilder",
+      "filePath": "src/Domain/Prompts/McpPromptBuilder.php",
+      "lineRange": [
+        24,
+        273
+      ],
+      "summary": "Base builder implementing McpPromptBuilderInterface with lazy configuration and argument construction helpers for subclassed prompts.",
+      "tags": [
+        "builder",
+        "prompts",
+        "abstract-class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPromptBuilder.php:build",
+      "type": "function",
+      "name": "build",
+      "filePath": "src/Domain/Prompts/McpPromptBuilder.php",
+      "lineRange": [
+        67,
+        130
+      ],
+      "summary": "Runs configure() and assembles the prompt definition array from the builder's accumulated name, title, description, arguments, and annotations.",
+      "tags": [
+        "builder",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "type": "file",
+      "name": "RegisterAbilityAsMcpPrompt.php",
+      "filePath": "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "summary": "Adapter that derives an MCP prompt definition from a WordPress ability, converting its input schema into prompt arguments and mapping annotations.",
+      "tags": [
+        "factory",
+        "adapter",
+        "prompts",
+        "wp-ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:RegisterAbilityAsMcpPrompt",
+      "type": "class",
+      "name": "RegisterAbilityAsMcpPrompt",
+      "filePath": "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "lineRange": [
+        47,
+        194
+      ],
+      "summary": "Builds an McpPrompt from an ability, exposing a static make() factory and input-schema-to-arguments conversion.",
+      "tags": [
+        "factory",
+        "adapter",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:get_data",
+      "type": "function",
+      "name": "get_data",
+      "filePath": "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "lineRange": [
+        92,
+        126
+      ],
+      "summary": "Derives the prompt's name, title, description, arguments, and annotations from the backing ability's metadata.",
+      "tags": [
+        "adapter",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:convert_input_schema_to_arguments",
+      "type": "function",
+      "name": "convert_input_schema_to_arguments",
+      "filePath": "src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "lineRange": [
+        150,
+        184
+      ],
+      "summary": "Translates a JSON-schema properties object into a list of MCP prompt argument descriptors with required flags.",
+      "tags": [
+        "adapter",
+        "schema",
+        "prompts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Resources/McpResource.php",
+      "type": "file",
+      "name": "McpResource.php",
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "summary": "Domain value object for an MCP resource (text or blob) with URI, mime type, and annotations, supporting serialization, hydration, and validation.",
+      "tags": [
+        "data-model",
+        "resources",
+        "serialization",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Domain/Resources/McpResource.php:McpResource",
+      "type": "class",
+      "name": "McpResource",
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "lineRange": [
+        27,
+        451
+      ],
+      "summary": "Represents a resource exposed over MCP with text/blob content, type predicates, getters/setters, and to_array/from_array conversion plus validation.",
+      "tags": [
+        "data-model",
+        "resources",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Resources/McpResource.php:to_array",
+      "type": "function",
+      "name": "to_array",
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "lineRange": [
+        337,
+        368
+      ],
+      "summary": "Serializes the resource to an array, including only the populated text or blob fields and non-empty annotations.",
+      "tags": [
+        "serialization",
+        "resources"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Resources/McpResource.php:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "lineRange": [
+        430,
+        450
+      ],
+      "summary": "Validates the resource instance against the server via McpResourceValidator when validation is enabled.",
+      "tags": [
+        "validation",
+        "resources"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Resources/McpResource.php:get_ability",
+      "type": "function",
+      "name": "get_ability",
+      "filePath": "src/Domain/Resources/McpResource.php",
+      "lineRange": [
+        192,
+        205
+      ],
+      "summary": "Resolves the backing WordPress ability for this resource, erroring when it is not registered.",
+      "tags": [
+        "wp-ability",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "type": "file",
+      "name": "RegisterAbilityAsMcpResource.php",
+      "filePath": "src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "summary": "Adapter that builds an MCP resource definition from a WordPress ability, deriving its URI, descriptive metadata, and content.",
+      "tags": [
+        "factory",
+        "adapter",
+        "resources",
+        "wp-ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Domain/Resources/RegisterAbilityAsMcpResource.php:RegisterAbilityAsMcpResource",
+      "type": "class",
+      "name": "RegisterAbilityAsMcpResource",
+      "filePath": "src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "lineRange": [
+        33,
+        187
+      ],
+      "summary": "Derives an McpResource from an ability via a static make() factory, resolving URI, metadata, and ability content.",
+      "tags": [
+        "factory",
+        "adapter",
+        "resources"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Resources/RegisterAbilityAsMcpResource.php:get_data",
+      "type": "function",
+      "name": "get_data",
+      "filePath": "src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "lineRange": [
+        104,
+        143
+      ],
+      "summary": "Assembles the resource definition array (URI, name, description, annotations) from the backing ability.",
+      "tags": [
+        "adapter",
+        "resources"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Tools/McpTool.php",
+      "type": "file",
+      "name": "McpTool.php",
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "summary": "Domain value object for an MCP tool carrying input/output schemas, annotations, and metadata, with serialization, hydration, and validation against the server.",
+      "tags": [
+        "data-model",
+        "tools",
+        "serialization",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Domain/Tools/McpTool.php:McpTool",
+      "type": "class",
+      "name": "McpTool",
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "lineRange": [
+        27,
+        404
+      ],
+      "summary": "Represents an MCP tool bound to a WordPress ability, exposing schema/annotation/metadata accessors, to_array/from_array, and validate().",
+      "tags": [
+        "data-model",
+        "tools",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpTool.php:to_array",
+      "type": "function",
+      "name": "to_array",
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "lineRange": [
+        325,
+        349
+      ],
+      "summary": "Serializes the tool to an array including name, schemas, and annotations, omitting null/empty optional fields.",
+      "tags": [
+        "serialization",
+        "tools"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpTool.php:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "lineRange": [
+        383,
+        403
+      ],
+      "summary": "Validates the tool instance via McpToolValidator when server-side MCP validation is enabled.",
+      "tags": [
+        "validation",
+        "tools"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpTool.php:get_ability",
+      "type": "function",
+      "name": "get_ability",
+      "filePath": "src/Domain/Tools/McpTool.php",
+      "lineRange": [
+        129,
+        142
+      ],
+      "summary": "Resolves the backing WordPress ability for this tool, returning an error when it is not registered.",
+      "tags": [
+        "wp-ability",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "type": "file",
+      "name": "RegisterAbilityAsMcpTool.php",
+      "filePath": "src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "summary": "Adapter that builds an MCP tool from a WordPress ability, transforming input/output schemas into object schemas and mapping annotations.",
+      "tags": [
+        "factory",
+        "adapter",
+        "tools",
+        "wp-ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Domain/Tools/RegisterAbilityAsMcpTool.php:RegisterAbilityAsMcpTool",
+      "type": "class",
+      "name": "RegisterAbilityAsMcpTool",
+      "filePath": "src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "lineRange": [
+        28,
+        141
+      ],
+      "summary": "Derives an McpTool from an ability via a static make() factory, using SchemaTransformer and McpAnnotationMapper.",
+      "tags": [
+        "factory",
+        "adapter",
+        "tools"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Tools/RegisterAbilityAsMcpTool.php:get_data",
+      "type": "function",
+      "name": "get_data",
+      "filePath": "src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "lineRange": [
+        73,
+        131
+      ],
+      "summary": "Builds the tool definition array, normalizing the ability's input/output schemas to object schemas and attaching annotations and metadata.",
+      "tags": [
+        "adapter",
+        "schema",
+        "tools"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "file",
+      "name": "McpAnnotationMapper.php",
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "summary": "Maps WordPress ability meta and annotations into MCP feature annotations, applying per-feature-type filtering and type normalization.",
+      "tags": [
+        "utility",
+        "mapper",
+        "annotations",
+        "normalization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Domain/Utils/McpAnnotationMapper.php:McpAnnotationMapper",
+      "type": "class",
+      "name": "McpAnnotationMapper",
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "lineRange": [
+        25,
+        247
+      ],
+      "summary": "Static mapper producing MCP annotations from ability annotations for tools, resources, and prompts with value resolution and normalization.",
+      "tags": [
+        "mapper",
+        "annotations",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "type": "function",
+      "name": "build_from_ability",
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "lineRange": [
+        122,
+        152
+      ],
+      "summary": "Reads an ability's meta to assemble candidate annotations (category, tier, permission) then maps them for the given feature type.",
+      "tags": [
+        "mapper",
+        "annotations",
+        "wp-ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpAnnotationMapper.php:map",
+      "type": "function",
+      "name": "map",
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "lineRange": [
+        166,
+        193
+      ],
+      "summary": "Filters and resolves ability annotations against the MCP annotation schema for the requested feature type.",
+      "tags": [
+        "mapper",
+        "annotations"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpAnnotationMapper.php:normalize_annotation_value",
+      "type": "function",
+      "name": "normalize_annotation_value",
+      "filePath": "src/Domain/Utils/McpAnnotationMapper.php",
+      "lineRange": [
+        225,
+        246
+      ],
+      "summary": "Coerces an annotation value to its declared field type (boolean, string, array, number), excluding empty or non-conforming values.",
+      "tags": [
+        "normalization",
+        "annotations"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Utils/SchemaTransformer.php",
+      "type": "file",
+      "name": "SchemaTransformer.php",
+      "filePath": "src/Domain/Utils/SchemaTransformer.php",
+      "summary": "Utility that normalizes arbitrary JSON schemas into object-typed schemas, wrapping non-object schemas under a configurable key for MCP compatibility.",
+      "tags": [
+        "utility",
+        "schema",
+        "transformation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Domain/Utils/SchemaTransformer.php:SchemaTransformer",
+      "type": "class",
+      "name": "SchemaTransformer",
+      "filePath": "src/Domain/Utils/SchemaTransformer.php",
+      "lineRange": [
+        24,
+        96
+      ],
+      "summary": "Static helper that converts schemas to object schemas, wrapping scalar/array schemas under a wrapper key.",
+      "tags": [
+        "utility",
+        "schema"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/SchemaTransformer.php:transform_to_object_schema",
+      "type": "function",
+      "name": "transform_to_object_schema",
+      "filePath": "src/Domain/Utils/SchemaTransformer.php",
+      "lineRange": [
+        37,
+        74
+      ],
+      "summary": "Returns a minimal object schema for empty input, passes through object schemas, and wraps other typed schemas under the wrapper key.",
+      "tags": [
+        "schema",
+        "transformation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/McpTransportHelperTrait.php",
+      "type": "file",
+      "name": "McpTransportHelperTrait.php",
+      "filePath": "src/Transport/Infrastructure/McpTransportHelperTrait.php",
+      "summary": "Shared trait providing helper methods reused across MCP transport classes.",
+      "tags": [
+        "trait",
+        "transport",
+        "utility"
+      ],
+      "complexity": "simple",
+      "languageNotes": "PHP trait for horizontal code reuse across transport implementations (no class extracted)."
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/OriginValidator.php",
+      "type": "file",
+      "name": "OriginValidator.php",
+      "filePath": "src/Transport/Infrastructure/OriginValidator.php",
+      "summary": "Validates the HTTP Origin header against an allowlist (home URL plus loopback) to defend MCP routes against cross-site request forgery.",
+      "tags": [
+        "security",
+        "validation",
+        "transport",
+        "middleware"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/OriginValidator.php:OriginValidator",
+      "type": "class",
+      "name": "OriginValidator",
+      "filePath": "src/Transport/Infrastructure/OriginValidator.php",
+      "lineRange": [
+        30,
+        181
+      ],
+      "summary": "Checks request Origin against allowed hosts and loopback, returning whether it is permitted and the safe echoable origin for CORS.",
+      "tags": [
+        "security",
+        "validation",
+        "transport"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "type": "file",
+      "name": "RequestRouter.php",
+      "filePath": "src/Transport/Infrastructure/RequestRouter.php",
+      "summary": "Routes MCP JSON-RPC methods to handlers, applying rate limiting, cursor compatibility, session-aware initialize, and error categorization.",
+      "tags": [
+        "transport",
+        "middleware",
+        "service",
+        "rate-limiting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/RequestRouter.php:RequestRouter",
+      "type": "class",
+      "name": "RequestRouter",
+      "filePath": "src/Transport/Infrastructure/RequestRouter.php",
+      "lineRange": [
+        27,
+        367
+      ],
+      "summary": "Dispatches MCP method calls, enforces rate limits via the limiter and trusted-proxy resolver, handles initialize/session, and categorizes/sanitizes errors for logging.",
+      "tags": [
+        "transport",
+        "middleware",
+        "rate-limiting",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "type": "file",
+      "name": "SettingsAbilitiesTest.php",
+      "filePath": "tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "summary": "Unit tests for SettingsAbilities verifying friction-gated guards, one-time tokens, param-swap rejection, and Bucket-1/2/3 keyword enforcement.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php:SettingsAbilitiesTest",
+      "type": "class",
+      "name": "SettingsAbilitiesTest",
+      "filePath": "tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "lineRange": [
+        18,
+        256
+      ],
+      "summary": "PHPUnit test class exercising the redaction-settings abilities' guard logic and confirmation-token flow.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "type": "file",
+      "name": "OAuthClientIpTrustedProxyTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "summary": "Unit tests verifying OAuth client-IP resolution honors trusted-proxy settings and rejects spoofed X-Forwarded-For from untrusted sources.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php:OAuthClientIpTrustedProxyTest",
+      "type": "class",
+      "name": "OAuthClientIpTrustedProxyTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "lineRange": [
+        35,
+        142
+      ],
+      "summary": "PHPUnit test class validating trusted-proxy-aware client IP extraction across allowlist and bypass scenarios.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Cli/RequestIdStateTest.php",
+      "type": "file",
+      "name": "RequestIdStateTest.php",
+      "filePath": "tests/Unit/Cli/RequestIdStateTest.php",
+      "summary": "Unit tests for the stdio bridge's request-vs-notification detection based on presence and type of the JSON-RPC id.",
+      "tags": [
+        "test",
+        "unit-test",
+        "cli"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Cli/RequestIdStateTest.php:RequestIdStateTest",
+      "type": "class",
+      "name": "RequestIdStateTest",
+      "filePath": "tests/Unit/Cli/RequestIdStateTest.php",
+      "lineRange": [
+        25,
+        77
+      ],
+      "summary": "PHPUnit test class asserting request_id_state correctly classifies absent/null/int/string/zero ids.",
+      "tags": [
+        "test",
+        "unit-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "type": "file",
+      "name": "BoundaryEventEmitterTest.php",
+      "filePath": "tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "summary": "Unit tests verifying the boundary event emitter drops raw API keys, hashes them to SHA-256, and allowlists tags.",
+      "tags": [
+        "test",
+        "unit-test",
+        "observability",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php:BoundaryEventEmitterTest",
+      "type": "class",
+      "name": "BoundaryEventEmitterTest",
+      "filePath": "tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "lineRange": [
+        15,
+        81
+      ],
+      "summary": "PHPUnit test class validating tag sanitization and API-key hashing in BoundaryEventEmitter.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "type": "file",
+      "name": "ResponseRedactionGateTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "summary": "Extensive unit tests for the redaction gate covering exemptions, dash/slash name translation, dual text-channel reconciliation, and cross-bucket safety.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php:ResponseRedactionGateTest",
+      "type": "class",
+      "name": "ResponseRedactionGateTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "lineRange": [
+        21,
+        780
+      ],
+      "summary": "PHPUnit test class exhaustively exercising ResponseRedactionGate redaction, exemption scoping, and text-channel regeneration.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/RateLimit/CounterStoreTest.php",
+      "type": "file",
+      "name": "CounterStoreTest.php",
+      "filePath": "tests/Unit/RateLimit/CounterStoreTest.php",
+      "summary": "Unit tests for the counter store covering transient and object-cache backends and fallback behavior.",
+      "tags": [
+        "test",
+        "unit-test",
+        "rate-limiting"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/RateLimit/CounterStoreTest.php:CounterStoreTest",
+      "type": "class",
+      "name": "CounterStoreTest",
+      "filePath": "tests/Unit/RateLimit/CounterStoreTest.php",
+      "lineRange": [
+        13,
+        43
+      ],
+      "summary": "PHPUnit test class validating CounterStore backend selection and increment semantics.",
+      "tags": [
+        "test",
+        "unit-test",
+        "rate-limiting"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/RateLimit/RateLimiterTest.php",
+      "type": "file",
+      "name": "RateLimiterTest.php",
+      "filePath": "tests/Unit/RateLimit/RateLimiterTest.php",
+      "summary": "Unit tests for the rate limiter covering per-IP/user/site windows, filter overrides, and the separate initialize window.",
+      "tags": [
+        "test",
+        "unit-test",
+        "rate-limiting",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/RateLimit/RateLimiterTest.php:RateLimiterTest",
+      "type": "class",
+      "name": "RateLimiterTest",
+      "filePath": "tests/Unit/RateLimit/RateLimiterTest.php",
+      "lineRange": [
+        14,
+        214
+      ],
+      "summary": "PHPUnit test class exercising RateLimiter window enforcement, isolation, and filter hooks.",
+      "tags": [
+        "test",
+        "unit-test",
+        "rate-limiting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "type": "file",
+      "name": "TrustedProxyResolverTest.php",
+      "filePath": "tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "summary": "Unit tests for trusted-proxy IP resolution covering Cloudflare presets, custom CIDR allowlists, CIDR matching, and IP truncation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/RateLimit/TrustedProxyResolverTest.php:TrustedProxyResolverTest",
+      "type": "class",
+      "name": "TrustedProxyResolverTest",
+      "filePath": "tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "lineRange": [
+        13,
+        174
+      ],
+      "summary": "PHPUnit test class validating TrustedProxyResolver header trust logic, CIDR matching, and settings round-trip.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "type": "file",
+      "name": "ConfirmationTokenStoreTest.php",
+      "filePath": "tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "summary": "Unit tests for the confirmation token store covering minting, one-time consumption, and session/ability/param mismatch rejection.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Settings/ConfirmationTokenStoreTest.php:ConfirmationTokenStoreTest",
+      "type": "class",
+      "name": "ConfirmationTokenStoreTest",
+      "filePath": "tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "lineRange": [
+        15,
+        92
+      ],
+      "summary": "PHPUnit test class validating ConfirmationTokenStore mint/consume and token-binding invariants.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "type": "file",
+      "name": "SafetySettingsRepositoryTest.php",
+      "filePath": "tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "summary": "Unit tests for the safety settings repository covering keyword bucket CRUD, default overrides, exemptions, and trusted-proxy persistence.",
+      "tags": [
+        "test",
+        "unit-test",
+        "data-model",
+        "config"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Settings/SafetySettingsRepositoryTest.php:SafetySettingsRepositoryTest",
+      "type": "class",
+      "name": "SafetySettingsRepositoryTest",
+      "filePath": "tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "lineRange": [
+        15,
+        160
+      ],
+      "summary": "PHPUnit test class validating SafetySettingsRepository keyword/exemption/proxy read-write behavior and sanitization.",
+      "tags": [
+        "test",
+        "unit-test",
+        "data-model"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Transport/HttpTransportTest.php",
+      "type": "file",
+      "name": "HttpTransportTest.php",
+      "filePath": "tests/Unit/Transport/HttpTransportTest.php",
+      "summary": "Unit tests for HttpTransport covering IP-truncation-for-logging and auth-deny enum distinctness.",
+      "tags": [
+        "test",
+        "unit-test",
+        "transport",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Transport/HttpTransportTest.php:HttpTransportTest",
+      "type": "class",
+      "name": "HttpTransportTest",
+      "filePath": "tests/Unit/Transport/HttpTransportTest.php",
+      "lineRange": [
+        18,
+        58
+      ],
+      "summary": "PHPUnit test class validating HttpTransport IP truncation and auth-deny constants.",
+      "tags": [
+        "test",
+        "unit-test",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "type": "file",
+      "name": "OriginValidatorTest.php",
+      "filePath": "tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "summary": "Unit tests for the origin validator covering same-origin/loopback allowance, allowlist filters, and rejection of evil/subdomain/wildcard origins.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php:OriginValidatorTest",
+      "type": "class",
+      "name": "OriginValidatorTest",
+      "filePath": "tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "lineRange": [
+        10,
+        148
+      ],
+      "summary": "PHPUnit test class exhaustively validating OriginValidator allow/deny and echoable-origin behavior.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "type": "file",
+      "name": "SettingsAbilities.php",
+      "filePath": "src/Abilities/Settings/SettingsAbilities.php",
+      "summary": "Registers MCP abilities that let clients inspect and mutate the response-redaction safety configuration (keyword buckets, defaults, ability exemptions) with friction-gated guards.",
+      "tags": [
+        "api-handler",
+        "service",
+        "validation",
+        "security",
+        "ability-registration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "WordPress Abilities API registration pattern: paired register_*/execute_* methods per ability."
+    },
+    {
+      "id": "class:src/Abilities/Settings/SettingsAbilities.php:SettingsAbilities",
+      "type": "class",
+      "name": "SettingsAbilities",
+      "filePath": "src/Abilities/Settings/SettingsAbilities.php",
+      "lineRange": [
+        40,
+        781
+      ],
+      "summary": "Registers and executes the redaction-settings abilities, enforcing Bucket-1 keyword guards, known-ability checks, and confirmation-token friction for risky weakening operations.",
+      "tags": [
+        "api-handler",
+        "validation",
+        "security",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Admin/Tabs/SafetyTab.php",
+      "type": "file",
+      "name": "SafetyTab.php",
+      "filePath": "src/Admin/Tabs/SafetyTab.php",
+      "summary": "Renders and processes the wp-admin Safety settings tab UI for managing redaction keyword buckets, ability exemptions, and trusted-proxy configuration.",
+      "tags": [
+        "component",
+        "admin-ui",
+        "validation",
+        "security",
+        "event-handler"
+      ],
+      "complexity": "complex",
+      "languageNotes": "WordPress admin settings tab with render_*/handle_* method pairs and nonce-guarded form handlers."
+    },
+    {
+      "id": "class:src/Admin/Tabs/SafetyTab.php:SafetyTab",
+      "type": "class",
+      "name": "SafetyTab",
+      "filePath": "src/Admin/Tabs/SafetyTab.php",
+      "lineRange": [
+        38,
+        714
+      ],
+      "summary": "Admin tab controller that renders the safety settings form sections and handles POST actions (master toggle, keyword add/remove, exemptions, trusted proxy) against the settings repository.",
+      "tags": [
+        "admin-ui",
+        "event-handler",
+        "validation",
+        "component"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Cli/StdioServerBridge.php",
+      "type": "file",
+      "name": "StdioServerBridge.php",
+      "filePath": "src/Cli/StdioServerBridge.php",
+      "summary": "Bridges stdin/stdout JSON-RPC framing to the MCP server for CLI/stdio transport, applying response redaction and producing JSON-RPC error/result envelopes.",
+      "tags": [
+        "service",
+        "transport",
+        "cli",
+        "serialization"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Distinguishes JSON-RPC notifications from requests by presence of the id key (request_id_state)."
+    },
+    {
+      "id": "class:src/Cli/StdioServerBridge.php:StdioServerBridge",
+      "type": "class",
+      "name": "StdioServerBridge",
+      "filePath": "src/Cli/StdioServerBridge.php",
+      "lineRange": [
+        30,
+        388
+      ],
+      "summary": "Stdio transport bridge that reads JSON-RPC requests from stdin, routes them through the request router with redaction, and writes framed responses to stdout.",
+      "tags": [
+        "transport",
+        "cli",
+        "serialization",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "file",
+      "name": "BoundaryEventEmitter.php",
+      "filePath": "src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "summary": "Emits sanitized observability events at trust boundaries, dropping raw secrets and replacing API keys with SHA-256 hashes before handing tags to an observability handler.",
+      "tags": [
+        "service",
+        "observability",
+        "security",
+        "utility"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Tag allowlisting plus SHA-256 hashing of secrets is a privacy-by-default telemetry pattern."
+    },
+    {
+      "id": "class:src/Infrastructure/Observability/BoundaryEventEmitter.php:BoundaryEventEmitter",
+      "type": "class",
+      "name": "BoundaryEventEmitter",
+      "filePath": "src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "lineRange": [
+        30,
+        171
+      ],
+      "summary": "Static event emitter that sanitizes a tag allowlist (hashing API keys) and dispatches the event to a configured observability handler.",
+      "tags": [
+        "observability",
+        "security",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "type": "file",
+      "name": "ConsoleObservabilityHandler.php",
+      "filePath": "src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "summary": "Default observability handler that writes structured boundary events to the PHP error log / console.",
+      "tags": [
+        "observability",
+        "service",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/Observability/ConsoleObservabilityHandler.php:ConsoleObservabilityHandler",
+      "type": "class",
+      "name": "ConsoleObservabilityHandler",
+      "filePath": "src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "lineRange": [
+        25,
+        60
+      ],
+      "summary": "Implements the observability handler contract by formatting and writing events to the console/error log.",
+      "tags": [
+        "observability",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "file",
+      "name": "McpObservabilityHandlerInterface.php",
+      "filePath": "src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "summary": "Defines the contract for observability handlers that record MCP boundary events with tags and timing.",
+      "tags": [
+        "type-definition",
+        "observability",
+        "interface"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php:McpObservabilityHandlerInterface",
+      "type": "class",
+      "name": "McpObservabilityHandlerInterface",
+      "filePath": "src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "lineRange": [
+        23,
+        35
+      ],
+      "summary": "Interface declaring record_event for pluggable observability backends.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "observability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "type": "file",
+      "name": "ResponseRedactionGate.php",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "summary": "Central gate that redacts sensitive content from MCP tool responses, reconciling structured and text channels and honoring per-ability Bucket-3 exemptions.",
+      "tags": [
+        "middleware",
+        "security",
+        "serialization",
+        "service"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Static name-translation cache maps dash-form tool names to slash-form ability names for exemption lookup."
+    },
+    {
+      "id": "class:src/Infrastructure/Redaction/ResponseRedactionGate.php:ResponseRedactionGate",
+      "type": "class",
+      "name": "ResponseRedactionGate",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "lineRange": [
+        33,
+        397
+      ],
+      "summary": "Applies keyword-bucket redaction to tools/call responses, translates dash/slash ability names, reconciles dual text channels, and emits redaction events.",
+      "tags": [
+        "middleware",
+        "security",
+        "serialization",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/RateLimit/CounterStore.php",
+      "type": "file",
+      "name": "CounterStore.php",
+      "filePath": "src/RateLimit/CounterStore.php",
+      "summary": "Atomic counter store for rate limiting, backed by the object cache when available and falling back to WordPress transients.",
+      "tags": [
+        "service",
+        "rate-limiting",
+        "data-model",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/RateLimit/CounterStore.php:CounterStore",
+      "type": "class",
+      "name": "CounterStore",
+      "filePath": "src/RateLimit/CounterStore.php",
+      "lineRange": [
+        19,
+        100
+      ],
+      "summary": "Increment/get counter store that auto-detects an external object cache backend and falls back to transients with TTL.",
+      "tags": [
+        "rate-limiting",
+        "service",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/RateLimit/RateLimiter.php",
+      "type": "file",
+      "name": "RateLimiter.php",
+      "filePath": "src/RateLimit/RateLimiter.php",
+      "summary": "Sliding-window rate limiter enforcing per-IP, per-user, and per-site request quotas with filterable limits and a separate initialize window.",
+      "tags": [
+        "service",
+        "rate-limiting",
+        "security",
+        "middleware"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/RateLimit/RateLimiter.php:RateLimiter",
+      "type": "class",
+      "name": "RateLimiter",
+      "filePath": "src/RateLimit/RateLimiter.php",
+      "lineRange": [
+        22,
+        222
+      ],
+      "summary": "Computes and enforces rate-limit windows (IP, user, site, initialize) against the counter store, with WordPress filter hooks for overrides and retry-after calculation.",
+      "tags": [
+        "rate-limiting",
+        "security",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/RateLimit/TrustedProxyResolver.php",
+      "type": "file",
+      "name": "TrustedProxyResolver.php",
+      "filePath": "src/RateLimit/TrustedProxyResolver.php",
+      "summary": "Resolves the real client IP behind trusted proxies (Cloudflare presets or custom CIDR allowlists), validating XFF/CF headers only from trusted sources.",
+      "tags": [
+        "service",
+        "security",
+        "rate-limiting",
+        "validation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "CIDR matching and IPv6 expansion guard against spoofed X-Forwarded-For from untrusted sources."
+    },
+    {
+      "id": "class:src/RateLimit/TrustedProxyResolver.php:TrustedProxyResolver",
+      "type": "class",
+      "name": "TrustedProxyResolver",
+      "filePath": "src/RateLimit/TrustedProxyResolver.php",
+      "lineRange": [
+        26,
+        437
+      ],
+      "summary": "Resolves client IP from forwarded headers when the remote address is in a trusted CIDR allowlist, manages Cloudflare IP refresh, and validates CIDR/IPv6 ranges.",
+      "tags": [
+        "security",
+        "validation",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Settings/ConfirmationTokenStore.php",
+      "type": "file",
+      "name": "ConfirmationTokenStore.php",
+      "filePath": "src/Settings/ConfirmationTokenStore.php",
+      "summary": "Mints and consumes one-time confirmation tokens that gate risky settings mutations, binding each token to session, ability, and parameter hash.",
+      "tags": [
+        "service",
+        "security",
+        "data-model",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Settings/ConfirmationTokenStore.php:ConfirmationTokenStore",
+      "type": "class",
+      "name": "ConfirmationTokenStore",
+      "filePath": "src/Settings/ConfirmationTokenStore.php",
+      "lineRange": [
+        27,
+        137
+      ],
+      "summary": "Stores single-use confirmation tokens keyed to session/ability/params hash, validating and invalidating them on consume.",
+      "tags": [
+        "security",
+        "validation",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "file",
+      "name": "SafetySettingsRepository.php",
+      "filePath": "src/Settings/SafetySettingsRepository.php",
+      "summary": "Persistence repository for safety/redaction settings: keyword buckets (1-3), custom and removed defaults, ability exemptions, and trusted-proxy configuration.",
+      "tags": [
+        "data-model",
+        "service",
+        "config",
+        "persistence"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Three-tier keyword bucket model with default+custom+removed override layering computed in get_active_keywords."
+    },
+    {
+      "id": "class:src/Settings/SafetySettingsRepository.php:SafetySettingsRepository",
+      "type": "class",
+      "name": "SafetySettingsRepository",
+      "filePath": "src/Settings/SafetySettingsRepository.php",
+      "lineRange": [
+        41,
+        543
+      ],
+      "summary": "Reads and writes redaction safety settings to WordPress options, exposing hardcoded default keyword buckets, custom/removed overrides, exemptions, and trusted-proxy fields with sanitization.",
+      "tags": [
+        "data-model",
+        "persistence",
+        "config",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Transport/Contracts/McpRestTransportInterface.php",
+      "type": "file",
+      "name": "McpRestTransportInterface.php",
+      "filePath": "src/Transport/Contracts/McpRestTransportInterface.php",
+      "summary": "Defines the contract for REST-based MCP transports (permission check and request handling).",
+      "tags": [
+        "type-definition",
+        "interface",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Transport/Contracts/McpRestTransportInterface.php:McpRestTransportInterface",
+      "type": "class",
+      "name": "McpRestTransportInterface",
+      "filePath": "src/Transport/Contracts/McpRestTransportInterface.php",
+      "lineRange": [
+        25,
+        42
+      ],
+      "summary": "Interface declaring check_permission and handle_request for REST MCP transports.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Transport/HttpTransport.php",
+      "type": "file",
+      "name": "HttpTransport.php",
+      "filePath": "src/Transport/HttpTransport.php",
+      "summary": "HTTP/REST transport that registers MCP routes, enforces authentication, origin checks, and CORS, and delegates request handling to the infrastructure handler.",
+      "tags": [
+        "transport",
+        "api-handler",
+        "security",
+        "middleware"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements McpRestTransportInterface; disables core CORS for MCP routes to emit its own origin-validated headers."
+    },
+    {
+      "id": "class:src/Transport/HttpTransport.php:HttpTransport",
+      "type": "class",
+      "name": "HttpTransport",
+      "filePath": "src/Transport/HttpTransport.php",
+      "lineRange": [
+        32,
+        442
+      ],
+      "summary": "Registers WordPress REST routes for MCP, performs permission/origin/CORS checks, handles preflight, and dispatches requests through the HTTP request handler.",
+      "tags": [
+        "transport",
+        "api-handler",
+        "security",
+        "middleware"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/HttpRequestContext.php",
+      "type": "file",
+      "name": "HttpRequestContext.php",
+      "filePath": "src/Transport/Infrastructure/HttpRequestContext.php",
+      "summary": "Immutable value object capturing per-request HTTP context (the WP_REST_Request and derived fields) passed through the transport pipeline.",
+      "tags": [
+        "data-model",
+        "transport",
+        "value-object"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/HttpRequestContext.php:HttpRequestContext",
+      "type": "class",
+      "name": "HttpRequestContext",
+      "filePath": "src/Transport/Infrastructure/HttpRequestContext.php",
+      "lineRange": [
+        19,
+        69
+      ],
+      "summary": "Constructor-built request context holding the REST request and derived transport state.",
+      "tags": [
+        "data-model",
+        "value-object",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "type": "file",
+      "name": "HttpRequestHandler.php",
+      "filePath": "src/Transport/Infrastructure/HttpRequestHandler.php",
+      "summary": "Processes MCP JSON-RPC messages over HTTP, handling single/batch requests, SSE, session lifecycle, and transport error emission with redaction.",
+      "tags": [
+        "transport",
+        "api-handler",
+        "service",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/HttpRequestHandler.php:HttpRequestHandler",
+      "type": "class",
+      "name": "HttpRequestHandler",
+      "filePath": "src/Transport/Infrastructure/HttpRequestHandler.php",
+      "lineRange": [
+        27,
+        547
+      ],
+      "summary": "Handles HTTP MCP requests by decoding JSON-RPC messages, processing single/batch/SSE flows, managing session headers, and emitting transport/session observability events.",
+      "tags": [
+        "transport",
+        "api-handler",
+        "serialization",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "file",
+      "name": "AuthorizationCodeStore.php",
+      "filePath": "src/Auth/OAuth/AuthorizationCodeStore.php",
+      "summary": "Stores and consumes OAuth 2.1 authorization codes with PKCE (S256) verification, persisting hashed codes and validating code_verifier on single-use exchange.",
+      "tags": [
+        "service",
+        "oauth",
+        "pkce",
+        "authorization-code",
+        "data-model"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Static store class backed by $wpdb; hashes codes at rest and uses hash_equals for constant-time comparison."
+    },
+    {
+      "id": "class:src/Auth/OAuth/AuthorizationCodeStore.php:AuthorizationCodeStore",
+      "type": "class",
+      "name": "AuthorizationCodeStore",
+      "filePath": "src/Auth/OAuth/AuthorizationCodeStore.php",
+      "lineRange": [
+        18,
+        170
+      ],
+      "summary": "Static store for OAuth authorization codes with PKCE S256 challenge computation and single-use consumption.",
+      "tags": [
+        "service",
+        "oauth",
+        "pkce",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationCodeStore.php:store",
+      "type": "function",
+      "name": "store",
+      "filePath": "src/Auth/OAuth/AuthorizationCodeStore.php",
+      "lineRange": [
+        51,
+        92
+      ],
+      "summary": "Persists a hashed authorization code with client, user, redirect_uri, scope, PKCE challenge, TTL, and selected role.",
+      "tags": [
+        "oauth",
+        "authorization-code",
+        "persistence"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationCodeStore.php:consume",
+      "type": "function",
+      "name": "consume",
+      "filePath": "src/Auth/OAuth/AuthorizationCodeStore.php",
+      "lineRange": [
+        106,
+        161
+      ],
+      "summary": "Single-use consumption of an authorization code, verifying client, redirect_uri, and PKCE code_verifier before marking it used.",
+      "tags": [
+        "oauth",
+        "pkce",
+        "validation",
+        "authorization-code"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "file",
+      "name": "ClientRegistry.php",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "summary": "Manages dynamically-registered OAuth client records: registration, lookup, redirect_uri validation (loopback/exact match), revocation, and active-client listing.",
+      "tags": [
+        "service",
+        "oauth",
+        "client-registration",
+        "validation",
+        "data-model"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Auth/OAuth/ClientRegistry.php:ClientRegistry",
+      "type": "class",
+      "name": "ClientRegistry",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        20,
+        239
+      ],
+      "summary": "Static registry of OAuth clients handling registration, lookup, redirect_uri validation, and revocation.",
+      "tags": [
+        "service",
+        "oauth",
+        "client-registration",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ClientRegistry.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        39,
+        67
+      ],
+      "summary": "Creates a new OAuth client record with generated id, redirect URIs, scope, and software metadata.",
+      "tags": [
+        "oauth",
+        "client-registration",
+        "persistence"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ClientRegistry.php:find",
+      "type": "function",
+      "name": "find",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        75,
+        86
+      ],
+      "summary": "Looks up an active OAuth client by client_id.",
+      "tags": [
+        "oauth",
+        "lookup",
+        "client-registration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ClientRegistry.php:redirect_uri_valid",
+      "type": "function",
+      "name": "redirect_uri_valid",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        112,
+        170
+      ],
+      "summary": "Validates a requested redirect URI against a client's registered URIs, handling loopback host/port flexibility and exact non-loopback matching.",
+      "tags": [
+        "oauth",
+        "validation",
+        "security",
+        "redirect-uri"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ClientRegistry.php:revoke",
+      "type": "function",
+      "name": "revoke",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        202,
+        216
+      ],
+      "summary": "Revokes a client and cascades revocation to its codes and tokens.",
+      "tags": [
+        "oauth",
+        "revocation",
+        "client-registration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ClientRegistry.php:list_active",
+      "type": "function",
+      "name": "list_active",
+      "filePath": "src/Auth/OAuth/ClientRegistry.php",
+      "lineRange": [
+        225,
+        238
+      ],
+      "summary": "Returns a paginated list of active OAuth clients.",
+      "tags": [
+        "oauth",
+        "lookup",
+        "pagination"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "type": "file",
+      "name": "AuthorizeRequestValidator.php",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "summary": "Validates incoming OAuth authorize requests, distinguishing pre-redirect errors from redirectable errors and enforcing client, redirect_uri, state, PKCE, scope, and resource constraints.",
+      "tags": [
+        "validation",
+        "oauth",
+        "authorization",
+        "consent",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeValidationResult",
+      "type": "class",
+      "name": "AuthorizeValidationResult",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "lineRange": [
+        36,
+        65
+      ],
+      "summary": "Value object representing the outcome of authorize-request validation (ok, pre-redirect error, or redirectable error).",
+      "tags": [
+        "type-definition",
+        "oauth",
+        "validation",
+        "result"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeRequestValidator",
+      "type": "class",
+      "name": "AuthorizeRequestValidator",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "lineRange": [
+        70,
+        201
+      ],
+      "summary": "Validates OAuth authorize requests and builds typed validation results separating pre-redirect from redirectable errors.",
+      "tags": [
+        "validation",
+        "oauth",
+        "authorization",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "lineRange": [
+        81,
+        161
+      ],
+      "summary": "Validates an authorize request end-to-end, returning a typed result with pre-redirect or redirectable errors for client, redirect_uri, state, PKCE, scope, and resource.",
+      "tags": [
+        "oauth",
+        "validation",
+        "authorization",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:pre_redirect_error",
+      "type": "function",
+      "name": "pre_redirect_error",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "lineRange": [
+        174,
+        186
+      ],
+      "summary": "Builds a pre-redirect error validation result for failures that must not redirect back to the client.",
+      "tags": [
+        "oauth",
+        "validation",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:redirectable_error",
+      "type": "function",
+      "name": "redirectable_error",
+      "filePath": "src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "lineRange": [
+        188,
+        200
+      ],
+      "summary": "Builds a redirectable-error validation result carrying client, redirect_uri, state, and OAuth error code/description.",
+      "tags": [
+        "oauth",
+        "validation",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "file",
+      "name": "DiscoveryEndpoints.php",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "summary": "Serves OAuth/OIDC discovery metadata (protected-resource, authorization-server, openid-configuration) and computes the issuer URL with multisite path-prefix support.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "discovery",
+        "oidc",
+        "metadata"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/DiscoveryEndpoints.php:DiscoveryEndpoints",
+      "type": "class",
+      "name": "DiscoveryEndpoints",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "lineRange": [
+        21,
+        145
+      ],
+      "summary": "Static handler producing OAuth/OIDC discovery metadata and computing issuer URLs with multisite path-prefix support.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "discovery",
+        "oidc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/DiscoveryEndpoints.php:issuer",
+      "type": "function",
+      "name": "issuer",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "lineRange": [
+        41,
+        51
+      ],
+      "summary": "Computes the OAuth issuer URL from the site origin, honoring SSL and an optional multisite path prefix.",
+      "tags": [
+        "oauth",
+        "discovery",
+        "url-building"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/DiscoveryEndpoints.php:serve_protected_resource",
+      "type": "function",
+      "name": "serve_protected_resource",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "lineRange": [
+        78,
+        86
+      ],
+      "summary": "Emits the OAuth protected-resource metadata JSON response.",
+      "tags": [
+        "oauth",
+        "discovery",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/DiscoveryEndpoints.php:as_metadata",
+      "type": "function",
+      "name": "as_metadata",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "lineRange": [
+        112,
+        129
+      ],
+      "summary": "Assembles the authorization-server metadata document (endpoints, supported scopes, grant types).",
+      "tags": [
+        "oauth",
+        "discovery",
+        "metadata"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/DiscoveryEndpoints.php:json_response",
+      "type": "function",
+      "name": "json_response",
+      "filePath": "src/Auth/OAuth/DiscoveryEndpoints.php",
+      "lineRange": [
+        135,
+        144
+      ],
+      "summary": "Writes a JSON HTTP response with status code and optional CORS headers.",
+      "tags": [
+        "http",
+        "serialization",
+        "response"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "type": "file",
+      "name": "RegisterEndpoint.php",
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "summary": "Handles RFC 7591 Dynamic Client Registration POST requests with rate limiting, redirect_uri validation, scope classification, and client persistence via ClientRegistry.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "client-registration",
+        "rate-limiting",
+        "endpoint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:RegisterEndpoint",
+      "type": "class",
+      "name": "RegisterEndpoint",
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "lineRange": [
+        26,
+        174
+      ],
+      "summary": "REST handler for Dynamic Client Registration: rate-limits, validates redirect URIs, classifies scopes, and registers clients.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "client-registration",
+        "endpoint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "type": "function",
+      "name": "handle_post",
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "lineRange": [
+        42,
+        129
+      ],
+      "summary": "Processes a Dynamic Client Registration request: rate-limit checks, redirect_uri validation, scope classification, and client creation.",
+      "tags": [
+        "oauth",
+        "client-registration",
+        "api-handler",
+        "rate-limiting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:classify_scopes",
+      "type": "function",
+      "name": "classify_scopes",
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "lineRange": [
+        141,
+        153
+      ],
+      "summary": "Splits a scope string into valid and sensitive scope lists, dropping unknown scopes.",
+      "tags": [
+        "oauth",
+        "scope",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:is_valid_redirect_uri",
+      "type": "function",
+      "name": "is_valid_redirect_uri",
+      "filePath": "src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "lineRange": [
+        160,
+        173
+      ],
+      "summary": "Checks a redirect URI uses an allowed scheme for client registration.",
+      "tags": [
+        "oauth",
+        "validation",
+        "redirect-uri"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "type": "file",
+      "name": "RevokeEndpoint.php",
+      "filePath": "src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "summary": "Handles RFC 7009 token revocation requests with rate limiting and client authentication, delegating revocation to TokenStore.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "token-revocation",
+        "rate-limiting",
+        "endpoint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:RevokeEndpoint",
+      "type": "class",
+      "name": "RevokeEndpoint",
+      "filePath": "src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "lineRange": [
+        36,
+        100
+      ],
+      "summary": "REST handler for RFC 7009 token revocation with rate limiting and client authentication.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "token-revocation",
+        "endpoint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "type": "function",
+      "name": "handle_post",
+      "filePath": "src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "lineRange": [
+        53,
+        99
+      ],
+      "summary": "Processes a token revocation request with rate limiting, client authentication, and plaintext-token revocation.",
+      "tags": [
+        "oauth",
+        "token-revocation",
+        "api-handler",
+        "rate-limiting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "type": "file",
+      "name": "TokenEndpoint.php",
+      "filePath": "src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "summary": "OAuth token endpoint dispatching authorization_code and refresh_token grants, consuming auth codes and issuing/rotating tokens via AuthorizationCodeStore and TokenStore.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "token-grant",
+        "endpoint",
+        "pkce"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Endpoints/TokenEndpoint.php:TokenEndpoint",
+      "type": "class",
+      "name": "TokenEndpoint",
+      "filePath": "src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "lineRange": [
+        25,
+        127
+      ],
+      "summary": "REST handler dispatching authorization_code and refresh_token grants to issue and rotate tokens.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "token-grant",
+        "endpoint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_auth_code",
+      "type": "function",
+      "name": "handle_auth_code",
+      "filePath": "src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "lineRange": [
+        49,
+        97
+      ],
+      "summary": "Handles the authorization_code grant: validates client, consumes the auth code, and issues tokens.",
+      "tags": [
+        "oauth",
+        "token-grant",
+        "pkce",
+        "authorization-code"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_refresh",
+      "type": "function",
+      "name": "handle_refresh",
+      "filePath": "src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "lineRange": [
+        100,
+        126
+      ],
+      "summary": "Handles the refresh_token grant by validating the client and rotating the refresh token.",
+      "tags": [
+        "oauth",
+        "token-grant",
+        "refresh-rotation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "file",
+      "name": "RateLimiter.php",
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "summary": "Per-IP rate limiter for DCR and token-revocation endpoints plus a site-wide client cap, using object cache or transients for atomic counters.",
+      "tags": [
+        "service",
+        "rate-limiting",
+        "security",
+        "oauth",
+        "throttling"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Prefers wp_using_ext_object_cache for atomic increments, falling back to transients."
+    },
+    {
+      "id": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "type": "class",
+      "name": "RateLimiter",
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "lineRange": [
+        30,
+        178
+      ],
+      "summary": "Static per-IP rate limiter with counter read/increment over object cache or transients and a site-wide client cap.",
+      "tags": [
+        "service",
+        "rate-limiting",
+        "security",
+        "throttling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/RateLimiter.php:check_dcr",
+      "type": "function",
+      "name": "check_dcr",
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "lineRange": [
+        50,
+        65
+      ],
+      "summary": "Checks per-IP and per-subnet Dynamic Client Registration rate limits.",
+      "tags": [
+        "rate-limiting",
+        "security",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/RateLimiter.php:check_revoke",
+      "type": "function",
+      "name": "check_revoke",
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "lineRange": [
+        90,
+        105
+      ],
+      "summary": "Checks per-IP and per-subnet token-revocation rate limits.",
+      "tags": [
+        "rate-limiting",
+        "security",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/RateLimiter.php:counter_increment",
+      "type": "function",
+      "name": "counter_increment",
+      "filePath": "src/Auth/OAuth/RateLimiter.php",
+      "lineRange": [
+        166,
+        177
+      ],
+      "summary": "Atomically increments a rate-limit counter with TTL using object cache or transients.",
+      "tags": [
+        "rate-limiting",
+        "caching",
+        "atomicity"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "file",
+      "name": "TokenStore.php",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "summary": "Core access/refresh token store: issues, rotates (with replay detection and encrypted replay blobs), looks up, and revokes tokens including family-cascade revocation.",
+      "tags": [
+        "service",
+        "oauth",
+        "token-store",
+        "refresh-rotation",
+        "security"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements refresh-token rotation with reuse detection; replay blobs are AES-encrypted via hash_hkdf-derived keys, and access-token touches are deferred to shutdown."
+    },
+    {
+      "id": "class:src/Auth/OAuth/TokenStore.php:TokenStore",
+      "type": "class",
+      "name": "TokenStore",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        21,
+        553
+      ],
+      "summary": "Static token store for issuing, rotating, looking up, and revoking access/refresh tokens with replay detection and family cascade.",
+      "tags": [
+        "service",
+        "oauth",
+        "token-store",
+        "refresh-rotation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:issue",
+      "type": "function",
+      "name": "issue",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        65,
+        145
+      ],
+      "summary": "Issues a new access/refresh token pair with hashed storage, TTLs, family id, and selected role.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "issuance",
+        "persistence"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:rotate",
+      "type": "function",
+      "name": "rotate",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        166,
+        273
+      ],
+      "summary": "Rotates a refresh token, detecting reuse via replay blobs and cascading family revocation on replay.",
+      "tags": [
+        "oauth",
+        "refresh-rotation",
+        "replay-detection",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:encrypt_replay_blob",
+      "type": "function",
+      "name": "encrypt_replay_blob",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        298,
+        315
+      ],
+      "summary": "Encrypts the rotated token pair into a replay blob using an HKDF-derived AES key.",
+      "tags": [
+        "oauth",
+        "encryption",
+        "replay-detection",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:decrypt_replay_blob",
+      "type": "function",
+      "name": "decrypt_replay_blob",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        323,
+        347
+      ],
+      "summary": "Decrypts and validates a stored replay blob to recover the rotated token pair on refresh reuse.",
+      "tags": [
+        "oauth",
+        "encryption",
+        "replay-detection",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:lookup_access_token",
+      "type": "function",
+      "name": "lookup_access_token",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        356,
+        371
+      ],
+      "summary": "Resolves a bearer access token to its stored record by hash.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:find_token_meta",
+      "type": "function",
+      "name": "find_token_meta",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        384,
+        405
+      ],
+      "summary": "Finds metadata for a token across access and refresh tables for revocation.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:revoke_by_plaintext",
+      "type": "function",
+      "name": "revoke_by_plaintext",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        416,
+        443
+      ],
+      "summary": "Revokes a token given its plaintext value, cascading to its family for refresh tokens.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "revocation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:revoke_family",
+      "type": "function",
+      "name": "revoke_family",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        448,
+        473
+      ],
+      "summary": "Revokes an entire refresh-token family and its associated access tokens.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "revocation",
+        "cascade"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/TokenStore.php:flush_pending_touches",
+      "type": "function",
+      "name": "flush_pending_touches",
+      "filePath": "src/Auth/OAuth/TokenStore.php",
+      "lineRange": [
+        523,
+        541
+      ],
+      "summary": "Flushes deferred access-token last-used touches to the database at shutdown.",
+      "tags": [
+        "oauth",
+        "token-store",
+        "performance",
+        "deferred-write"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "type": "file",
+      "name": "AuthorizationCodeStoreSelectedRoleTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "summary": "PHPUnit unit test exercising AuthorizationCodeStore with 2 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php:AuthorizationCodeStoreSelectedRoleTest",
+      "type": "class",
+      "name": "AuthorizationCodeStoreSelectedRoleTest",
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "lineRange": [
+        19,
+        87
+      ],
+      "summary": "Test case class with 2 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "type": "file",
+      "name": "AuthorizationCodeStoreTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "summary": "PHPUnit unit test exercising AuthorizationCodeStore with 7 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php:AuthorizationCodeStoreTest",
+      "type": "class",
+      "name": "AuthorizationCodeStoreTest",
+      "filePath": "tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "lineRange": [
+        18,
+        150
+      ],
+      "summary": "Test case class with 7 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "type": "file",
+      "name": "ClientRegistryTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "summary": "PHPUnit unit test exercising ClientRegistry with 12 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/ClientRegistryTest.php:ClientRegistryTest",
+      "type": "class",
+      "name": "ClientRegistryTest",
+      "filePath": "tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "lineRange": [
+        18,
+        97
+      ],
+      "summary": "Test case class with 12 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "type": "file",
+      "name": "AuthorizeRequestValidatorTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "summary": "PHPUnit unit test exercising AuthorizeRequestValidator with 14 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php:AuthorizeRequestValidatorTest",
+      "type": "class",
+      "name": "AuthorizeRequestValidatorTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "lineRange": [
+        26,
+        346
+      ],
+      "summary": "Test case class with 14 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "type": "file",
+      "name": "DiscoveryEndpointsTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "summary": "PHPUnit unit test exercising DiscoveryEndpoints with 5 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php:DiscoveryEndpointsTest",
+      "type": "class",
+      "name": "DiscoveryEndpointsTest",
+      "filePath": "tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "lineRange": [
+        18,
+        63
+      ],
+      "summary": "Test case class with 5 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "type": "file",
+      "name": "RegisterEndpointClassifyScopesTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "summary": "PHPUnit unit test exercising RegisterEndpoint with 6 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php:RegisterEndpointClassifyScopesTest",
+      "type": "class",
+      "name": "RegisterEndpointClassifyScopesTest",
+      "filePath": "tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "lineRange": [
+        20,
+        91
+      ],
+      "summary": "Test case class with 6 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "type": "file",
+      "name": "PathStyleMultisiteDiscoveryTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "summary": "PHPUnit unit test exercising AuthorizationServer, DiscoveryEndpoints with 19 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php:PathStyleMultisiteDiscoveryTest",
+      "type": "class",
+      "name": "PathStyleMultisiteDiscoveryTest",
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "lineRange": [
+        34,
+        200
+      ],
+      "summary": "Test case class with 19 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "type": "file",
+      "name": "RateLimiterAtomicTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "summary": "PHPUnit unit test exercising RateLimiter with 8 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php:RateLimiterAtomicTest",
+      "type": "class",
+      "name": "RateLimiterAtomicTest",
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "lineRange": [
+        24,
+        139
+      ],
+      "summary": "Test case class with 8 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "type": "file",
+      "name": "RateLimiterTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "summary": "PHPUnit unit test exercising RateLimiter with 5 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/RateLimiterTest.php:RateLimiterTest",
+      "type": "class",
+      "name": "RateLimiterTest",
+      "filePath": "tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "lineRange": [
+        20,
+        72
+      ],
+      "summary": "Test case class with 5 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "type": "file",
+      "name": "RedirectUriNormalizeTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "summary": "PHPUnit unit test exercising ClientRegistry with 19 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php:RedirectUriNormalizeTest",
+      "type": "class",
+      "name": "RedirectUriNormalizeTest",
+      "filePath": "tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "lineRange": [
+        29,
+        178
+      ],
+      "summary": "Test case class with 19 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "type": "file",
+      "name": "TokenEndpointRedirectUriRawTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "summary": "PHPUnit unit test exercising AuthorizationCodeStore, TokenEndpoint with 2 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php:TokenEndpointRedirectUriRawTest",
+      "type": "class",
+      "name": "TokenEndpointRedirectUriRawTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "lineRange": [
+        34,
+        168
+      ],
+      "summary": "Test case class with 2 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "type": "file",
+      "name": "TokenStoreIssueResponseTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 8 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php:TokenStoreIssueResponseTest",
+      "type": "class",
+      "name": "TokenStoreIssueResponseTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "lineRange": [
+        30,
+        145
+      ],
+      "summary": "Test case class with 8 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "type": "file",
+      "name": "TokenStoreReplayBlobTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 7 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php:TokenStoreReplayBlobTest",
+      "type": "class",
+      "name": "TokenStoreReplayBlobTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "lineRange": [
+        42,
+        408
+      ],
+      "summary": "Test case class with 7 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "type": "file",
+      "name": "TokenStoreRevocationCascadeTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 4 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php:TokenStoreRevocationCascadeTest",
+      "type": "class",
+      "name": "TokenStoreRevocationCascadeTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "lineRange": [
+        26,
+        159
+      ],
+      "summary": "Test case class with 4 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "type": "file",
+      "name": "TokenStoreRotationFamilyTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 6 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php:TokenStoreRotationFamilyTest",
+      "type": "class",
+      "name": "TokenStoreRotationFamilyTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "lineRange": [
+        25,
+        363
+      ],
+      "summary": "Test case class with 6 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "type": "file",
+      "name": "TokenStoreSelectedRoleTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 5 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php:TokenStoreSelectedRoleTest",
+      "type": "class",
+      "name": "TokenStoreSelectedRoleTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "lineRange": [
+        24,
+        273
+      ],
+      "summary": "Test case class with 5 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "type": "file",
+      "name": "TokenStoreTouchDeferredTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "summary": "PHPUnit unit test exercising TokenStore with 7 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php:TokenStoreTouchDeferredTest",
+      "type": "class",
+      "name": "TokenStoreTouchDeferredTest",
+      "filePath": "tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "lineRange": [
+        26,
+        166
+      ],
+      "summary": "Test case class with 7 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "type": "file",
+      "name": "RevokeEndpointClientAuthTest.php",
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "summary": "PHPUnit unit test exercising RevokeEndpoint with 5 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php:RevokeEndpointClientAuthTest",
+      "type": "class",
+      "name": "RevokeEndpointClientAuthTest",
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "lineRange": [
+        31,
+        205
+      ],
+      "summary": "Test case class with 5 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "type": "file",
+      "name": "RevokeEndpointRateLimitTest.php",
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "summary": "PHPUnit unit test exercising RevokeEndpoint, RateLimiter with 5 test cases.",
+      "tags": [
+        "test",
+        "phpunit",
+        "oauth",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php:RevokeEndpointRateLimitTest",
+      "type": "class",
+      "name": "RevokeEndpointRateLimitTest",
+      "filePath": "tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "lineRange": [
+        23,
+        150
+      ],
+      "summary": "Test case class with 5 test methods validating the OAuth subject under test.",
+      "tags": [
+        "test",
+        "phpunit",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/McpResourcePath.php",
+      "type": "file",
+      "name": "McpResourcePath.php",
+      "filePath": "src/Auth/OAuth/McpResourcePath.php",
+      "summary": "Small constants/value holder defining the canonical MCP REST namespace, route, and resource path used for OAuth resource indicators.",
+      "tags": [
+        "config",
+        "constants",
+        "oauth",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Auth/OAuth/McpResourcePath.php:McpResourcePath",
+      "type": "class",
+      "name": "McpResourcePath",
+      "filePath": "src/Auth/OAuth/McpResourcePath.php",
+      "lineRange": [
+        24,
+        37
+      ],
+      "summary": "Holds the canonical MCP REST namespace/route constants and the assembled resource path (with and without leading slash).",
+      "tags": [
+        "constants",
+        "config",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "type": "file",
+      "name": "BoundaryAuditBufferTest.php",
+      "filePath": "tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "summary": "Unit tests for BoundaryAuditBuffer covering event capture, non-OAuth filtering, bounded size, and optional-field handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "audit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php:BoundaryAuditBufferTest",
+      "type": "class",
+      "name": "BoundaryAuditBufferTest",
+      "filePath": "tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "lineRange": [
+        16,
+        65
+      ],
+      "summary": "PHPUnit test class exercising the OAuth boundary audit buffer's capture and read behavior.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "type": "file",
+      "name": "BridgeRowProjectorTest.php",
+      "filePath": "tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "summary": "Unit tests for BridgeRowProjector covering row projection, silent-warning thresholds, missing tokens, and software-string formatting.",
+      "tags": [
+        "test",
+        "unit-test",
+        "projection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php:BridgeRowProjectorTest",
+      "type": "class",
+      "name": "BridgeRowProjectorTest",
+      "filePath": "tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "lineRange": [
+        15,
+        94
+      ],
+      "summary": "PHPUnit test class verifying the connected-client row projection and silent-consent warning logic.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "type": "file",
+      "name": "ConnectedBridgesTabTest.php",
+      "filePath": "tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "summary": "Unit tests for ConnectedBridgesTab covering the header-diagnostic filter contract, render states, table rendering, and nonce/capability-gated revoke.",
+      "tags": [
+        "test",
+        "unit-test",
+        "admin"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php:ConnectedBridgesTabTest",
+      "type": "class",
+      "name": "ConnectedBridgesTabTest",
+      "filePath": "tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "lineRange": [
+        21,
+        219
+      ],
+      "summary": "PHPUnit test class for the Connected Bridges admin tab rendering and revoke action handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "type": "file",
+      "name": "ConsentDecisionEvaluatorTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "summary": "Comprehensive unit tests for ConsentDecisionEvaluator covering auto-approve, silent-cap boundaries, sensitive scopes, and incremental decisions.",
+      "tags": [
+        "test",
+        "unit-test",
+        "consent",
+        "policy"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php:ConsentDecisionEvaluatorTest",
+      "type": "class",
+      "name": "ConsentDecisionEvaluatorTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "lineRange": [
+        21,
+        213
+      ],
+      "summary": "PHPUnit test class exhaustively covering the consent decision policy across scope and timing edge cases.",
+      "tags": [
+        "test",
+        "unit-test",
+        "policy"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "type": "file",
+      "name": "ConsentScreenRendererTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "summary": "Unit tests for ConsentScreenRenderer covering form/hidden-input round-tripping, scope checkboxes, escaping/XSS safety, and decision notices.",
+      "tags": [
+        "test",
+        "unit-test",
+        "consent",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php:ConsentScreenRendererTest",
+      "type": "class",
+      "name": "ConsentScreenRendererTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "lineRange": [
+        27,
+        212
+      ],
+      "summary": "PHPUnit test class validating the consent screen HTML structure, escaping, and decision-specific copy.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "type": "file",
+      "name": "LastConsentLookupTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "summary": "Unit tests for LastConsentLookup covering record/read round-trips, per-pair isolation, days-since math, and resilience when option lookups throw.",
+      "tags": [
+        "test",
+        "unit-test",
+        "consent"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php:LastConsentLookupTest",
+      "type": "class",
+      "name": "LastConsentLookupTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "lineRange": [
+        17,
+        128
+      ],
+      "summary": "PHPUnit test class verifying last-consent timestamp storage and its fail-safe routing to full consent.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "type": "file",
+      "name": "PolicyStoreTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "summary": "Unit tests for PolicyStore covering default, option override, filter override, and clamping of the silent-consent days policy.",
+      "tags": [
+        "test",
+        "unit-test",
+        "policy",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php:PolicyStoreTest",
+      "type": "class",
+      "name": "PolicyStoreTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "lineRange": [
+        15,
+        56
+      ],
+      "summary": "PHPUnit test class verifying the silent-cap policy resolution precedence and clamping bounds.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "type": "file",
+      "name": "RenderedScopeNonceTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "summary": "Unit tests for RenderedScopeNonce covering single-use redemption, subset validation, and rejection on mismatched request binding fields.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security",
+        "consent"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php:RenderedScopeNonceTest",
+      "type": "class",
+      "name": "RenderedScopeNonceTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "lineRange": [
+        21,
+        125
+      ],
+      "summary": "PHPUnit test class validating scope-nonce issuance, single-use redemption, and subset/binding checks.",
+      "tags": [
+        "test",
+        "unit-test",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "type": "file",
+      "name": "RoleSelectorTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "summary": "Unit tests for RoleSelector covering resolver-based role lists, non-string filtering, membership checks, and get_userdata fallback.",
+      "tags": [
+        "test",
+        "unit-test",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php:RoleSelectorTest",
+      "type": "class",
+      "name": "RoleSelectorTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "lineRange": [
+        20,
+        62
+      ],
+      "summary": "PHPUnit test class verifying role resolution and role-membership validation for consent.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "type": "file",
+      "name": "McpResourcePathTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "summary": "Unit tests for McpResourcePath asserting the MCP REST namespace, default-server route, and path assembly with/without leading slash.",
+      "tags": [
+        "test",
+        "unit-test",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/McpResourcePathTest.php:McpResourcePathTest",
+      "type": "class",
+      "name": "McpResourcePathTest",
+      "filePath": "tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "lineRange": [
+        21,
+        39
+      ],
+      "summary": "PHPUnit test class verifying the canonical MCP resource path constants.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "type": "file",
+      "name": "PathStyleMultisiteAuthorizeRoutingTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "summary": "Unit tests for path-style multisite authorize routing covering prefix extraction edge cases, self_url construction, and resource-indicator computation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "oauth",
+        "routing"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php:PathStyleMultisiteAuthorizeRoutingTest",
+      "type": "class",
+      "name": "PathStyleMultisiteAuthorizeRoutingTest",
+      "filePath": "tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "lineRange": [
+        41,
+        205
+      ],
+      "summary": "PHPUnit test class for AuthorizeEndpoint/AuthorizationServer path-prefix routing under multisite.",
+      "tags": [
+        "test",
+        "unit-test",
+        "routing"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "type": "file",
+      "name": "BoundaryAuditBuffer.php",
+      "filePath": "src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "summary": "Bounded in-memory/options-backed ring buffer that captures recent OAuth boundary events for the admin diagnostics panel.",
+      "tags": [
+        "service",
+        "audit",
+        "oauth",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Admin/Bridges/BoundaryAuditBuffer.php:BoundaryAuditBuffer",
+      "type": "class",
+      "name": "BoundaryAuditBuffer",
+      "filePath": "src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "lineRange": [
+        28,
+        118
+      ],
+      "summary": "Captures OAuth boundary audit events via a WordPress action hook, storing a bounded slice of recent entries in an option for admin display.",
+      "tags": [
+        "service",
+        "audit",
+        "event-handler",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Bridges/BoundaryAuditBuffer.php:capture",
+      "type": "function",
+      "name": "capture",
+      "filePath": "src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "lineRange": [
+        62,
+        84
+      ],
+      "summary": "Records an OAuth boundary event with optional tags and duration into the bounded buffer, trimming oldest entries past the cap.",
+      "tags": [
+        "event-handler",
+        "audit",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Bridges/BoundaryAuditBuffer.php:read",
+      "type": "function",
+      "name": "read",
+      "filePath": "src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "lineRange": [
+        91,
+        112
+      ],
+      "summary": "Reads and normalizes the stored audit buffer from the WordPress option into a clean array of event entries.",
+      "tags": [
+        "audit",
+        "serialization",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "type": "file",
+      "name": "BridgeRowProjector.php",
+      "filePath": "src/Admin/Bridges/BridgeRowProjector.php",
+      "summary": "Pure projection helper that builds a display row (software label, timestamps, silent-consent warning) for a connected OAuth client.",
+      "tags": [
+        "utility",
+        "projection",
+        "admin",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Admin/Bridges/BridgeRowProjector.php:BridgeRowProjector",
+      "type": "class",
+      "name": "BridgeRowProjector",
+      "filePath": "src/Admin/Bridges/BridgeRowProjector.php",
+      "lineRange": [
+        24,
+        101
+      ],
+      "summary": "Projects a connected-client record plus token/consent metadata into a view-model row, computing the silent-consent warning flag.",
+      "tags": [
+        "utility",
+        "projection",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Bridges/BridgeRowProjector.php:project",
+      "type": "function",
+      "name": "project",
+      "filePath": "src/Admin/Bridges/BridgeRowProjector.php",
+      "lineRange": [
+        50,
+        100
+      ],
+      "summary": "Computes the display row fields and silent-consent warning by comparing last interactive consent against the silent cap.",
+      "tags": [
+        "projection",
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "type": "file",
+      "name": "ConnectedBridgesTab.php",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "summary": "Admin-page tab that lists connected OAuth bridge clients, renders an audit slice and an Authorization-header diagnostic, and handles revoke actions.",
+      "tags": [
+        "api-handler",
+        "admin",
+        "oauth",
+        "component"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Admin/Tabs/ConnectedBridgesTab.php:ConnectedBridgesTab",
+      "type": "class",
+      "name": "ConnectedBridgesTab",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        39,
+        429
+      ],
+      "summary": "Renders the Connected Bridges admin tab (client table, audit log, header diagnostic) and processes nonce-guarded revoke actions.",
+      "tags": [
+        "api-handler",
+        "admin",
+        "component",
+        "oauth"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render",
+      "type": "function",
+      "name": "render",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        57,
+        84
+      ],
+      "summary": "Renders the tab shell: flash messages, the active-client table, the audit slice, and the header diagnostic.",
+      "tags": [
+        "component",
+        "admin",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_table",
+      "type": "function",
+      "name": "render_table",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        91,
+        184
+      ],
+      "summary": "Renders the table of connected clients with projected rows, status, last-activity, and per-row revoke forms.",
+      "tags": [
+        "component",
+        "admin",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_audit_slice",
+      "type": "function",
+      "name": "render_audit_slice",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        187,
+        247
+      ],
+      "summary": "Renders the most recent OAuth boundary audit events from the buffer as a diagnostic table.",
+      "tags": [
+        "component",
+        "audit",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_authorization_header_diagnostic",
+      "type": "function",
+      "name": "render_authorization_header_diagnostic",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        257,
+        292
+      ],
+      "summary": "Renders a diagnostic panel reporting whether the server forwards the HTTP Authorization header.",
+      "tags": [
+        "component",
+        "diagnostic",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:handle_action",
+      "type": "function",
+      "name": "handle_action",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        297,
+        334
+      ],
+      "summary": "Processes the revoke action with capability and nonce checks, then redirects back to the tab.",
+      "tags": [
+        "api-handler",
+        "security",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:resolve_status",
+      "type": "function",
+      "name": "resolve_status",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        386,
+        416
+      ],
+      "summary": "Resolves the Authorization-header forwarding status via a documented filter contract, defaulting to unknown.",
+      "tags": [
+        "validation",
+        "diagnostic",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:format_datetime",
+      "type": "function",
+      "name": "format_datetime",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        366,
+        379
+      ],
+      "summary": "Formats a stored datetime using the site timezone/locale, falling back to UTC.",
+      "tags": [
+        "utility",
+        "formatting",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/Tabs/ConnectedBridgesTab.php:latest_token_for",
+      "type": "function",
+      "name": "latest_token_for",
+      "filePath": "src/Admin/Tabs/ConnectedBridgesTab.php",
+      "lineRange": [
+        339,
+        354
+      ],
+      "summary": "Queries the newest access token row for a given client id from the tokens table.",
+      "tags": [
+        "data-model",
+        "query",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "type": "file",
+      "name": "ConsentDecision.php",
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecision.php",
+      "summary": "Immutable value object describing the outcome of a consent evaluation (auto-approve, render full, or render incremental) plus effective scopes.",
+      "tags": [
+        "data-model",
+        "value-object",
+        "oauth",
+        "consent"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/ConsentDecision.php:ConsentDecision",
+      "type": "class",
+      "name": "ConsentDecision",
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecision.php",
+      "lineRange": [
+        23,
+        60
+      ],
+      "summary": "Value object holding the consent decision mode and computed scope sets, exposing predicate accessors for the chosen mode.",
+      "tags": [
+        "data-model",
+        "value-object",
+        "consent"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "type": "file",
+      "name": "ConsentDecisionEvaluator.php",
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "summary": "Pure policy engine that decides whether an OAuth authorization can be silently auto-approved or requires full/incremental consent re-display.",
+      "tags": [
+        "service",
+        "policy",
+        "oauth",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php:ConsentDecisionEvaluator",
+      "type": "class",
+      "name": "ConsentDecisionEvaluator",
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "lineRange": [
+        33,
+        125
+      ],
+      "summary": "Evaluates requested vs previously granted scopes, sensitivity, and the silent-consent cap to produce a ConsentDecision.",
+      "tags": [
+        "service",
+        "policy",
+        "consent",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php:evaluate",
+      "type": "function",
+      "name": "evaluate",
+      "filePath": "src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "lineRange": [
+        45,
+        117
+      ],
+      "summary": "Core decision logic: auto-approves unchanged/subset scopes within the silent cap, else routes to full or incremental consent.",
+      "tags": [
+        "policy",
+        "consent",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "type": "file",
+      "name": "ConsentScreenRenderer.php",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "summary": "Server-side renderer for the OAuth consent screen and error pages, producing escaped HTML with grouped, toggleable scope checkboxes.",
+      "tags": [
+        "component",
+        "oauth",
+        "consent",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:ConsentScreenRenderer",
+      "type": "class",
+      "name": "ConsentScreenRenderer",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        34,
+        343
+      ],
+      "summary": "Builds the full consent HTML (form, hidden flow params, scope groups, role selector) and standalone error pages.",
+      "tags": [
+        "component",
+        "consent",
+        "serialization",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:build_html",
+      "type": "function",
+      "name": "build_html",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        93,
+        223
+      ],
+      "summary": "Assembles the complete consent-screen HTML document including client info, scope groups, role selector, and action buttons.",
+      "tags": [
+        "component",
+        "serialization",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render_scope_groups",
+      "type": "function",
+      "name": "render_scope_groups",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        232,
+        284
+      ],
+      "summary": "Renders requested scopes grouped by module, marking sensitive scopes and previously granted dates.",
+      "tags": [
+        "component",
+        "consent",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render",
+      "type": "function",
+      "name": "render",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        72,
+        84
+      ],
+      "summary": "Emits the consent screen with HTTP status and security headers, then prints the built HTML.",
+      "tags": [
+        "component",
+        "http",
+        "consent"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render_error",
+      "type": "function",
+      "name": "render_error",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        301,
+        312
+      ],
+      "summary": "Emits a standalone OAuth error page with appropriate status and headers.",
+      "tags": [
+        "component",
+        "error-handling",
+        "http"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:build_error_html",
+      "type": "function",
+      "name": "build_error_html",
+      "filePath": "src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "lineRange": [
+        317,
+        342
+      ],
+      "summary": "Builds the escaped HTML for a standalone OAuth error page.",
+      "tags": [
+        "serialization",
+        "error-handling",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "file",
+      "name": "LastConsentLookup.php",
+      "filePath": "src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "summary": "Per-(client,user) store recording the timestamp of the last interactive consent, used to enforce the silent-consent cap.",
+      "tags": [
+        "service",
+        "consent",
+        "oauth",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/LastConsentLookup.php:LastConsentLookup",
+      "type": "class",
+      "name": "LastConsentLookup",
+      "filePath": "src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "lineRange": [
+        35,
+        97
+      ],
+      "summary": "Records and reads the last interactive consent timestamp per client/user pair and computes elapsed days.",
+      "tags": [
+        "service",
+        "consent",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/LastConsentLookup.php:timestamp_for",
+      "type": "function",
+      "name": "timestamp_for",
+      "filePath": "src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "lineRange": [
+        61,
+        71
+      ],
+      "summary": "Reads the stored last-consent unix timestamp for a client/user pair, returning null when absent or invalid.",
+      "tags": [
+        "consent",
+        "query",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/LastConsentLookup.php:days_since",
+      "type": "function",
+      "name": "days_since",
+      "filePath": "src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "lineRange": [
+        86,
+        96
+      ],
+      "summary": "Returns the integer number of days since the last interactive consent for a client/user pair.",
+      "tags": [
+        "consent",
+        "utility",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "file",
+      "name": "PolicyStore.php",
+      "filePath": "src/Auth/OAuth/Consent/PolicyStore.php",
+      "summary": "Resolves the configurable silent-consent maximum-days policy from option and filter, clamped to safe bounds.",
+      "tags": [
+        "config",
+        "policy",
+        "consent",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/PolicyStore.php:PolicyStore",
+      "type": "class",
+      "name": "PolicyStore",
+      "filePath": "src/Auth/OAuth/Consent/PolicyStore.php",
+      "lineRange": [
+        23,
+        71
+      ],
+      "summary": "Reads the consent silent-cap policy (option then filter override) and clamps it within a fixed min/max range.",
+      "tags": [
+        "config",
+        "policy",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/PolicyStore.php:consent_max_silent_days",
+      "type": "function",
+      "name": "consent_max_silent_days",
+      "filePath": "src/Auth/OAuth/Consent/PolicyStore.php",
+      "lineRange": [
+        47,
+        59
+      ],
+      "summary": "Returns the effective max silent-consent days, applying the option value, filter override, and clamping.",
+      "tags": [
+        "policy",
+        "config",
+        "consent"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "type": "file",
+      "name": "PriorGrantLookup.php",
+      "filePath": "src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "summary": "Looks up the set of scopes previously granted to a client by a user from the most recent stored token.",
+      "tags": [
+        "service",
+        "consent",
+        "oauth",
+        "query"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/PriorGrantLookup.php:PriorGrantLookup",
+      "type": "class",
+      "name": "PriorGrantLookup",
+      "filePath": "src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "lineRange": [
+        22,
+        55
+      ],
+      "summary": "Queries the latest token row for a client/user pair and returns the previously granted scope list.",
+      "tags": [
+        "service",
+        "consent",
+        "query"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/PriorGrantLookup.php:scopes_for",
+      "type": "function",
+      "name": "scopes_for",
+      "filePath": "src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "lineRange": [
+        35,
+        54
+      ],
+      "summary": "Returns the array of previously granted scopes for a client/user pair from the newest token, or empty.",
+      "tags": [
+        "query",
+        "consent",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "type": "file",
+      "name": "RenderedScopeNonce.php",
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "summary": "Issues and redeems single-use server-side nonces binding the exact set of rendered consent scopes to a specific authorization request.",
+      "tags": [
+        "security",
+        "oauth",
+        "consent",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/RenderedScopeNonce.php:RenderedScopeNonce",
+      "type": "class",
+      "name": "RenderedScopeNonce",
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "lineRange": [
+        29,
+        125
+      ],
+      "summary": "Mints transient-backed nonces over the rendered scope set and request context, and validates submitted scope subsets against them.",
+      "tags": [
+        "security",
+        "consent",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:issue",
+      "type": "function",
+      "name": "issue",
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "lineRange": [
+        47,
+        64
+      ],
+      "summary": "Creates a single-use nonce capturing the rendered scopes and request binding, stored as a transient.",
+      "tags": [
+        "security",
+        "consent",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:redeem",
+      "type": "function",
+      "name": "redeem",
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "lineRange": [
+        73,
+        85
+      ],
+      "summary": "Atomically reads and deletes a stored scope nonce, enforcing single-use redemption of the rendered-scope binding.",
+      "tags": [
+        "security",
+        "consent",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:submitted_subset_is_valid",
+      "type": "function",
+      "name": "submitted_subset_is_valid",
+      "filePath": "src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "lineRange": [
+        97,
+        124
+      ],
+      "summary": "Validates that submitted scopes are a subset of the rendered set and that the request binding matches, using constant-time comparisons.",
+      "tags": [
+        "security",
+        "validation",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "type": "file",
+      "name": "RoleSelector.php",
+      "filePath": "src/Auth/OAuth/Consent/RoleSelector.php",
+      "summary": "Resolves the WordPress roles available to a user and validates a submitted role against that set during consent.",
+      "tags": [
+        "utility",
+        "consent",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/RoleSelector.php:RoleSelector",
+      "type": "class",
+      "name": "RoleSelector",
+      "filePath": "src/Auth/OAuth/Consent/RoleSelector.php",
+      "lineRange": [
+        26,
+        72
+      ],
+      "summary": "Provides the user's role list (via injectable resolver or get_userdata) and checks role membership for consent role selection.",
+      "tags": [
+        "utility",
+        "validation",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/RoleSelector.php:roles_for_user_id",
+      "type": "function",
+      "name": "roles_for_user_id",
+      "filePath": "src/Auth/OAuth/Consent/RoleSelector.php",
+      "lineRange": [
+        38,
+        53
+      ],
+      "summary": "Returns the string role slugs for a user, using an injected resolver when provided or falling back to get_userdata.",
+      "tags": [
+        "utility",
+        "validation",
+        "consent"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "type": "file",
+      "name": "AuthorizeEndpoint.php",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "summary": "OAuth 2.1 authorization endpoint orchestrating GET (validate, evaluate consent, auto-approve or render) and POST (verify nonce, mint code, redirect).",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "endpoint",
+        "entry-point"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:AuthorizeEndpoint",
+      "type": "class",
+      "name": "AuthorizeEndpoint",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        54,
+        471
+      ],
+      "summary": "Handles the /authorize flow: request validation, consent evaluation/rendering, scope-nonce verification, authorization-code minting, and redirects.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "endpoint",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:dispatch",
+      "type": "function",
+      "name": "dispatch",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        70,
+        77
+      ],
+      "summary": "Routes the request to GET or POST handlers based on HTTP method, rejecting others.",
+      "tags": [
+        "api-handler",
+        "routing",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:handle_get",
+      "type": "function",
+      "name": "handle_get",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        96,
+        148
+      ],
+      "summary": "Validates the authorize request, evaluates consent, and either auto-approves (mint+redirect) or renders the consent screen.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "consent"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:mint_code_and_redirect",
+      "type": "function",
+      "name": "mint_code_and_redirect",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        155,
+        207
+      ],
+      "summary": "Mints an authorization code for the approved scopes, records consent, and redirects to the client with code or error.",
+      "tags": [
+        "oauth",
+        "security",
+        "api-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:render_consent",
+      "type": "function",
+      "name": "render_consent",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        210,
+        243
+      ],
+      "summary": "Builds the consent-screen parameters (roles, scopes, action URL) and delegates rendering to ConsentScreenRenderer.",
+      "tags": [
+        "api-handler",
+        "consent",
+        "component"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:handle_post",
+      "type": "function",
+      "name": "handle_post",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        258,
+        370
+      ],
+      "summary": "Processes the submitted consent form: validates request, redeems the scope nonce, checks role, then mints the code.",
+      "tags": [
+        "api-handler",
+        "oauth",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:submitted_scopes",
+      "type": "function",
+      "name": "submitted_scopes",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        378,
+        390
+      ],
+      "summary": "Normalizes the submitted scope selection from the POST payload into a unique scope array.",
+      "tags": [
+        "validation",
+        "utility",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_to_login",
+      "type": "function",
+      "name": "redirect_to_login",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        395,
+        407
+      ],
+      "summary": "Redirects an unauthenticated user to wp-login with a return path back to the authorize endpoint.",
+      "tags": [
+        "oauth",
+        "http",
+        "routing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_with_code",
+      "type": "function",
+      "name": "redirect_with_code",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        414,
+        424
+      ],
+      "summary": "Issues a redirect to the client redirect_uri carrying the authorization code and state.",
+      "tags": [
+        "oauth",
+        "http",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_with_error",
+      "type": "function",
+      "name": "redirect_with_error",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        430,
+        441
+      ],
+      "summary": "Issues a redirect to the client redirect_uri carrying an OAuth error code and description.",
+      "tags": [
+        "oauth",
+        "http",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:resource_indicator",
+      "type": "function",
+      "name": "resource_indicator",
+      "filePath": "src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "lineRange": [
+        463,
+        470
+      ],
+      "summary": "Computes the RFC 8707 resource indicator URL for the authorization, respecting path-style multisite prefixes.",
+      "tags": [
+        "oauth",
+        "utility",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "type": "file",
+      "name": "AuthHeaderProbe.php",
+      "filePath": "src/Admin/Bridges/AuthHeaderProbe.php",
+      "summary": "Records whether incoming MCP requests carried an Authorization header over a rolling 100-observation window and derives an OK/WARN health status surfaced in the Connected Bridges admin tab.",
+      "tags": [
+        "monitoring",
+        "diagnostics",
+        "auth",
+        "admin"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Static class storing its rolling window in a WordPress option via update_option/get_option."
+    },
+    {
+      "id": "class:src/Admin/Bridges/AuthHeaderProbe.php:AuthHeaderProbe",
+      "type": "class",
+      "name": "AuthHeaderProbe",
+      "filePath": "src/Admin/Bridges/AuthHeaderProbe.php",
+      "lineRange": [
+        33,
+        144
+      ],
+      "summary": "Static probe that observes Authorization-header presence on MCP-namespace requests and resolves a human-readable bridge auth health status.",
+      "tags": [
+        "monitoring",
+        "diagnostics",
+        "singleton",
+        "auth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Bridges/AuthHeaderProbe.php:record",
+      "type": "function",
+      "name": "record",
+      "filePath": "src/Admin/Bridges/AuthHeaderProbe.php",
+      "lineRange": [
+        56,
+        66
+      ],
+      "summary": "Appends a 0/1 header-presence observation, trims the window to the most recent 100 entries, and persists it with a timestamp.",
+      "tags": [
+        "monitoring",
+        "state-update",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/Bridges/AuthHeaderProbe.php:resolve_status",
+      "type": "function",
+      "name": "resolve_status",
+      "filePath": "src/Admin/Bridges/AuthHeaderProbe.php",
+      "lineRange": [
+        78,
+        125
+      ],
+      "summary": "Computes an OK or WARN bridge auth status (with localized message) from the ratio of recent requests that carried an Authorization header.",
+      "tags": [
+        "diagnostics",
+        "validation",
+        "auth",
+        "i18n"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "file",
+      "name": "AuthorizationServer.php",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "summary": "Central OAuth 2.1 authorization server: boots hooks, runs DB migrations, intercepts discovery/authorize routes, registers REST endpoints, gates by host allowlist, and authenticates Bearer tokens narrowed to the MCP resource.",
+      "tags": [
+        "auth",
+        "oauth",
+        "entry-point",
+        "service",
+        "api-handler"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Drives WordPress via add_action/add_filter; uses dbDelta for schema migration and DateTimeImmutable for token expiry checks."
+    },
+    {
+      "id": "class:src/Auth/OAuth/AuthorizationServer.php:AuthorizationServer",
+      "type": "class",
+      "name": "AuthorizationServer",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        42,
+        553
+      ],
+      "summary": "Orchestrates the OAuth lifecycle for the MCP adapter — route interception, REST registration, host allowlist gating, and constant-time Bearer authentication populating the request context.",
+      "tags": [
+        "auth",
+        "oauth",
+        "service",
+        "singleton",
+        "api-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:boot",
+      "type": "function",
+      "name": "boot",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        50,
+        94
+      ],
+      "summary": "One-time bootstrap wiring init/rest_api_init hooks, the Bearer authentication filter, migrations, and registering the audit buffer and auth-header probe.",
+      "tags": [
+        "bootstrap",
+        "event-handler",
+        "oauth",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:maybe_run_migration",
+      "type": "function",
+      "name": "maybe_run_migration",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        97,
+        110
+      ],
+      "summary": "Runs the schema migration only when the stored DB version is behind the current target version, then records the new version.",
+      "tags": [
+        "migration",
+        "database",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:run_migration",
+      "type": "function",
+      "name": "run_migration",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        113,
+        194
+      ],
+      "summary": "Creates or updates the OAuth clients, authorization codes, and access/refresh token tables using WordPress dbDelta with the site charset collation.",
+      "tags": [
+        "migration",
+        "database",
+        "schema",
+        "oauth"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:intercept_pre_wp_routes",
+      "type": "function",
+      "name": "intercept_pre_wp_routes",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        210,
+        250
+      ],
+      "summary": "Early request interceptor that serves OAuth discovery documents and the authorize endpoint for allowed hosts before WordPress route resolution.",
+      "tags": [
+        "routing",
+        "oauth",
+        "middleware",
+        "discovery"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:extract_path_prefix",
+      "type": "function",
+      "name": "extract_path_prefix",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        263,
+        275
+      ],
+      "summary": "Derives the multisite path prefix preceding a known discovery path segment so routing works under subdirectory installs.",
+      "tags": [
+        "routing",
+        "utility",
+        "multisite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:extract_authorize_path_prefix",
+      "type": "function",
+      "name": "extract_authorize_path_prefix",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        297,
+        310
+      ],
+      "summary": "Extracts the path prefix preceding the OAuth authorize path segment for correct dispatch on subdirectory multisite.",
+      "tags": [
+        "routing",
+        "utility",
+        "multisite",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:is_well_known_or_oauth_path",
+      "type": "function",
+      "name": "is_well_known_or_oauth_path",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        312,
+        323
+      ],
+      "summary": "Returns whether the current request URI targets a .well-known discovery document or an /oauth/ path, used to scope the host allowlist gate.",
+      "tags": [
+        "routing",
+        "validation",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:register_rest_routes",
+      "type": "function",
+      "name": "register_rest_routes",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        326,
+        368
+      ],
+      "summary": "Registers the OAuth token, register, and revoke REST routes with their endpoint dispatch callbacks.",
+      "tags": [
+        "api-handler",
+        "rest",
+        "oauth",
+        "routing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:rest_host_allowlist_gate",
+      "type": "function",
+      "name": "rest_host_allowlist_gate",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        384,
+        395
+      ],
+      "summary": "REST pre-dispatch gate that rejects requests from hosts not on the OAuth allowlist with a 404-style error and a boundary audit event.",
+      "tags": [
+        "security",
+        "validation",
+        "middleware",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:authenticate_bearer",
+      "type": "function",
+      "name": "authenticate_bearer",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        415,
+        521
+      ],
+      "summary": "Authenticates a Bearer token scoped to the MCP resource: validates header, looks up and hash-compares the token, checks expiry/revocation, populates the OAuth request context, and schedules WWW-Authenticate challenges on failure.",
+      "tags": [
+        "auth",
+        "oauth",
+        "security",
+        "validation",
+        "api-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/AuthorizationServer.php:schedule_www_authenticate",
+      "type": "function",
+      "name": "schedule_www_authenticate",
+      "filePath": "src/Auth/OAuth/AuthorizationServer.php",
+      "lineRange": [
+        532,
+        552
+      ],
+      "summary": "Registers a deferred filter that emits an RFC-compliant WWW-Authenticate Bearer challenge header (bare or with error details) on the response.",
+      "tags": [
+        "auth",
+        "oauth",
+        "security",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "type": "file",
+      "name": "OAuthHostAllowlist.php",
+      "filePath": "src/Auth/OAuth/OAuthHostAllowlist.php",
+      "summary": "Builds and checks the set of hostnames permitted to reach OAuth endpoints, derived from the site home URL plus multisite domains, with test override/reset hooks.",
+      "tags": [
+        "security",
+        "validation",
+        "oauth",
+        "multisite"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Caches a static host list and supports override()/reset() for deterministic unit testing."
+    },
+    {
+      "id": "class:src/Auth/OAuth/OAuthHostAllowlist.php:OAuthHostAllowlist",
+      "type": "class",
+      "name": "OAuthHostAllowlist",
+      "filePath": "src/Auth/OAuth/OAuthHostAllowlist.php",
+      "lineRange": [
+        24,
+        87
+      ],
+      "summary": "Static allowlist of OAuth-permitted hosts built from home URL and multisite blogs, with port-stripping host membership checks.",
+      "tags": [
+        "security",
+        "validation",
+        "oauth",
+        "singleton"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthHostAllowlist.php:build",
+      "type": "function",
+      "name": "build",
+      "filePath": "src/Auth/OAuth/OAuthHostAllowlist.php",
+      "lineRange": [
+        32,
+        58
+      ],
+      "summary": "Assembles the lowercase, de-duplicated host allowlist from the home URL host and, on multisite, all registered blog domains.",
+      "tags": [
+        "security",
+        "factory",
+        "oauth",
+        "multisite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "file",
+      "name": "OAuthRequestContext.php",
+      "filePath": "src/Auth/OAuth/OAuthRequestContext.php",
+      "summary": "Per-request holder for the authenticated OAuth identity — user id, granted scopes, resource, client, token id, and selected role — with exact-match scope checks and reset between requests.",
+      "tags": [
+        "auth",
+        "oauth",
+        "state",
+        "data-model"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Static request-scoped context reset on init/rest_api_init to prevent cross-request leakage."
+    },
+    {
+      "id": "class:src/Auth/OAuth/OAuthRequestContext.php:OAuthRequestContext",
+      "type": "class",
+      "name": "OAuthRequestContext",
+      "filePath": "src/Auth/OAuth/OAuthRequestContext.php",
+      "lineRange": [
+        21,
+        118
+      ],
+      "summary": "Static request context exposing the authenticated OAuth principal and granted scopes, with exact-match oauth_has_scope and reset semantics.",
+      "tags": [
+        "auth",
+        "oauth",
+        "state",
+        "singleton"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthRequestContext.php:set",
+      "type": "function",
+      "name": "set",
+      "filePath": "src/Auth/OAuth/OAuthRequestContext.php",
+      "lineRange": [
+        37,
+        46
+      ],
+      "summary": "Populates the current OAuth request context with the authenticated user id, scopes, resource, client id, token id, and selected role.",
+      "tags": [
+        "auth",
+        "oauth",
+        "state-update"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "type": "file",
+      "name": "SelectedRoleEnforcer.php",
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "summary": "Downgrades an OAuth-bound user's effective capabilities to those of a token-selected role via the user_has_cap filter, enforcing least privilege per session.",
+      "tags": [
+        "security",
+        "authorization",
+        "oauth",
+        "middleware"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Hooks user_has_cap; resolves role capabilities through an injectable resolver defaulting to wp_roles()."
+    },
+    {
+      "id": "class:src/Auth/OAuth/SelectedRoleEnforcer.php:SelectedRoleEnforcer",
+      "type": "class",
+      "name": "SelectedRoleEnforcer",
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "lineRange": [
+        35,
+        159
+      ],
+      "summary": "Capability enforcer that replaces an OAuth-bound user's caps with the selected role's caps, falling back to empty caps for unknown roles.",
+      "tags": [
+        "security",
+        "authorization",
+        "oauth",
+        "singleton"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:apply",
+      "type": "function",
+      "name": "apply",
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "lineRange": [
+        85,
+        110
+      ],
+      "summary": "user_has_cap filter callback that, for the OAuth-bound user with a selected role, replaces the capability map with the selected role's capabilities.",
+      "tags": [
+        "security",
+        "authorization",
+        "event-handler",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:role_capabilities",
+      "type": "function",
+      "name": "role_capabilities",
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "lineRange": [
+        119,
+        128
+      ],
+      "summary": "Resolves a role slug to its capability map via the injected resolver, falling back to the default WordPress roles resolver.",
+      "tags": [
+        "authorization",
+        "utility",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:default_role_capabilities",
+      "type": "function",
+      "name": "default_role_capabilities",
+      "filePath": "src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "lineRange": [
+        137,
+        147
+      ],
+      "summary": "Default resolver that reads a role slug's capabilities from wp_roles(), returning an empty array for unknown roles.",
+      "tags": [
+        "authorization",
+        "utility",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "type": "file",
+      "name": "AuthHeaderProbeTest.php",
+      "filePath": "tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "summary": "Unit tests for AuthHeaderProbe covering empty state, all-present OK status, missing-header WARN status, and the 100-observation window cap.",
+      "tags": [
+        "test",
+        "monitoring",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php:AuthHeaderProbeTest",
+      "type": "class",
+      "name": "AuthHeaderProbeTest",
+      "filePath": "tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "lineRange": [
+        15,
+        61
+      ],
+      "summary": "PHPUnit test case asserting AuthHeaderProbe's status resolution and rolling-window behaviour.",
+      "tags": [
+        "test",
+        "monitoring",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "type": "file",
+      "name": "AuthHeaderProbeNamespaceGateTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "summary": "Verifies AuthHeaderProbe only records on MCP-namespace requests, ignoring stale namespaces and unrelated REST routes, and records zero when the Authorization header is absent.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "monitoring"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php:AuthHeaderProbeNamespaceGateTest",
+      "type": "class",
+      "name": "AuthHeaderProbeNamespaceGateTest",
+      "filePath": "tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "lineRange": [
+        26,
+        93
+      ],
+      "summary": "PHPUnit test case exercising authenticate_bearer to confirm the probe's namespace gating.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "type": "file",
+      "name": "AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "summary": "Asserts Bearer authentication is a no-op on non-MCP routes (wp/v2 users/plugins, oauth token endpoint) and only authenticates on the MCP resource, leaving already-authenticated users untouched.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php:AuthenticateBearerNarrowsToMcpResourceTest",
+      "type": "class",
+      "name": "AuthenticateBearerNarrowsToMcpResourceTest",
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "lineRange": [
+        31,
+        136
+      ],
+      "summary": "PHPUnit test case with a stubbed wpdb confirming resource-narrowed Bearer authentication.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "type": "file",
+      "name": "AuthenticateBearerSelectedRoleTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "summary": "Confirms authenticate_bearer reads the token's selected_role into the OAuth request context, defaulting to empty when absent or unset.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "authorization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php:AuthenticateBearerSelectedRoleTest",
+      "type": "class",
+      "name": "AuthenticateBearerSelectedRoleTest",
+      "filePath": "tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "lineRange": [
+        26,
+        128
+      ],
+      "summary": "PHPUnit test case asserting selected-role propagation from token row into the request context.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "type": "file",
+      "name": "BearerHeaderTrimTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "summary": "Verifies authenticate_bearer trims leading, trailing, and tab whitespace from the Bearer token so padded headers authenticate identically to clean ones.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php:BearerHeaderTrimTest",
+      "type": "class",
+      "name": "BearerHeaderTrimTest",
+      "filePath": "tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "lineRange": [
+        33,
+        145
+      ],
+      "summary": "PHPUnit test case asserting whitespace-tolerant Bearer token parsing against a stubbed token store.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "type": "file",
+      "name": "IsWellKnownOrOAuthPathTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "summary": "Reflection-driven tests for the is_well_known_or_oauth_path predicate covering unset/empty/non-string URIs, root, well-known and /oauth/ prefixes, and near-miss substrings.",
+      "tags": [
+        "test",
+        "oauth",
+        "routing",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php:IsWellKnownOrOAuthPathTest",
+      "type": "class",
+      "name": "IsWellKnownOrOAuthPathTest",
+      "filePath": "tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "lineRange": [
+        20,
+        80
+      ],
+      "summary": "PHPUnit test case invoking the private path predicate via reflection across edge-case request URIs.",
+      "tags": [
+        "test",
+        "oauth",
+        "routing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "type": "file",
+      "name": "OAuthHostAllowlistTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "summary": "Tests OAuthHostAllowlist override/reset behaviour, port stripping, empty-host rejection, and rebuild-from-environment after reset.",
+      "tags": [
+        "test",
+        "security",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php:OAuthHostAllowlistTest",
+      "type": "class",
+      "name": "OAuthHostAllowlistTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "lineRange": [
+        15,
+        57
+      ],
+      "summary": "PHPUnit test case asserting host allowlist membership rules and lifecycle hooks.",
+      "tags": [
+        "test",
+        "security",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "type": "file",
+      "name": "OAuthRequestContextResetTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "summary": "Confirms OAuthRequestContext::reset is wired to init (priority 0) and rest_api_init during boot, and that reset clears a previously set context.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "state"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php:OAuthRequestContextResetTest",
+      "type": "class",
+      "name": "OAuthRequestContextResetTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "lineRange": [
+        25,
+        92
+      ],
+      "summary": "PHPUnit test case verifying the reset hook registration and context clearing.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "type": "file",
+      "name": "OAuthRequestContextTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "summary": "Core unit tests for OAuthRequestContext covering set/get of the principal, exact-match scope checks that do not expand umbrella grants, reset, and selected-role round-tripping.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php:OAuthRequestContextTest",
+      "type": "class",
+      "name": "OAuthRequestContextTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "lineRange": [
+        15,
+        132
+      ],
+      "summary": "PHPUnit test case asserting request-context accessors and strict scope semantics.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "type": "file",
+      "name": "ResponseDifferentialHardeningTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "summary": "Security tests ensuring revoked tokens return the same WWW-Authenticate error description as invalid ones (no oracle), the old revoked wording never leaks, and expired-token wording is unchanged.",
+      "tags": [
+        "test",
+        "security",
+        "oauth",
+        "auth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php:ResponseDifferentialHardeningTest",
+      "type": "class",
+      "name": "ResponseDifferentialHardeningTest",
+      "filePath": "tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "lineRange": [
+        27,
+        146
+      ],
+      "summary": "PHPUnit test case asserting indistinguishable error responses across revoked/invalid token states.",
+      "tags": [
+        "test",
+        "security",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "type": "file",
+      "name": "RestRouteHostAllowlistTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "summary": "Tests the REST host allowlist gate: allows known hosts, rejects unknown/missing hosts with a 404-style error, and emits a boundary audit event only on rejection.",
+      "tags": [
+        "test",
+        "security",
+        "oauth",
+        "rest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php:RestRouteHostAllowlistTest",
+      "type": "class",
+      "name": "RestRouteHostAllowlistTest",
+      "filePath": "tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "lineRange": [
+        26,
+        115
+      ],
+      "summary": "PHPUnit test case exercising rest_host_allowlist_gate accept/reject paths and audit emission.",
+      "tags": [
+        "test",
+        "security",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "type": "file",
+      "name": "SelectedRoleEnforcerTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "summary": "Comprehensive tests for SelectedRoleEnforcer covering passthrough cases, capability downgrade for OAuth-bound users, deterministic repeats, unknown/empty-role empty-cap fallback, and custom resolver overrides.",
+      "tags": [
+        "test",
+        "security",
+        "authorization",
+        "oauth"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php:SelectedRoleEnforcerTest",
+      "type": "class",
+      "name": "SelectedRoleEnforcerTest",
+      "filePath": "tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "lineRange": [
+        33,
+        245
+      ],
+      "summary": "PHPUnit test case asserting capability-downgrade and resolver behaviour of the selected-role enforcer.",
+      "tags": [
+        "test",
+        "security",
+        "authorization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "type": "file",
+      "name": "WwwAuthenticateBareChallengeCTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "summary": "Verifies a bare WWW-Authenticate challenge is scheduled for token-less MCP-resource requests (and invalid token formats) but not for non-MCP routes, with an empty error code.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php:WwwAuthenticateBareChallengeCTest",
+      "type": "class",
+      "name": "WwwAuthenticateBareChallengeCTest",
+      "filePath": "tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "lineRange": [
+        29,
+        120
+      ],
+      "summary": "PHPUnit test case asserting bare-challenge scheduling semantics for unauthenticated MCP requests.",
+      "tags": [
+        "test",
+        "auth",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Abilities/BatchExecuteAbility.php",
+      "type": "file",
+      "name": "BatchExecuteAbility.php",
+      "filePath": "src/Abilities/BatchExecuteAbility.php",
+      "summary": "Registers and implements the meta-tool ability that executes multiple WordPress abilities in a single batched MCP call, delegating each item to the tools handler.",
+      "tags": [
+        "api-handler",
+        "meta-tool",
+        "ability",
+        "batch",
+        "service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "WordPress ability registered via wp_register_ability with check_permission and execute callbacks."
+    },
+    {
+      "id": "class:src/Abilities/BatchExecuteAbility.php:BatchExecuteAbility",
+      "type": "class",
+      "name": "BatchExecuteAbility",
+      "filePath": "src/Abilities/BatchExecuteAbility.php",
+      "lineRange": [
+        25,
+        174
+      ],
+      "summary": "Meta-tool ability class that registers a batch-execute MCP tool, gates access via capability checks, and runs each requested ability through the tools handler.",
+      "tags": [
+        "api-handler",
+        "meta-tool",
+        "ability",
+        "batch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/BatchExecuteAbility.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Abilities/BatchExecuteAbility.php",
+      "lineRange": [
+        31,
+        86
+      ],
+      "summary": "Registers the batch-execute ability with the WordPress Abilities API, declaring its input schema, permission callback, and read-leaning MCP annotations.",
+      "tags": [
+        "registration",
+        "ability",
+        "schema",
+        "meta-tool"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/BatchExecuteAbility.php:execute",
+      "type": "function",
+      "name": "execute",
+      "filePath": "src/Abilities/BatchExecuteAbility.php",
+      "lineRange": [
+        109,
+        173
+      ],
+      "summary": "Resolves the active MCP server, iterates the requested tool calls, and aggregates per-item results and errors into a single batch response.",
+      "tags": [
+        "api-handler",
+        "batch",
+        "execution",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "type": "file",
+      "name": "ExecuteAbilityAbility.php",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "summary": "Registers and implements the meta-tool ability that executes a single named WordPress ability, enforcing permission checks, MCP exposure rules, and OAuth scope enforcement before delegation.",
+      "tags": [
+        "api-handler",
+        "meta-tool",
+        "ability",
+        "validation",
+        "security"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Layers self::check_permission, MCP exposure checks, and OAuthScopeEnforcer::check before invoking the inner ability."
+    },
+    {
+      "id": "class:src/Abilities/ExecuteAbilityAbility.php:ExecuteAbilityAbility",
+      "type": "class",
+      "name": "ExecuteAbilityAbility",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "lineRange": [
+        32,
+        271
+      ],
+      "summary": "Meta-tool ability class that runs an arbitrary named ability after validating user access, MCP exposure, the inner ability's own permission callback, and OAuth scope.",
+      "tags": [
+        "api-handler",
+        "meta-tool",
+        "ability",
+        "security",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Abilities/ExecuteAbilityAbility.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "lineRange": [
+        38,
+        94
+      ],
+      "summary": "Registers the execute-ability meta-tool with the Abilities API, declaring its input schema, permission callback, and read-leaning destructive client annotations.",
+      "tags": [
+        "registration",
+        "ability",
+        "schema",
+        "meta-tool"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/ExecuteAbilityAbility.php:check_permission",
+      "type": "function",
+      "name": "check_permission",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "lineRange": [
+        106,
+        148
+      ],
+      "summary": "Validates user access, confirms MCP exposure, and delegates to the target ability's own permission callback before allowing execution.",
+      "tags": [
+        "validation",
+        "security",
+        "permission",
+        "ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/ExecuteAbilityAbility.php:validate_user_access",
+      "type": "function",
+      "name": "validate_user_access",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "lineRange": [
+        155,
+        172
+      ],
+      "summary": "Confirms the user is logged in and holds the filterable capability required to invoke the meta-tool, returning a WP_Error otherwise.",
+      "tags": [
+        "validation",
+        "security",
+        "capability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Abilities/ExecuteAbilityAbility.php:execute",
+      "type": "function",
+      "name": "execute",
+      "filePath": "src/Abilities/ExecuteAbilityAbility.php",
+      "lineRange": [
+        183,
+        270
+      ],
+      "summary": "Re-runs the permission check, enforces OAuth scope, executes the resolved inner ability, and normalizes its result or error into the MCP response shape.",
+      "tags": [
+        "api-handler",
+        "execution",
+        "security",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Admin/PermissionManager.php",
+      "type": "file",
+      "name": "PermissionManager.php",
+      "filePath": "src/Admin/PermissionManager.php",
+      "summary": "Derives the effective read/write/delete permission for an ability from explicit meta or MCP annotations, and persists per-ability enabled/disabled settings with a cached option store.",
+      "tags": [
+        "data-model",
+        "permission",
+        "settings",
+        "security",
+        "service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Static utility class with a cached_settings static property backing get_option/update_option."
+    },
+    {
+      "id": "class:src/Admin/PermissionManager.php:PermissionManager",
+      "type": "class",
+      "name": "PermissionManager",
+      "filePath": "src/Admin/PermissionManager.php",
+      "lineRange": [
+        23,
+        188
+      ],
+      "summary": "Static manager that resolves ability permission levels from annotations and maintains the cached per-ability enabled-settings option.",
+      "tags": [
+        "data-model",
+        "permission",
+        "settings",
+        "singleton"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/PermissionManager.php:get_permission",
+      "type": "function",
+      "name": "get_permission",
+      "filePath": "src/Admin/PermissionManager.php",
+      "lineRange": [
+        67,
+        92
+      ],
+      "summary": "Resolves an ability's permission level, honoring an explicit permission meta first then deriving read/write/delete from readonly and destructive annotations.",
+      "tags": [
+        "permission",
+        "derivation",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/PermissionManager.php:set_enabled",
+      "type": "function",
+      "name": "set_enabled",
+      "filePath": "src/Admin/PermissionManager.php",
+      "lineRange": [
+        123,
+        134
+      ],
+      "summary": "Updates the enabled flag for a single ability in the settings store and refreshes the in-memory cache.",
+      "tags": [
+        "settings",
+        "persistence",
+        "cache"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/PermissionManager.php:get_settings",
+      "type": "function",
+      "name": "get_settings",
+      "filePath": "src/Admin/PermissionManager.php",
+      "lineRange": [
+        141,
+        154
+      ],
+      "summary": "Lazily loads and caches the per-ability settings array from the WordPress option store.",
+      "tags": [
+        "settings",
+        "cache",
+        "persistence"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "type": "file",
+      "name": "ScopeGrouper.php",
+      "filePath": "src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "summary": "Groups flat OAuth scope strings into per-module buckets for the consent screen, ordering umbrella scopes first and flagging groups that contain sensitive scopes.",
+      "tags": [
+        "oauth",
+        "consent",
+        "grouping",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Auth/OAuth/Consent/ScopeGrouper.php:ScopeGrouper",
+      "type": "class",
+      "name": "ScopeGrouper",
+      "filePath": "src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "lineRange": [
+        24,
+        83
+      ],
+      "summary": "Static helper that arranges OAuth scopes into module groups for consent rendering and reports per-group sensitivity.",
+      "tags": [
+        "oauth",
+        "consent",
+        "grouping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/Consent/ScopeGrouper.php:group",
+      "type": "function",
+      "name": "group",
+      "filePath": "src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "lineRange": [
+        39,
+        66
+      ],
+      "summary": "Splits each scope on its module segment, buckets scopes by module, and sorts groups with umbrella scopes rendered before alphabetical modules.",
+      "tags": [
+        "oauth",
+        "grouping",
+        "sorting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "file",
+      "name": "OAuthScopeEnforcer.php",
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "summary": "Enforces OAuth scope on ability execution by deriving the required scope from category and permission, then checking it against granted scopes including umbrella fallbacks for non-sensitive scopes.",
+      "tags": [
+        "oauth",
+        "security",
+        "scope",
+        "authorization",
+        "service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Bridges PermissionManager-derived permissions and ScopeRegistry sensitivity to gate OAuth requests."
+    },
+    {
+      "id": "class:src/Auth/OAuth/OAuthScopeEnforcer.php:OAuthScopeEnforcer",
+      "type": "class",
+      "name": "OAuthScopeEnforcer",
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "lineRange": [
+        47,
+        173
+      ],
+      "summary": "Static enforcer mapping an ability to its required OAuth scope and validating it against the request's granted scopes, with umbrella coverage for non-sensitive scopes.",
+      "tags": [
+        "oauth",
+        "security",
+        "scope",
+        "authorization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check_scope",
+      "type": "function",
+      "name": "check_scope",
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "lineRange": [
+        92,
+        125
+      ],
+      "summary": "Verifies a required scope against the OAuth request's granted scopes, allowing umbrella-grant fallback for non-sensitive scopes and returning a denial payload otherwise.",
+      "tags": [
+        "oauth",
+        "scope",
+        "authorization",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check",
+      "type": "function",
+      "name": "check",
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "lineRange": [
+        74,
+        76
+      ],
+      "summary": "Gates a WP_Ability against the current OAuth request context by deriving the required scope from the ability and delegating to check_scope; thin wrapper returning a denial payload or null when allowed.",
+      "tags": [
+        "oauth",
+        "scope",
+        "authorization",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:umbrella_for",
+      "type": "function",
+      "name": "umbrella_for",
+      "filePath": "src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "lineRange": [
+        151,
+        172
+      ],
+      "summary": "Computes the umbrella scope that would imply a given required scope, used as a fallback grant for non-sensitive scopes.",
+      "tags": [
+        "oauth",
+        "scope",
+        "umbrella"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "file",
+      "name": "ScopeRegistry.php",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "summary": "Canonical registry of all OAuth scopes, declaring umbrella-to-scope expansions, sensitivity flags, and category-coverage checks derived from the live abilities registry.",
+      "tags": [
+        "oauth",
+        "scope",
+        "registry",
+        "schema-definition",
+        "data-model"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Static cache of all_scopes with umbrella expansion and registry-derived category coverage validation."
+    },
+    {
+      "id": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "class",
+      "name": "ScopeRegistry",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "lineRange": [
+        21,
+        321
+      ],
+      "summary": "Static source of truth for OAuth scopes: enumerates all scopes, expands umbrellas, flags sensitive scopes, and validates category coverage against registered abilities.",
+      "tags": [
+        "oauth",
+        "scope",
+        "registry",
+        "schema-definition"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ScopeRegistry.php:expand",
+      "type": "function",
+      "name": "expand",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "lineRange": [
+        127,
+        136
+      ],
+      "summary": "Expands umbrella scopes into their implied non-sensitive concrete scopes and returns a deduplicated scope list.",
+      "tags": [
+        "oauth",
+        "scope",
+        "umbrella",
+        "expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ScopeRegistry.php:all_scopes",
+      "type": "function",
+      "name": "all_scopes",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "lineRange": [
+        148,
+        236
+      ],
+      "summary": "Builds and caches the full deduplicated list of every recognized OAuth scope across all modules and umbrellas.",
+      "tags": [
+        "oauth",
+        "scope",
+        "registry",
+        "cache"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ScopeRegistry.php:categories_from_registry",
+      "type": "function",
+      "name": "categories_from_registry",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "lineRange": [
+        263,
+        286
+      ],
+      "summary": "Derives the sorted, unique set of ability category slugs from the live WordPress abilities registry for coverage checking.",
+      "tags": [
+        "oauth",
+        "scope",
+        "category",
+        "derivation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/ScopeRegistry.php:has_category_coverage",
+      "type": "function",
+      "name": "has_category_coverage",
+      "filePath": "src/Auth/OAuth/ScopeRegistry.php",
+      "lineRange": [
+        294,
+        308
+      ],
+      "summary": "Checks whether at least one registered scope exists for a given ability category, guarding against scope-coverage drift.",
+      "tags": [
+        "oauth",
+        "scope",
+        "category",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "type": "file",
+      "name": "ExecuteAbilityScopeEnforcementTest.php",
+      "filePath": "tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "summary": "Unit tests asserting that the execute-ability meta-tool enforces OAuth scope on the inner ability, blocking when the token lacks the inner scope and allowing explicit or non-OAuth requests.",
+      "tags": [
+        "test",
+        "oauth",
+        "security",
+        "ability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php:ExecuteAbilityScopeEnforcementTest",
+      "type": "class",
+      "name": "ExecuteAbilityScopeEnforcementTest",
+      "filePath": "tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "lineRange": [
+        23,
+        108
+      ],
+      "summary": "PHPUnit test case verifying OAuth scope enforcement when ExecuteAbilityAbility runs an inner ability.",
+      "tags": [
+        "test",
+        "oauth",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "type": "file",
+      "name": "MetaToolPermissionAnnotationTest.php",
+      "filePath": "tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "summary": "Unit tests verifying that the execute and batch-execute meta-tools resolve to a read permission rather than delete, while retaining their destructive client annotation.",
+      "tags": [
+        "test",
+        "permission",
+        "annotation",
+        "meta-tool"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php:MetaToolPermissionAnnotationTest",
+      "type": "class",
+      "name": "MetaToolPermissionAnnotationTest",
+      "filePath": "tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "lineRange": [
+        27,
+        93
+      ],
+      "summary": "PHPUnit test case asserting meta-tool permission derivation and preserved destructive annotations.",
+      "tags": [
+        "test",
+        "permission",
+        "annotation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Admin/PermissionManagerTest.php",
+      "type": "file",
+      "name": "PermissionManagerTest.php",
+      "filePath": "tests/Unit/Admin/PermissionManagerTest.php",
+      "summary": "Extensive unit tests covering PermissionManager permission derivation from annotations, explicit overrides, enabled-flag persistence, and cache behavior.",
+      "tags": [
+        "test",
+        "permission",
+        "settings",
+        "cache"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Admin/PermissionManagerTest.php:PermissionManagerTest",
+      "type": "class",
+      "name": "PermissionManagerTest",
+      "filePath": "tests/Unit/Admin/PermissionManagerTest.php",
+      "lineRange": [
+        13,
+        178
+      ],
+      "summary": "PHPUnit test case exercising PermissionManager's permission resolution, settings persistence, and cache invalidation.",
+      "tags": [
+        "test",
+        "permission",
+        "settings"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "type": "file",
+      "name": "ScopeGrouperTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "summary": "Unit tests verifying ScopeGrouper buckets scopes by module, places umbrella scopes first, sorts modules alphabetically, and flags sensitive groups.",
+      "tags": [
+        "test",
+        "oauth",
+        "consent",
+        "grouping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php:ScopeGrouperTest",
+      "type": "class",
+      "name": "ScopeGrouperTest",
+      "filePath": "tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "lineRange": [
+        15,
+        51
+      ],
+      "summary": "PHPUnit test case validating ScopeGrouper grouping order and sensitivity detection.",
+      "tags": [
+        "test",
+        "oauth",
+        "grouping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "type": "file",
+      "name": "OAuthScopeEnforcerCheckScopeTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "summary": "Unit tests for OAuthScopeEnforcer::check_scope covering non-OAuth no-op, direct matches, missing-scope denial payloads, and umbrella coverage of non-sensitive scopes.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope",
+        "authorization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php:OAuthScopeEnforcerCheckScopeTest",
+      "type": "class",
+      "name": "OAuthScopeEnforcerCheckScopeTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "lineRange": [
+        19,
+        77
+      ],
+      "summary": "PHPUnit test case focused on OAuthScopeEnforcer scope-checking behavior and denial payloads.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "type": "file",
+      "name": "OAuthScopeEnforcerTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "summary": "Unit tests for OAuthScopeEnforcer::check covering read vs write umbrellas, sensitive-scope denial, umbrella fallbacks, and category-to-scope mapping.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope",
+        "authorization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php:OAuthScopeEnforcerTest",
+      "type": "class",
+      "name": "OAuthScopeEnforcerTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "lineRange": [
+        21,
+        177
+      ],
+      "summary": "PHPUnit test case validating OAuthScopeEnforcer end-to-end scope enforcement across umbrella and sensitive-scope scenarios.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "type": "file",
+      "name": "ScopeCoverageDriftTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "summary": "Drift-guard unit tests asserting every snapshot and registry-derived ability category has scope coverage in ScopeRegistry, including regression checks for site and surecart scopes.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope",
+        "regression",
+        "drift"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php:ScopeCoverageDriftTest",
+      "type": "class",
+      "name": "ScopeCoverageDriftTest",
+      "filePath": "tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "lineRange": [
+        43,
+        251
+      ],
+      "summary": "PHPUnit test case guarding against scope-coverage drift between the abilities snapshot, the registry, and ScopeRegistry's category coverage.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope",
+        "drift"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "type": "file",
+      "name": "ScopeRegistryTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "summary": "Unit tests for ScopeRegistry covering scope enumeration, uniqueness, sensitivity flags, umbrella expansion semantics, and unknown-scope detection.",
+      "tags": [
+        "test",
+        "oauth",
+        "scope",
+        "registry"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/ScopeRegistryTest.php:ScopeRegistryTest",
+      "type": "class",
+      "name": "ScopeRegistryTest",
+      "filePath": "tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "lineRange": [
+        15,
+        153
+      ],
+      "summary": "PHPUnit test case validating ScopeRegistry enumeration, expansion, sensitivity, and unknown-scope behavior.",
+      "tags": [
+        "test",
+        "oauth",
+        "registry"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "type": "file",
+      "name": "McpAnnotationMapperBuildTest.php",
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "summary": "Unit tests for McpAnnotationMapper::build_from_ability verifying injection of category, tier, bridge hints, derived permission, and enabled defaults without overriding explicit annotations.",
+      "tags": [
+        "test",
+        "annotation",
+        "mapper",
+        "permission"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php:McpAnnotationMapperBuildTest",
+      "type": "class",
+      "name": "McpAnnotationMapperBuildTest",
+      "filePath": "tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "lineRange": [
+        16,
+        224
+      ],
+      "summary": "PHPUnit test case validating McpAnnotationMapper's annotation-building logic and permission derivation via PermissionManager.",
+      "tags": [
+        "test",
+        "annotation",
+        "mapper"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "type": "file",
+      "name": "DiscoverAbilitiesAbility.php",
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "summary": "Registers and implements the 'discover-abilities' meta-tool that lists, filters, paginates, and summarizes WordPress abilities exposed over MCP, with permission gating and category histograms.",
+      "tags": [
+        "api-handler",
+        "ability",
+        "discovery",
+        "pagination",
+        "permission"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Abilities/DiscoverAbilitiesAbility.php:DiscoverAbilitiesAbility",
+      "type": "class",
+      "name": "DiscoverAbilitiesAbility",
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "lineRange": [
+        29,
+        345
+      ],
+      "summary": "Meta-tool that registers the discover-abilities ability and executes discovery with compact/verbose modes, category filtering, pagination, and per-category histograms.",
+      "tags": [
+        "api-handler",
+        "ability",
+        "discovery",
+        "meta-tool"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Abilities/DiscoverAbilitiesAbility.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "lineRange": [
+        35,
+        110
+      ],
+      "summary": "Registers the discover-abilities ability with its input/output schema and permission callback via wp_register_ability.",
+      "tags": [
+        "ability",
+        "registration",
+        "schema"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/DiscoverAbilitiesAbility.php:validate_user_access",
+      "type": "function",
+      "name": "validate_user_access",
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "lineRange": [
+        132,
+        149
+      ],
+      "summary": "Validates that the current user is logged in and holds the filtered capability required to discover abilities.",
+      "tags": [
+        "permission",
+        "validation",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Abilities/DiscoverAbilitiesAbility.php:execute",
+      "type": "function",
+      "name": "execute",
+      "filePath": "src/Abilities/DiscoverAbilitiesAbility.php",
+      "lineRange": [
+        160,
+        344
+      ],
+      "summary": "Executes ability discovery: enforces permission, collects public MCP abilities, applies search/category filters, paginates, sorts, and builds compact or verbose result payloads with histograms.",
+      "tags": [
+        "api-handler",
+        "discovery",
+        "pagination",
+        "filtering"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Abilities/GetStartedAbility.php",
+      "type": "file",
+      "name": "GetStartedAbility.php",
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "summary": "Registers and implements the 'get-started' onboarding meta-tool that returns site context, available ability categories, and guidance for MCP clients.",
+      "tags": [
+        "api-handler",
+        "ability",
+        "onboarding",
+        "meta-tool",
+        "permission"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Abilities/GetStartedAbility.php:GetStartedAbility",
+      "type": "class",
+      "name": "GetStartedAbility",
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "lineRange": [
+        23,
+        256
+      ],
+      "summary": "Onboarding meta-tool that registers the get-started ability and builds an orientation response describing the site, abilities, and categories for MCP clients.",
+      "tags": [
+        "api-handler",
+        "ability",
+        "onboarding",
+        "meta-tool"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Abilities/GetStartedAbility.php:register",
+      "type": "function",
+      "name": "register",
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "lineRange": [
+        29,
+        87
+      ],
+      "summary": "Registers the get-started ability with its schema and permission callback via wp_register_ability.",
+      "tags": [
+        "ability",
+        "registration",
+        "schema"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/GetStartedAbility.php:check_permission",
+      "type": "function",
+      "name": "check_permission",
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "lineRange": [
+        96,
+        111
+      ],
+      "summary": "Validates that the current user is logged in and holds the filtered capability required to use the get-started ability.",
+      "tags": [
+        "permission",
+        "validation",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Abilities/GetStartedAbility.php:execute",
+      "type": "function",
+      "name": "execute",
+      "filePath": "src/Abilities/GetStartedAbility.php",
+      "lineRange": [
+        120,
+        255
+      ],
+      "summary": "Builds the onboarding payload: gathers site info, current user, public abilities and their categories, and assembles guidance and next-step suggestions.",
+      "tags": [
+        "api-handler",
+        "onboarding",
+        "discovery"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Cli/McpCommand.php",
+      "type": "file",
+      "name": "McpCommand.php",
+      "filePath": "src/Cli/McpCommand.php",
+      "summary": "WP-CLI command class exposing `wp mcp serve` and `wp mcp list` subcommands to run the stdio MCP server bridge and inspect registered MCP servers.",
+      "tags": [
+        "cli",
+        "entry-point",
+        "wp-cli",
+        "command"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Cli/McpCommand.php:McpCommand",
+      "type": "class",
+      "name": "McpCommand",
+      "filePath": "src/Cli/McpCommand.php",
+      "lineRange": [
+        25,
+        189
+      ],
+      "summary": "WP-CLI command providing serve (run stdio bridge for a server, optionally as a given user) and list (enumerate MCP servers and their tool/resource/prompt counts) subcommands.",
+      "tags": [
+        "cli",
+        "wp-cli",
+        "command",
+        "entry-point"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Cli/McpCommand.php:serve",
+      "type": "function",
+      "name": "serve",
+      "filePath": "src/Cli/McpCommand.php",
+      "lineRange": [
+        57,
+        112
+      ],
+      "summary": "Resolves the requested MCP server, optionally switches to a specified user, and runs the stdio server bridge to serve MCP over standard input/output.",
+      "tags": [
+        "cli",
+        "wp-cli",
+        "stdio",
+        "server"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Cli/McpCommand.php:list",
+      "type": "function",
+      "name": "list",
+      "filePath": "src/Cli/McpCommand.php",
+      "lineRange": [
+        141,
+        166
+      ],
+      "summary": "Lists all registered MCP servers with their id, name, version, and tool/resource/prompt counts in a formatted table.",
+      "tags": [
+        "cli",
+        "wp-cli",
+        "listing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Cli/McpCommand.php:get_user",
+      "type": "function",
+      "name": "get_user",
+      "filePath": "src/Cli/McpCommand.php",
+      "lineRange": [
+        174,
+        188
+      ],
+      "summary": "Resolves a CLI-supplied user identifier (numeric id, email, or login) to a WP_User object.",
+      "tags": [
+        "cli",
+        "user",
+        "resolution"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Core/McpAdapter.php",
+      "type": "file",
+      "name": "McpAdapter.php",
+      "filePath": "src/Core/McpAdapter.php",
+      "summary": "Central singleton that bootstraps the MCP adapter: wires WordPress hooks, creates and registers MCP servers from config, registers default abilities and the WP-CLI command.",
+      "tags": [
+        "entry-point",
+        "singleton",
+        "core",
+        "bootstrap",
+        "factory"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:src/Core/McpAdapter.php:McpAdapter",
+      "type": "class",
+      "name": "McpAdapter",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        31,
+        362
+      ],
+      "summary": "Singleton orchestrator that holds registered MCP servers, validates and creates servers from configuration, and registers the default category, abilities, and WP-CLI commands.",
+      "tags": [
+        "singleton",
+        "core",
+        "factory",
+        "bootstrap"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:instance",
+      "type": "function",
+      "name": "instance",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        61,
+        75
+      ],
+      "summary": "Returns the lazily-initialized singleton instance and wires the init and default-server action hooks on first call.",
+      "tags": [
+        "singleton",
+        "bootstrap",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:init",
+      "type": "function",
+      "name": "init",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        82,
+        99
+      ],
+      "summary": "Initialization hook that creates the default server, fires extension actions, and registers WP-CLI commands exactly once.",
+      "tags": [
+        "bootstrap",
+        "initialization",
+        "hook"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:create_server_from_config",
+      "type": "function",
+      "name": "create_server_from_config",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        110,
+        126
+      ],
+      "summary": "Unpacks an McpServerConfig value object and delegates to create_server with the individual server parameters.",
+      "tags": [
+        "factory",
+        "core",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:create_server",
+      "type": "function",
+      "name": "create_server",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        149,
+        269
+      ],
+      "summary": "Validates transports, error/observability handlers and registration timing, constructs an McpServer, records an observability event, and stores it in the server registry.",
+      "tags": [
+        "factory",
+        "core",
+        "validation",
+        "server"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:maybe_create_default_server",
+      "type": "function",
+      "name": "maybe_create_default_server",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        296,
+        307
+      ],
+      "summary": "Conditionally wires hooks to register the default category, abilities, and default server when the create-default-server filter is enabled.",
+      "tags": [
+        "bootstrap",
+        "factory",
+        "hook"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "type": "function",
+      "name": "register_default_abilities",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        329,
+        336
+      ],
+      "summary": "Registers the built-in adapter abilities (get-started, discover, get-info, execute, batch-execute) with the Abilities API.",
+      "tags": [
+        "bootstrap",
+        "ability",
+        "registration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Core/McpAdapter.php:register_wp_cli_commands",
+      "type": "function",
+      "name": "register_wp_cli_commands",
+      "filePath": "src/Core/McpAdapter.php",
+      "lineRange": [
+        343,
+        361
+      ],
+      "summary": "Registers the `wp mcp` WP-CLI command when running under WP-CLI.",
+      "tags": [
+        "cli",
+        "wp-cli",
+        "registration",
+        "bootstrap"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Core/McpServerConfig.php",
+      "type": "file",
+      "name": "McpServerConfig.php",
+      "filePath": "src/Core/McpServerConfig.php",
+      "summary": "Immutable value object holding all configuration for an MCP server (id, routes, name, version, transports, handlers, tools/resources/prompts, permission callback) with a from_array factory and getters.",
+      "tags": [
+        "data-model",
+        "config",
+        "value-object",
+        "core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Core/McpServerConfig.php:McpServerConfig",
+      "type": "class",
+      "name": "McpServerConfig",
+      "filePath": "src/Core/McpServerConfig.php",
+      "lineRange": [
+        26,
+        216
+      ],
+      "summary": "Configuration value object for an MCP server, constructed via from_array with sensible defaults and exposing read-only getters for each server parameter.",
+      "tags": [
+        "data-model",
+        "config",
+        "value-object",
+        "factory"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Core/McpServerConfig.php:from_array",
+      "type": "function",
+      "name": "from_array",
+      "filePath": "src/Core/McpServerConfig.php",
+      "lineRange": [
+        100,
+        118
+      ],
+      "summary": "Static factory that builds an McpServerConfig from an associative array, applying defaults for optional fields.",
+      "tags": [
+        "factory",
+        "config",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "file",
+      "name": "McpErrorHandlerInterface.php",
+      "filePath": "src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "summary": "Contract for MCP error handlers, defining a single log() method that error-handling strategies must implement.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "error-handling",
+        "contract"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php:McpErrorHandlerInterface",
+      "type": "class",
+      "name": "McpErrorHandlerInterface",
+      "filePath": "src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "lineRange": [
+        22,
+        34
+      ],
+      "summary": "Interface defining the log() contract that all MCP error handler implementations must satisfy.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "error-handling",
+        "contract"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "type": "file",
+      "name": "ErrorLogMcpErrorHandler.php",
+      "filePath": "src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "summary": "Error handler implementation that writes formatted MCP error messages (with user id and JSON context) to the PHP error log.",
+      "tags": [
+        "error-handling",
+        "logging",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php:ErrorLogMcpErrorHandler",
+      "type": "class",
+      "name": "ErrorLogMcpErrorHandler",
+      "filePath": "src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "lineRange": [
+        23,
+        45
+      ],
+      "summary": "McpErrorHandlerInterface implementation that logs MCP errors to the PHP error log with severity, user id, and JSON-encoded context.",
+      "tags": [
+        "error-handling",
+        "logging",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "type": "file",
+      "name": "NullMcpErrorHandler.php",
+      "filePath": "src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "summary": "Null-object error handler implementing McpErrorHandlerInterface as a no-op, used as the default when error logging is not desired.",
+      "tags": [
+        "error-handling",
+        "null-object",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php:NullMcpErrorHandler",
+      "type": "class",
+      "name": "NullMcpErrorHandler",
+      "filePath": "src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "lineRange": [
+        23,
+        39
+      ],
+      "summary": "No-op implementation of McpErrorHandlerInterface whose log() method intentionally does nothing.",
+      "tags": [
+        "error-handling",
+        "null-object",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "file",
+      "name": "NullMcpObservabilityHandler.php",
+      "filePath": "src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "summary": "Null-object observability handler implementing McpObservabilityHandlerInterface as a no-op, used as the default when no event tracking is desired.",
+      "tags": [
+        "observability",
+        "null-object",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/Observability/NullMcpObservabilityHandler.php:NullMcpObservabilityHandler",
+      "type": "class",
+      "name": "NullMcpObservabilityHandler",
+      "filePath": "src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "lineRange": [
+        24,
+        40
+      ],
+      "summary": "No-op implementation of McpObservabilityHandlerInterface whose record_event() method intentionally does nothing.",
+      "tags": [
+        "observability",
+        "null-object",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Servers/DefaultServerFactory.php",
+      "type": "file",
+      "name": "DefaultServerFactory.php",
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "summary": "Factory that assembles the default MCP server by discovering public abilities by type (tools/resources/prompts) and creating the server through McpAdapter and McpServerConfig.",
+      "tags": [
+        "factory",
+        "server",
+        "discovery",
+        "core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Servers/DefaultServerFactory.php:DefaultServerFactory",
+      "type": "class",
+      "name": "DefaultServerFactory",
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "lineRange": [
+        30,
+        166
+      ],
+      "summary": "Builds the default MCP server: discovers MCP-public abilities by type, applies configuration filters, and delegates server creation to the McpAdapter singleton.",
+      "tags": [
+        "factory",
+        "server",
+        "discovery"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Servers/DefaultServerFactory.php:create",
+      "type": "function",
+      "name": "create",
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "lineRange": [
+        41,
+        103
+      ],
+      "summary": "Discovers tool/resource/prompt abilities, merges filtered server config, and creates the default server via McpAdapter, surfacing creation errors via _doing_it_wrong.",
+      "tags": [
+        "factory",
+        "server",
+        "discovery",
+        "configuration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Servers/DefaultServerFactory.php:is_ability_mcp_public",
+      "type": "function",
+      "name": "is_ability_mcp_public",
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "lineRange": [
+        116,
+        128
+      ],
+      "summary": "Determines whether an ability is publicly exposable over MCP based on its show_in_rest flag and MCP meta.",
+      "tags": [
+        "discovery",
+        "validation",
+        "ability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Servers/DefaultServerFactory.php:discover_abilities_by_type",
+      "type": "function",
+      "name": "discover_abilities_by_type",
+      "filePath": "src/Servers/DefaultServerFactory.php",
+      "lineRange": [
+        140,
+        165
+      ],
+      "summary": "Iterates all registered abilities and returns the names of public ones matching the requested MCP type (tool, resource, or prompt).",
+      "tags": [
+        "discovery",
+        "ability",
+        "filtering"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "type": "file",
+      "name": "DiscoverAbilitiesDefaultsTest.php",
+      "filePath": "tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "summary": "Unit tests for DiscoverAbilitiesAbility covering default compact/limit behavior, pagination, verbose mode, category filtering, histogram accuracy, and exclusion of non-public abilities.",
+      "tags": [
+        "test",
+        "ability",
+        "discovery",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php:DiscoverAbilitiesDefaultsTest",
+      "type": "class",
+      "name": "DiscoverAbilitiesDefaultsTest",
+      "filePath": "tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "lineRange": [
+        17,
+        194
+      ],
+      "summary": "PHPUnit test case exercising DiscoverAbilitiesAbility::execute across default, verbose, pagination, category-filter, and histogram scenarios.",
+      "tags": [
+        "test",
+        "ability",
+        "discovery",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "type": "file",
+      "name": "StdioServerBridgeIdNullTest.php",
+      "filePath": "tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "summary": "Unit tests verifying StdioServerBridge JSON-RPC id handling: notifications without id return empty, explicit null/string/int/zero ids round-trip correctly in responses.",
+      "tags": [
+        "test",
+        "cli",
+        "stdio",
+        "json-rpc",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Cli/StdioServerBridgeIdNullTest.php:StdioServerBridgeIdNullTest",
+      "type": "class",
+      "name": "StdioServerBridgeIdNullTest",
+      "filePath": "tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "lineRange": [
+        35,
+        132
+      ],
+      "summary": "PHPUnit test case using reflection to drive StdioServerBridge and assert correct JSON-RPC id semantics for notifications and various id types.",
+      "tags": [
+        "test",
+        "cli",
+        "stdio",
+        "json-rpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Core/McpServerConfigTest.php",
+      "type": "file",
+      "name": "McpServerConfigTest.php",
+      "filePath": "tests/Unit/Core/McpServerConfigTest.php",
+      "summary": "Unit tests for McpServerConfig verifying from_array construction, every getter, default values for optional fields, and required-only/empty-array construction paths.",
+      "tags": [
+        "test",
+        "config",
+        "value-object",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Core/McpServerConfigTest.php:McpServerConfigTest",
+      "type": "class",
+      "name": "McpServerConfigTest",
+      "filePath": "tests/Unit/Core/McpServerConfigTest.php",
+      "lineRange": [
+        15,
+        206
+      ],
+      "summary": "PHPUnit test case validating McpServerConfig::from_array and each getter, including default and edge-case configurations.",
+      "tags": [
+        "test",
+        "config",
+        "value-object"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:abilities-mcp-adapter.php",
+      "type": "file",
+      "name": "abilities-mcp-adapter.php",
+      "filePath": "abilities-mcp-adapter.php",
+      "summary": "Main WordPress plugin bootstrap file that defines plugin headers/constants, wires the PSR-4 autoloader, and registers core services (MCP adapter, admin pages, OAuth server, settings abilities) via WordPress hooks.",
+      "tags": [
+        "entry-point",
+        "bootstrap",
+        "plugin",
+        "wordpress",
+        "service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "WordPress plugin main file: header docblock drives plugin metadata; uses real PSR-4 `use` imports plus procedural hook registration at file scope."
+    },
+    {
+      "id": "file:src/Admin/AbilitySettingsPage.php",
+      "type": "file",
+      "name": "AbilitySettingsPage.php",
+      "filePath": "src/Admin/AbilitySettingsPage.php",
+      "summary": "Legacy admin settings-page shim that registers the old abilities menu slug and 301-redirects requests to the consolidated AdapterAdminPage abilities tab.",
+      "tags": [
+        "admin",
+        "redirect",
+        "legacy",
+        "wordpress",
+        "backward-compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Admin/AdapterAdminPage.php",
+      "type": "file",
+      "name": "AdapterAdminPage.php",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "summary": "Central admin UI controller that registers the top-level adapter menu page, resolves and renders tabs (Abilities, Connected Bridges, Safety), dispatches form submissions to tab handlers, and builds tab/page URLs.",
+      "tags": [
+        "admin",
+        "api-handler",
+        "ui-controller",
+        "wordpress",
+        "router"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses static class constants for tab IDs and self:: dispatch; centralizes WP admin menu and asset enqueue logic."
+    },
+    {
+      "id": "file:src/Admin/SafetySettingsPage.php",
+      "type": "file",
+      "name": "SafetySettingsPage.php",
+      "filePath": "src/Admin/SafetySettingsPage.php",
+      "summary": "Legacy admin settings-page shim that registers the old safety menu slug and 301-redirects requests to the consolidated AdapterAdminPage safety tab.",
+      "tags": [
+        "admin",
+        "redirect",
+        "legacy",
+        "wordpress",
+        "backward-compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "type": "file",
+      "name": "AbilitiesTab.php",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "summary": "Admin tab that renders and processes the Abilities and License subtabs: toggles which WordPress abilities are MCP-exposed, persists per-permission settings, and drives license activation/deactivation.",
+      "tags": [
+        "admin",
+        "api-handler",
+        "ui-controller",
+        "validation",
+        "wordpress"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Heavy use of WP escaping helpers (esc_html_e, esc_attr) and nonce verification; static handler methods invoked by AdapterAdminPage dispatch."
+    },
+    {
+      "id": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "type": "file",
+      "name": "OAuthCleanup.php",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "summary": "Scheduled maintenance service that registers a WP-Cron event to batch-delete expired/revoked OAuth authorization codes, access/refresh tokens, and stale DCR clients, and alerts when table row counts exceed a threshold.",
+      "tags": [
+        "service",
+        "cron",
+        "cleanup",
+        "oauth",
+        "database"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses $wpdb direct queries with LIMIT-bounded batch deletes; cron hook name and 50000-row alert threshold are class constants."
+    },
+    {
+      "id": "file:src/Plugin.php",
+      "type": "file",
+      "name": "Plugin.php",
+      "filePath": "src/Plugin.php",
+      "summary": "Singleton plugin orchestrator that checks runtime dependencies, boots the MCP adapter and admin settings pages, and guards against cloning/unserialization of the instance.",
+      "tags": [
+        "singleton",
+        "bootstrap",
+        "service",
+        "factory",
+        "wordpress"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Classic PHP singleton pattern (static $instance, guarded __clone/__wakeup) used as the plugin's setup entry point."
+    },
+    {
+      "id": "file:tests/Unit/Admin/AdapterAdminPageTest.php",
+      "type": "file",
+      "name": "AdapterAdminPageTest.php",
+      "filePath": "tests/Unit/Admin/AdapterAdminPageTest.php",
+      "summary": "Unit tests for AdapterAdminPage covering tab ID enumeration, active-tab resolution and fallback, page/tab URL construction, and network-admin menu registration behavior.",
+      "tags": [
+        "test",
+        "unit-test",
+        "admin",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "type": "file",
+      "name": "LegacyRedirectorsTest.php",
+      "filePath": "tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "summary": "Unit tests verifying the legacy AbilitySettingsPage and SafetySettingsPage shims preserve old menu slugs and emit 301 redirects to the new consolidated admin tabs.",
+      "tags": [
+        "test",
+        "unit-test",
+        "redirect",
+        "admin",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "type": "file",
+      "name": "OAuthCleanupTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "summary": "Unit tests for OAuthCleanup covering cron scheduling idempotency, the delete queries issued for expired/revoked codes and tokens and stale DCR clients, LIMIT usage, and the row-count alert threshold.",
+      "tags": [
+        "test",
+        "unit-test",
+        "cron",
+        "oauth",
+        "database"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Installs a capturing $wpdb double to assert on the exact SQL emitted by the cleanup run."
+    },
+    {
+      "id": "class:src/Admin/AbilitySettingsPage.php:AbilitySettingsPage",
+      "type": "class",
+      "name": "AbilitySettingsPage",
+      "filePath": "src/Admin/AbilitySettingsPage.php",
+      "lineRange": [
+        28,
+        63
+      ],
+      "summary": "Legacy abilities settings page that hooks admin_init to redirect the old slug to the new abilities tab.",
+      "tags": [
+        "admin",
+        "redirect",
+        "legacy",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/AbilitySettingsPage.php:maybe_redirect",
+      "type": "function",
+      "name": "maybe_redirect",
+      "filePath": "src/Admin/AbilitySettingsPage.php",
+      "lineRange": [
+        45,
+        62
+      ],
+      "summary": "Detects requests to the legacy abilities page slug and issues a safe redirect to the consolidated AdapterAdminPage abilities tab, preserving relevant query args.",
+      "tags": [
+        "redirect",
+        "admin",
+        "backward-compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Admin/AdapterAdminPage.php:AdapterAdminPage",
+      "type": "class",
+      "name": "AdapterAdminPage",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        32,
+        236
+      ],
+      "summary": "Central admin page controller managing the top-level menu, tab routing, form-submission dispatch, asset enqueue, and rendering for the adapter's settings UI.",
+      "tags": [
+        "admin",
+        "ui-controller",
+        "router",
+        "wordpress"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Admin/AdapterAdminPage.php:add_menu_page",
+      "type": "function",
+      "name": "add_menu_page",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        64,
+        75
+      ],
+      "summary": "Registers the plugin's top-level WordPress admin menu page, using the appropriate capability for single-site vs network admin contexts.",
+      "tags": [
+        "admin",
+        "menu",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/AdapterAdminPage.php:dispatch_form_submissions",
+      "type": "function",
+      "name": "dispatch_form_submissions",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        126,
+        146
+      ],
+      "summary": "Routes POST form submissions to the correct tab handler (abilities save, license actions, safety save, connected-bridges action) based on submitted action keys.",
+      "tags": [
+        "admin",
+        "router",
+        "form-handler",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/AdapterAdminPage.php:enqueue_assets",
+      "type": "function",
+      "name": "enqueue_assets",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        153,
+        166
+      ],
+      "summary": "Conditionally enqueues the admin stylesheet only on the adapter's own settings page hook.",
+      "tags": [
+        "admin",
+        "assets",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/AdapterAdminPage.php:render_page",
+      "type": "function",
+      "name": "render_page",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        171,
+        222
+      ],
+      "summary": "Renders the settings page chrome (capability check, header, tab navigation, settings errors) and delegates body rendering to the active tab's render method.",
+      "tags": [
+        "admin",
+        "ui-rendering",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "function",
+      "name": "tab_url",
+      "filePath": "src/Admin/AdapterAdminPage.php",
+      "lineRange": [
+        94,
+        97
+      ],
+      "summary": "Builds the admin URL for a given tab by appending the tab query arg plus any extra args to the page URL.",
+      "tags": [
+        "admin",
+        "url-builder",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Admin/SafetySettingsPage.php:SafetySettingsPage",
+      "type": "class",
+      "name": "SafetySettingsPage",
+      "filePath": "src/Admin/SafetySettingsPage.php",
+      "lineRange": [
+        26,
+        55
+      ],
+      "summary": "Legacy safety settings page that hooks admin_init to redirect the old slug to the new safety tab.",
+      "tags": [
+        "admin",
+        "redirect",
+        "legacy",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/SafetySettingsPage.php:maybe_redirect",
+      "type": "function",
+      "name": "maybe_redirect",
+      "filePath": "src/Admin/SafetySettingsPage.php",
+      "lineRange": [
+        43,
+        54
+      ],
+      "summary": "Detects requests to the legacy safety page slug and issues a safe redirect to the consolidated AdapterAdminPage safety tab.",
+      "tags": [
+        "redirect",
+        "admin",
+        "backward-compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Admin/Tabs/AbilitiesTab.php:AbilitiesTab",
+      "type": "class",
+      "name": "AbilitiesTab",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        34,
+        369
+      ],
+      "summary": "Admin tab handling MCP ability exposure toggling, per-permission persistence, and license management, with separate Abilities and License subtab renderers.",
+      "tags": [
+        "admin",
+        "ui-controller",
+        "validation",
+        "wordpress"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:handle_save_abilities",
+      "type": "function",
+      "name": "handle_save_abilities",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        52,
+        91
+      ],
+      "summary": "Verifies nonce and capability, then persists which MCP-exposed abilities are enabled via PermissionManager and redirects back to the abilities tab.",
+      "tags": [
+        "admin",
+        "validation",
+        "form-handler",
+        "security",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:handle_license_actions",
+      "type": "function",
+      "name": "handle_license_actions",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        98,
+        136
+      ],
+      "summary": "Processes license activate/deactivate form actions with capability and referer checks, surfacing settings errors and redirecting back to the license subtab.",
+      "tags": [
+        "admin",
+        "validation",
+        "license",
+        "form-handler",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:render",
+      "type": "function",
+      "name": "render",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        141,
+        162
+      ],
+      "summary": "Renders the abilities tab subtab navigation and dispatches to the abilities or license subtab renderer based on the active subtab.",
+      "tags": [
+        "admin",
+        "ui-rendering",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:render_abilities_subtab",
+      "type": "function",
+      "name": "render_abilities_subtab",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        176,
+        243
+      ],
+      "summary": "Renders the grouped, permission-bucketed list of MCP-exposed abilities with enable checkboxes and a save form.",
+      "tags": [
+        "admin",
+        "ui-rendering",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:render_license_subtab",
+      "type": "function",
+      "name": "render_license_subtab",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        248,
+        326
+      ],
+      "summary": "Renders the license status panel and activation/deactivation forms based on the current license manager status.",
+      "tags": [
+        "admin",
+        "ui-rendering",
+        "license",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:group_abilities_by_permission",
+      "type": "function",
+      "name": "group_abilities_by_permission",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        335,
+        354
+      ],
+      "summary": "Filters abilities to MCP-exposed ones and groups them by their configured permission level for display.",
+      "tags": [
+        "admin",
+        "data-transformation",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Admin/Tabs/AbilitiesTab.php:is_mcp_exposed",
+      "type": "function",
+      "name": "is_mcp_exposed",
+      "filePath": "src/Admin/Tabs/AbilitiesTab.php",
+      "lineRange": [
+        359,
+        368
+      ],
+      "summary": "Determines whether a given ability is exposed to MCP clients by inspecting its REST visibility and meta.",
+      "tags": [
+        "validation",
+        "predicate",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Auth/OAuth/OAuthCleanup.php:OAuthCleanup",
+      "type": "class",
+      "name": "OAuthCleanup",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "lineRange": [
+        35,
+        178
+      ],
+      "summary": "WP-Cron-driven cleanup service that purges expired/revoked OAuth artifacts in bounded batches and alerts on oversized tables.",
+      "tags": [
+        "service",
+        "cron",
+        "cleanup",
+        "oauth",
+        "database"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthCleanup.php:schedule",
+      "type": "function",
+      "name": "schedule",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "lineRange": [
+        62,
+        69
+      ],
+      "summary": "Registers the daily WP-Cron event for OAuth cleanup if it is not already scheduled.",
+      "tags": [
+        "cron",
+        "scheduling",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthCleanup.php:run",
+      "type": "function",
+      "name": "run",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "lineRange": [
+        90,
+        123
+      ],
+      "summary": "Cron callback that batch-deletes used/expired auth codes, revoked/expired access and refresh tokens, and stale DCR clients, then checks row-count alerts.",
+      "tags": [
+        "cron",
+        "cleanup",
+        "database",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthCleanup.php:batch_delete",
+      "type": "function",
+      "name": "batch_delete",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "lineRange": [
+        131,
+        139
+      ],
+      "summary": "Executes a LIMIT-bounded DELETE query against a given table and where clause using $wpdb.",
+      "tags": [
+        "database",
+        "cleanup",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Auth/OAuth/OAuthCleanup.php:maybe_alert_row_counts",
+      "type": "function",
+      "name": "maybe_alert_row_counts",
+      "filePath": "src/Auth/OAuth/OAuthCleanup.php",
+      "lineRange": [
+        147,
+        177
+      ],
+      "summary": "Counts rows in OAuth tables and, when any exceeds the alert threshold, persists an admin-notice option warning of oversized tables.",
+      "tags": [
+        "monitoring",
+        "database",
+        "alerting",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Plugin.php:Plugin",
+      "type": "class",
+      "name": "Plugin",
+      "filePath": "src/Plugin.php",
+      "lineRange": [
+        26,
+        134
+      ],
+      "summary": "Singleton plugin orchestrator that boots the MCP adapter and admin pages once dependencies are satisfied.",
+      "tags": [
+        "singleton",
+        "bootstrap",
+        "factory",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Plugin.php:instance",
+      "type": "function",
+      "name": "instance",
+      "filePath": "src/Plugin.php",
+      "lineRange": [
+        39,
+        53
+      ],
+      "summary": "Lazily creates and returns the single Plugin instance, running setup once and firing a loaded action hook.",
+      "tags": [
+        "singleton",
+        "factory",
+        "wordpress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Plugin.php:setup",
+      "type": "function",
+      "name": "setup",
+      "filePath": "src/Plugin.php",
+      "lineRange": [
+        58,
+        74
+      ],
+      "summary": "Boots the MCP adapter and (in admin context) registers the legacy settings-page redirectors after confirming dependencies are present.",
+      "tags": [
+        "bootstrap",
+        "service-wiring",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Plugin.php:has_dependencies",
+      "type": "function",
+      "name": "has_dependencies",
+      "filePath": "src/Plugin.php",
+      "lineRange": [
+        83,
+        103
+      ],
+      "summary": "Checks for required runtime dependencies (e.g. the Abilities API) and shows an admin notice if any are missing.",
+      "tags": [
+        "validation",
+        "dependency-check",
+        "wordpress"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Admin/AdapterAdminPageTest.php:AdapterAdminPageTest",
+      "type": "class",
+      "name": "AdapterAdminPageTest",
+      "filePath": "tests/Unit/Admin/AdapterAdminPageTest.php",
+      "lineRange": [
+        15,
+        102
+      ],
+      "summary": "PHPUnit test case exercising AdapterAdminPage tab resolution, URL building, and admin-menu registration.",
+      "tags": [
+        "test",
+        "unit-test",
+        "admin"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Admin/LegacyRedirectorsTest.php:LegacyRedirectorsTest",
+      "type": "class",
+      "name": "LegacyRedirectorsTest",
+      "filePath": "tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "lineRange": [
+        23,
+        99
+      ],
+      "summary": "PHPUnit test case verifying legacy abilities/safety redirector shims preserve slugs and emit 301 redirects.",
+      "tags": [
+        "test",
+        "unit-test",
+        "redirect"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthCleanupTest.php:OAuthCleanupTest",
+      "type": "class",
+      "name": "OAuthCleanupTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "lineRange": [
+        28,
+        212
+      ],
+      "summary": "PHPUnit test case asserting OAuthCleanup cron scheduling, the SQL deletes it issues, batch LIMIT usage, and row-count alerting via a capturing $wpdb double.",
+      "tags": [
+        "test",
+        "unit-test",
+        "cron",
+        "database"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Domain/Utils/McpValidator.php",
+      "type": "file",
+      "name": "McpValidator.php",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "summary": "Shared low-level MCP validation utility providing static helpers for names, MIME types, base64, resource URIs, roles, priorities, ISO-8601 timestamps, and annotation validation used across the tool/resource/prompt validators.",
+      "tags": [
+        "validation",
+        "utility",
+        "mcp",
+        "data-model",
+        "shared"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Stateless class of static methods acting as a validation toolkit; relies on WordPress i18n (__) for error strings."
+    },
+    {
+      "id": "class:src/Domain/Utils/McpValidator.php:McpValidator",
+      "type": "class",
+      "name": "McpValidator",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        22,
+        392
+      ],
+      "summary": "Static utility class with 15 primitive validators (name, ability name, MIME type, base64, resource URI, role, priority, ISO-8601, and annotation/tool-annotation error collection) that underpin all higher-level MCP component validators.",
+      "tags": [
+        "validation",
+        "utility",
+        "mcp",
+        "static-methods"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:validate_iso8601_timestamp",
+      "type": "function",
+      "name": "validate_iso8601_timestamp",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        34,
+        57
+      ],
+      "summary": "Validates that a string is a well-formed ISO-8601 timestamp, accepting both UTC ('Z') and explicit timezone offset formats via DateTime round-trip checks.",
+      "tags": [
+        "validation",
+        "datetime",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:validate_name",
+      "type": "function",
+      "name": "validate_name",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        72,
+        85
+      ],
+      "summary": "Core name validator enforcing non-emptiness, a configurable maximum length, and an allowed-character regex; delegated to by tool/prompt and argument name checks.",
+      "tags": [
+        "validation",
+        "utility",
+        "string"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:validate_base64",
+      "type": "function",
+      "name": "validate_base64",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        177,
+        190
+      ],
+      "summary": "Checks that a string is non-empty and decodes cleanly as strict base64, used to validate inline binary resource/content payloads.",
+      "tags": [
+        "validation",
+        "serialization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:validate_resource_uri",
+      "type": "function",
+      "name": "validate_resource_uri",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        202,
+        216
+      ],
+      "summary": "Validates an MCP resource URI for non-emptiness, maximum length, and conformance to the expected scheme/format regex.",
+      "tags": [
+        "validation",
+        "uri",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:validate_roles_array",
+      "type": "function",
+      "name": "validate_roles_array",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        240,
+        252
+      ],
+      "summary": "Validates that an audience roles array is non-empty and contains only string values that pass the individual role check (user/assistant).",
+      "tags": [
+        "validation",
+        "utility",
+        "array"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:get_tool_annotation_validation_errors",
+      "type": "function",
+      "name": "get_tool_annotation_validation_errors",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        285,
+        328
+      ],
+      "summary": "Collects validation errors for tool annotation hints (boolean behavior hints and title), returning a list of localized error messages while ignoring unknown fields.",
+      "tags": [
+        "validation",
+        "annotations",
+        "mcp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Utils/McpValidator.php:get_annotation_validation_errors",
+      "type": "function",
+      "name": "get_annotation_validation_errors",
+      "filePath": "src/Domain/Utils/McpValidator.php",
+      "lineRange": [
+        345,
+        391
+      ],
+      "summary": "Collects validation errors for generic MCP annotations (audience roles, lastModified timestamp, priority), returning localized messages used by the tool, resource, and prompt validators.",
+      "tags": [
+        "validation",
+        "annotations",
+        "mcp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Domain/Tools/McpToolValidator.php",
+      "type": "file",
+      "name": "McpToolValidator.php",
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "summary": "Validates MCP tool definitions and instances, checking name, description, input/output JSON schemas, annotations, and per-server name uniqueness.",
+      "tags": [
+        "validation",
+        "mcp",
+        "data-model",
+        "schema-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Delegates primitive checks to McpValidator and returns WP_Error on instance validation failures."
+    },
+    {
+      "id": "class:src/Domain/Tools/McpToolValidator.php:McpToolValidator",
+      "type": "class",
+      "name": "McpToolValidator",
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "lineRange": [
+        27,
+        293
+      ],
+      "summary": "Static validator for MCP tools that aggregates field errors (name, description, input/output schema, annotations) and enforces uniqueness of tool names within a server.",
+      "tags": [
+        "validation",
+        "mcp",
+        "tool",
+        "static-methods"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpToolValidator.php:get_validation_errors",
+      "type": "function",
+      "name": "get_validation_errors",
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "lineRange": [
+        78,
+        140
+      ],
+      "summary": "Builds the full list of validation errors for a tool data array, covering name, description, input/output schemas, and both generic and tool-specific annotations.",
+      "tags": [
+        "validation",
+        "mcp",
+        "tool"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpToolValidator.php:get_schema_validation_errors",
+      "type": "function",
+      "name": "get_schema_validation_errors",
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "lineRange": [
+        150,
+        264
+      ],
+      "summary": "Validates a tool's JSON Schema fragment, ensuring object type, well-formed properties (including stdClass), and that required fields reference declared properties.",
+      "tags": [
+        "validation",
+        "schema-definition",
+        "json-schema"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Tools/McpToolValidator.php:validate_tool_uniqueness",
+      "type": "function",
+      "name": "validate_tool_uniqueness",
+      "filePath": "src/Domain/Tools/McpToolValidator.php",
+      "lineRange": [
+        274,
+        292
+      ],
+      "summary": "Ensures a tool's name is not already registered on its MCP server, returning a WP_Error describing the collision when found.",
+      "tags": [
+        "validation",
+        "mcp",
+        "uniqueness"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Domain/Resources/McpResourceValidator.php",
+      "type": "file",
+      "name": "McpResourceValidator.php",
+      "filePath": "src/Domain/Resources/McpResourceValidator.php",
+      "summary": "Validates MCP resource definitions and instances, checking URI, name/description types, MIME type, mutually exclusive text/blob content, annotations, and per-server URI uniqueness.",
+      "tags": [
+        "validation",
+        "mcp",
+        "data-model",
+        "resource"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Delegates URI/MIME/annotation checks to McpValidator; returns WP_Error from instance-level validation."
+    },
+    {
+      "id": "class:src/Domain/Resources/McpResourceValidator.php:McpResourceValidator",
+      "type": "class",
+      "name": "McpResourceValidator",
+      "filePath": "src/Domain/Resources/McpResourceValidator.php",
+      "lineRange": [
+        26,
+        176
+      ],
+      "summary": "Static validator for MCP resources aggregating field-level errors and enforcing that a resource URI is unique within its server.",
+      "tags": [
+        "validation",
+        "mcp",
+        "resource",
+        "static-methods"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Resources/McpResourceValidator.php:get_validation_errors",
+      "type": "function",
+      "name": "get_validation_errors",
+      "filePath": "src/Domain/Resources/McpResourceValidator.php",
+      "lineRange": [
+        77,
+        151
+      ],
+      "summary": "Collects all validation errors for resource data, including URI validity, name/description/MIME-type string checks, mutually exclusive text vs blob content, and annotations.",
+      "tags": [
+        "validation",
+        "mcp",
+        "resource"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Resources/McpResourceValidator.php:validate_resource_uniqueness",
+      "type": "function",
+      "name": "validate_resource_uniqueness",
+      "filePath": "src/Domain/Resources/McpResourceValidator.php",
+      "lineRange": [
+        161,
+        175
+      ],
+      "summary": "Checks that a resource's URI is not already registered on its MCP server, returning a WP_Error on collision.",
+      "tags": [
+        "validation",
+        "mcp",
+        "uniqueness"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "type": "file",
+      "name": "McpPromptValidator.php",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "summary": "Validates MCP prompt definitions and instances, including name, description/title, argument definitions, message roles, and multi-type message content (text, image, audio, embedded resource).",
+      "tags": [
+        "validation",
+        "mcp",
+        "data-model",
+        "prompt"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Reuses McpValidator for primitives and McpResourceValidator for embedded resource content within prompt messages."
+    },
+    {
+      "id": "class:src/Domain/Prompts/McpPromptValidator.php:McpPromptValidator",
+      "type": "class",
+      "name": "McpPromptValidator",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "lineRange": [
+        27,
+        427
+      ],
+      "summary": "Static validator for MCP prompts that aggregates field, argument, message, and content errors and enforces per-server name uniqueness.",
+      "tags": [
+        "validation",
+        "mcp",
+        "prompt",
+        "static-methods"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPromptValidator.php:get_validation_errors",
+      "type": "function",
+      "name": "get_validation_errors",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "lineRange": [
+        102,
+        151
+      ],
+      "summary": "Builds the validation error list for prompt data, covering name, description/title types, argument definitions, and annotations.",
+      "tags": [
+        "validation",
+        "mcp",
+        "prompt"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPromptValidator.php:get_arguments_validation_errors",
+      "type": "function",
+      "name": "get_arguments_validation_errors",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "lineRange": [
+        160,
+        220
+      ],
+      "summary": "Validates a prompt's argument definitions, ensuring each is an array with a valid name, string description, and boolean required flag.",
+      "tags": [
+        "validation",
+        "mcp",
+        "prompt",
+        "arguments"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPromptValidator.php:validate_prompt_messages",
+      "type": "function",
+      "name": "validate_prompt_messages",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "lineRange": [
+        229,
+        281
+      ],
+      "summary": "Validates the array of prompt messages, checking each has a valid role and content object, and aggregating per-message content errors.",
+      "tags": [
+        "validation",
+        "mcp",
+        "prompt",
+        "messages"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Domain/Prompts/McpPromptValidator.php:get_content_validation_errors",
+      "type": "function",
+      "name": "get_content_validation_errors",
+      "filePath": "src/Domain/Prompts/McpPromptValidator.php",
+      "lineRange": [
+        291,
+        426
+      ],
+      "summary": "Validates a single prompt message content block across all MCP content types (text, image, audio, embedded resource), delegating base64, MIME-type, and resource checks to the shared validators.",
+      "tags": [
+        "validation",
+        "mcp",
+        "prompt",
+        "content"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "type": "file",
+      "name": "McpValidatorTest.php",
+      "filePath": "tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "summary": "Unit test suite (57 cases) exhaustively exercising every McpValidator primitive: name/ability/argument names, MIME types, resource URIs, roles, priority, ISO-8601, base64, and annotation error collection.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "mcp"
+      ],
+      "complexity": "complex",
+      "languageNotes": "PHPUnit-style test class with one assertion-focused method per validator behavior."
+    },
+    {
+      "id": "class:tests/Unit/Domain/Utils/McpValidatorTest.php:McpValidatorTest",
+      "type": "class",
+      "name": "McpValidatorTest",
+      "filePath": "tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "lineRange": [
+        10,
+        336
+      ],
+      "summary": "Test case class with 57 methods verifying boundary conditions and accept/reject behavior of each McpValidator static helper.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "type": "file",
+      "name": "McpToolValidatorTest.php",
+      "filePath": "tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "summary": "Unit test suite (23 cases) covering McpToolValidator: name/description/schema validation, annotation handling, and stdClass schema edge cases.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "mcp"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses a valid_tool_data fixture builder mutated per test to isolate each failure mode."
+    },
+    {
+      "id": "class:tests/Unit/Domain/Tools/McpToolValidatorTest.php:McpToolValidatorTest",
+      "type": "class",
+      "name": "McpToolValidatorTest",
+      "filePath": "tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "lineRange": [
+        10,
+        269
+      ],
+      "summary": "Test case class with 23 methods asserting WP_Error and success outcomes for tool data and JSON schema validation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "type": "file",
+      "name": "McpResourceValidatorTest.php",
+      "filePath": "tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "summary": "Unit test suite (19 cases) covering McpResourceValidator: URI validity, MIME types, mutually exclusive text/blob content, and annotation handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "mcp"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses a valid_resource_data fixture builder mutated per test to isolate failure modes."
+    },
+    {
+      "id": "class:tests/Unit/Domain/Resources/McpResourceValidatorTest.php:McpResourceValidatorTest",
+      "type": "class",
+      "name": "McpResourceValidatorTest",
+      "filePath": "tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "lineRange": [
+        10,
+        186
+      ],
+      "summary": "Test case class with 19 methods asserting accept/reject outcomes for resource data validation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "type": "file",
+      "name": "McpPromptValidatorTest.php",
+      "filePath": "tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "summary": "Unit test suite (26 cases) covering McpPromptValidator: name, description/title, argument definitions, annotations, and message role/content validation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "mcp"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses a valid_prompt_data fixture builder mutated per test to isolate failure modes."
+    },
+    {
+      "id": "class:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php:McpPromptValidatorTest",
+      "type": "class",
+      "name": "McpPromptValidatorTest",
+      "filePath": "tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "lineRange": [
+        10,
+        265
+      ],
+      "summary": "Test case class with 26 methods asserting accept/reject outcomes for prompt data and message content validation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "type": "file",
+      "name": "RedactionConfig.php",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "summary": "Static configuration facade for the response-redaction subsystem, resolving the three keyword buckets, master on/off toggle, and per-ability exemptions from the SafetySettingsRepository with WordPress filter overrides.",
+      "tags": [
+        "config",
+        "redaction",
+        "security",
+        "data-model",
+        "infrastructure"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "All-static accessor class; reads settings via SafetySettingsRepository and exposes WordPress apply_filters extension points."
+    },
+    {
+      "id": "class:src/Infrastructure/Redaction/RedactionConfig.php:RedactionConfig",
+      "type": "class",
+      "name": "RedactionConfig",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "lineRange": [
+        31,
+        149
+      ],
+      "summary": "Provides the keyword buckets (bucket1 always-on secrets, bucket2/bucket3 toggleable PII), master-enabled check, and ability-exemption logic that drive ResponseRedactor.",
+      "tags": [
+        "config",
+        "redaction",
+        "security",
+        "singleton"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/RedactionConfig.php:is_master_enabled",
+      "type": "function",
+      "name": "is_master_enabled",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "lineRange": [
+        76,
+        84
+      ],
+      "summary": "Returns whether the master redaction toggle is on, reading from SafetySettingsRepository and allowing a WordPress filter override.",
+      "tags": [
+        "config",
+        "validation",
+        "redaction",
+        "feature-flag"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/RedactionConfig.php:bucket3_keywords",
+      "type": "function",
+      "name": "bucket3_keywords",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "lineRange": [
+        91,
+        107
+      ],
+      "summary": "Resolves the effective bucket-3 PII keyword list by merging defaults with active custom keywords and normalizing the result, with a filter hook for extension.",
+      "tags": [
+        "config",
+        "redaction",
+        "serialization",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/RedactionConfig.php:is_ability_exempt",
+      "type": "function",
+      "name": "is_ability_exempt",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "lineRange": [
+        119,
+        127
+      ],
+      "summary": "Determines if a given ability is exempt from redaction for a specified bucket, consulting the configured exemption lists.",
+      "tags": [
+        "config",
+        "redaction",
+        "validation",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/RedactionConfig.php:normalize_keywords",
+      "type": "function",
+      "name": "normalize_keywords",
+      "filePath": "src/Infrastructure/Redaction/RedactionConfig.php",
+      "lineRange": [
+        135,
+        148
+      ],
+      "summary": "Normalizes a keyword list to lowercase, de-duplicated string keys for case-insensitive field matching.",
+      "tags": [
+        "utility",
+        "normalization",
+        "redaction",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "type": "file",
+      "name": "RedactionLimitExceeded.php",
+      "filePath": "src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "summary": "Marker exception thrown by ResponseRedactor when traversal exceeds the configured max-nodes or max-depth safety guards.",
+      "tags": [
+        "exception",
+        "redaction",
+        "error-handling",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/Infrastructure/Redaction/RedactionLimitExceeded.php:RedactionLimitExceeded",
+      "type": "class",
+      "name": "RedactionLimitExceeded",
+      "filePath": "src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "lineRange": [
+        25,
+        25
+      ],
+      "summary": "RuntimeException subclass signalling that redaction traversal hit a node-count or depth limit.",
+      "tags": [
+        "exception",
+        "redaction",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "type": "file",
+      "name": "ResponseRedactor.php",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "summary": "Core PII/secret redactor that recursively walks an ability response and replaces sensitive field values with type-preserving markers, applying bucket rules, schema-subtree exemptions, and depth/node safety guards.",
+      "tags": [
+        "redaction",
+        "security",
+        "serialization",
+        "service",
+        "infrastructure"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Recursive array/object traversal with per-field keyword matching; deliberately avoids regex over full documents, running pattern matchers only on scalar strings."
+    },
+    {
+      "id": "class:src/Infrastructure/Redaction/ResponseRedactor.php:ResponseRedactor",
+      "type": "class",
+      "name": "ResponseRedactor",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        59,
+        531
+      ],
+      "summary": "Stateful redactor configured per ability/method that traverses a response tree, redacts bucket-matched and pattern-matched sensitive values into type-preserving markers, and tracks per-bucket redaction counts.",
+      "tags": [
+        "redaction",
+        "security",
+        "serialization",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:__construct",
+      "type": "function",
+      "name": "__construct",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        172,
+        187
+      ],
+      "summary": "Builds the redactor's lowercased keyword sets and resolves which buckets are active for the given ability and MCP method, honouring the master toggle and per-ability exemptions.",
+      "tags": [
+        "redaction",
+        "security",
+        "factory",
+        "config"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:redact",
+      "type": "function",
+      "name": "redact",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        198,
+        207
+      ],
+      "summary": "Public entry point that walks the supplied response and returns the redacted result, resetting traversal counters per invocation.",
+      "tags": [
+        "redaction",
+        "security",
+        "entry-point",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:walk_array",
+      "type": "function",
+      "name": "walk_array",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        234,
+        250
+      ],
+      "summary": "Recursively iterates an array/object level, enforcing depth and node-count guards and dispatching named fields versus positional values.",
+      "tags": [
+        "redaction",
+        "traversal",
+        "recursion",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:process_named_field",
+      "type": "function",
+      "name": "process_named_field",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        281,
+        310
+      ],
+      "summary": "Applies bucket matching to a keyed field, redacting bucket1/2/3 and email-family matches into markers while exempting schema-metadata keys, otherwise recursing into the value.",
+      "tags": [
+        "redaction",
+        "security",
+        "validation",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:count_subtree_safe",
+      "type": "function",
+      "name": "count_subtree_safe",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        376,
+        392
+      ],
+      "summary": "Recursively counts nodes in a subtree against the node-count guard so that exempted schema subtrees are still bounded by safety limits.",
+      "tags": [
+        "redaction",
+        "traversal",
+        "recursion",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:process_value",
+      "type": "function",
+      "name": "process_value",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        405,
+        421
+      ],
+      "summary": "Routes a positional value by type, recursing into arrays/objects and running scalar-string pattern matching for unkeyed secrets.",
+      "tags": [
+        "redaction",
+        "traversal",
+        "serialization",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:maybe_redact_scalar_string",
+      "type": "function",
+      "name": "maybe_redact_scalar_string",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        438,
+        450
+      ],
+      "summary": "Runs pattern matchers (password hashes, known API keys, Luhn-valid numbers) against a scalar string and redacts to a marker on a hit.",
+      "tags": [
+        "redaction",
+        "validation",
+        "security",
+        "pattern-matching"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/ResponseRedactor.php:default_marker",
+      "type": "function",
+      "name": "default_marker",
+      "filePath": "src/Infrastructure/Redaction/ResponseRedactor.php",
+      "lineRange": [
+        488,
+        513
+      ],
+      "summary": "Produces a type-preserving redaction marker (bool, int/float, string, array, or object) so the redacted response keeps its original shape.",
+      "tags": [
+        "redaction",
+        "serialization",
+        "factory",
+        "type-preservation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "type": "file",
+      "name": "Bucket3EmailFamilyTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "summary": "Unit tests covering bucket-3 email-family field redaction, including token-boundary matching, negative controls for master-off and exempt abilities, counter increments, and cold AI replay fixtures.",
+      "tags": [
+        "test",
+        "redaction",
+        "security",
+        "email"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php:Bucket3EmailFamilyTest",
+      "type": "class",
+      "name": "Bucket3EmailFamilyTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "lineRange": [
+        22,
+        257
+      ],
+      "summary": "Data-provider-driven test class verifying email-family token redaction behaviour of ResponseRedactor across default settings, exemptions, and real-world response shapes.",
+      "tags": [
+        "test",
+        "redaction",
+        "data-provider",
+        "email"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "type": "file",
+      "name": "RedactionConfigTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "summary": "Unit tests for RedactionConfig covering the master toggle, bucket keyword resolution, custom-keyword merging, and per-bucket ability exemption rules.",
+      "tags": [
+        "test",
+        "config",
+        "redaction",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php:RedactionConfigTest",
+      "type": "class",
+      "name": "RedactionConfigTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "lineRange": [
+        10,
+        76
+      ],
+      "summary": "Test class asserting RedactionConfig's static accessors: master-enabled default, bucket1 credential keywords, bucket3 defaults plus custom merges, and bucket-scoped exemptions.",
+      "tags": [
+        "test",
+        "config",
+        "redaction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "type": "file",
+      "name": "ResponseRedactorTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "summary": "Primary unit suite for ResponseRedactor covering bucket redaction across abilities, type-preserving markers, recursive traversal, depth/node guards, scalar-only pattern matching, and per-bucket counters.",
+      "tags": [
+        "test",
+        "redaction",
+        "security",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php:ResponseRedactorTest",
+      "type": "class",
+      "name": "ResponseRedactorTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "lineRange": [
+        12,
+        344
+      ],
+      "summary": "Comprehensive test class exercising ResponseRedactor end-to-end: field-level redaction, toggle/exemption interactions, type detection, safety guards, and bucket-1 invariants.",
+      "tags": [
+        "test",
+        "redaction",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "type": "file",
+      "name": "SchemaPathExemptionTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "summary": "Unit tests verifying that JSON-schema subtrees in get-ability-info responses pass through unredacted while runtime data payloads and bucket-1 secrets inside schemas are still redacted, with guards intact.",
+      "tags": [
+        "test",
+        "redaction",
+        "schema-definition",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php:SchemaPathExemptionTest",
+      "type": "class",
+      "name": "SchemaPathExemptionTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "lineRange": [
+        23,
+        301
+      ],
+      "summary": "Test class for the schema-subtree exemption path of ResponseRedactor under the mcp-adapter/get-ability-info ability, including negative controls and counter assertions.",
+      "tags": [
+        "test",
+        "redaction",
+        "schema-definition"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "type": "file",
+      "name": "ToolsListSchemaExemptionTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "summary": "Unit tests for the tools/list method schema exemption, asserting that input/output schemas pass through for all PII property families while tools/call payloads and unrelated methods still redact, driven via ResponseRedactionGate.",
+      "tags": [
+        "test",
+        "redaction",
+        "schema-definition",
+        "security"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php:ToolsListSchemaExemptionTest",
+      "type": "class",
+      "name": "ToolsListSchemaExemptionTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "lineRange": [
+        30,
+        393
+      ],
+      "summary": "Test class validating method-scoped tools/list schema exemption through ResponseRedactionGate and ResponseRedactor, with negative controls and the max-nodes guard.",
+      "tags": [
+        "test",
+        "redaction",
+        "schema-definition"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:bin/rate-limit-burst.php",
+      "type": "file",
+      "name": "rate-limit-burst.php",
+      "filePath": "bin/rate-limit-burst.php",
+      "summary": "Operator CLI tool that bursts a tight series of MCP JSON-RPC requests at a live endpoint and asserts the rate limiter trips at the configured threshold with a 429 + Retry-After response. Verifies wire-level limiter behavior, complementing the in-memory RateLimiter unit tests.",
+      "tags": [
+        "cli",
+        "rate-limiting",
+        "testing-tool",
+        "harness",
+        "operations"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Procedural PHP CLI script with strict_types and a SAPI guard; delegates parsing/classification logic to the BurstHarness class so the wire-level math stays unit-testable."
+    },
+    {
+      "id": "function:bin/rate-limit-burst.php:parse_args",
+      "type": "function",
+      "name": "parse_args",
+      "filePath": "bin/rate-limit-burst.php",
+      "lineRange": [
+        63,
+        97
+      ],
+      "summary": "Parses --key=value style argv into a normalized options array for the burst harness, splitting flag names from values and collecting repeated headers.",
+      "tags": [
+        "cli",
+        "argument-parsing",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:bin/rate-limit-burst.php:usage",
+      "type": "function",
+      "name": "usage",
+      "filePath": "bin/rate-limit-burst.php",
+      "lineRange": [
+        99,
+        129
+      ],
+      "summary": "Prints the CLI usage banner describing available flags, test cases, and exit codes for the rate-limit burst harness.",
+      "tags": [
+        "cli",
+        "documentation",
+        "help-text"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:bin/rate-limit-burst.php:send",
+      "type": "function",
+      "name": "send",
+      "filePath": "bin/rate-limit-burst.php",
+      "lineRange": [
+        136,
+        157
+      ],
+      "summary": "Issues a single HTTP request via cURL with the given method, body, and headers, then hands the raw response to BurstHarness::parse_response for status/header/body extraction.",
+      "tags": [
+        "http",
+        "curl",
+        "transport"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:bin/rate-limit-burst.php:compose_headers",
+      "type": "function",
+      "name": "compose_headers",
+      "filePath": "bin/rate-limit-burst.php",
+      "lineRange": [
+        160,
+        178
+      ],
+      "summary": "Builds the outgoing request header list, conditionally adding the MCP session id, bearer authorization, and any operator-supplied extra headers.",
+      "tags": [
+        "http",
+        "headers",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/RateLimit/BurstHarness.php",
+      "type": "file",
+      "name": "BurstHarness.php",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "summary": "Pure-logic helper class backing the rate-limit burst CLI tool: parses raw cURL responses, tracks MCP session state across requests, classifies whether a burst tripped the limiter correctly, and builds JSON-RPC request bodies. Isolated from I/O so it can be unit tested.",
+      "tags": [
+        "rate-limiting",
+        "utility",
+        "json-rpc",
+        "service",
+        "testing-support"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Static-method utility class under WickedEvolutions\\McpAdapter\\RateLimit; no instance state, used purely as a namespaced function bag for testability."
+    },
+    {
+      "id": "class:src/RateLimit/BurstHarness.php:BurstHarness",
+      "type": "class",
+      "name": "BurstHarness",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "lineRange": [
+        30,
+        235
+      ],
+      "summary": "Stateless helper aggregating response parsing, session extraction/merging, threshold-trip classification, and JSON-RPC body construction for the rate-limit burst harness.",
+      "tags": [
+        "rate-limiting",
+        "utility",
+        "json-rpc",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/RateLimit/BurstHarness.php:parse_response",
+      "type": "function",
+      "name": "parse_response",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "lineRange": [
+        47,
+        83
+      ],
+      "summary": "Parses a raw HTTP response string into status code, lowercased headers, and body, skipping interim 100 Continue lines and preserving blank lines within the body.",
+      "tags": [
+        "http",
+        "parsing",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/RateLimit/BurstHarness.php:classify_threshold_trip",
+      "type": "function",
+      "name": "classify_threshold_trip",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "lineRange": [
+        137,
+        192
+      ],
+      "summary": "Inspects an ordered list of burst results against the expected threshold and decides whether the limiter behaved correctly, flagging no-trip, premature-trip, and 429-without-Retry-After failures with diagnostic messages.",
+      "tags": [
+        "rate-limiting",
+        "validation",
+        "classification"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/RateLimit/BurstHarness.php:build_tools_call_body",
+      "type": "function",
+      "name": "build_tools_call_body",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "lineRange": [
+        203,
+        213
+      ],
+      "summary": "Constructs a JSON-RPC tools/call request body with the given request id for use in burst sequences.",
+      "tags": [
+        "json-rpc",
+        "serialization",
+        "request-builder"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/RateLimit/BurstHarness.php:build_initialize_body",
+      "type": "function",
+      "name": "build_initialize_body",
+      "filePath": "src/RateLimit/BurstHarness.php",
+      "lineRange": [
+        220,
+        234
+      ],
+      "summary": "Constructs a JSON-RPC initialize request body with the given request id, used to exercise the initialize rate-limit window.",
+      "tags": [
+        "json-rpc",
+        "serialization",
+        "request-builder"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/Unit/RateLimit/BurstHarnessTest.php",
+      "type": "file",
+      "name": "BurstHarnessTest.php",
+      "filePath": "tests/Unit/RateLimit/BurstHarnessTest.php",
+      "summary": "PHPUnit unit suite for BurstHarness, covering response parsing (status/header/body, 100 Continue skip, blank-line preservation), session extraction and merge precedence, threshold-trip classification cases, and JSON-RPC body validity.",
+      "tags": [
+        "test",
+        "rate-limiting",
+        "unit-test",
+        "phpunit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/RateLimit/BurstHarnessTest.php:BurstHarnessTest",
+      "type": "class",
+      "name": "BurstHarnessTest",
+      "filePath": "tests/Unit/RateLimit/BurstHarnessTest.php",
+      "lineRange": [
+        20,
+        187
+      ],
+      "summary": "Test case exercising every public BurstHarness helper, with fixtures for OK/denied burst results and assertions on parsing, session handling, classification verdicts, and JSON-RPC body structure.",
+      "tags": [
+        "test",
+        "unit-test",
+        "phpunit",
+        "rate-limiting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/test.yml",
+      "type": "pipeline",
+      "name": "test.yml",
+      "filePath": ".github/workflows/test.yml",
+      "summary": "GitHub Actions CI workflow that runs the PHPUnit test suite via Composer across a PHP 8.2/8.3 matrix on every push and pull request targeting main.",
+      "tags": [
+        "ci-cd",
+        "testing",
+        "infrastructure",
+        "deployment"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses a build matrix (php-version: ['8.2','8.3']) to run the same job against multiple PHP versions in parallel."
+    },
+    {
+      "id": "step:.github/workflows/test.yml:Setup PHP",
+      "type": "pipeline",
+      "name": "Setup PHP",
+      "filePath": ".github/workflows/test.yml",
+      "summary": "Provisions the matrixed PHP version (8.2 or 8.3) via shivammathur/setup-php with coverage disabled.",
+      "tags": [
+        "ci-cd",
+        "setup",
+        "php"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "step:.github/workflows/test.yml:Install dependencies",
+      "type": "pipeline",
+      "name": "Install dependencies",
+      "filePath": ".github/workflows/test.yml",
+      "summary": "Installs project dependencies with composer install using prefer-dist and no-progress flags.",
+      "tags": [
+        "ci-cd",
+        "dependencies",
+        "composer"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "step:.github/workflows/test.yml:Run tests",
+      "type": "pipeline",
+      "name": "Run tests",
+      "filePath": ".github/workflows/test.yml",
+      "summary": "Executes the project test suite via the composer test script.",
+      "tags": [
+        "ci-cd",
+        "testing",
+        "composer"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/ability-gap.yml",
+      "type": "config",
+      "name": "ability-gap.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/ability-gap.yml",
+      "summary": "GitHub issue form template for requesting a new ability or reporting a missing capability, capturing proposed ability spec, tier (Free/Pro), and launch priority.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "feature-request"
+      ],
+      "complexity": "simple",
+      "languageNotes": "GitHub issue forms schema: typed fields (textarea, dropdown) with validations.required, rendered as a structured submission UI."
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/bug-report.yml",
+      "type": "config",
+      "name": "bug-report.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/bug-report.yml",
+      "summary": "GitHub issue form template for reporting plugin bugs, collecting the affected ability name, reproduction steps, plugin version, and reporter role.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "bug-report"
+      ],
+      "complexity": "simple",
+      "languageNotes": "GitHub issue forms schema with input/textarea/dropdown field types and required validations."
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/dev-brief.yml",
+      "type": "config",
+      "name": "dev-brief.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/dev-brief.yml",
+      "summary": "GitHub issue form template defining a structured dev-agent implementation brief, with fields for objective, technical spec, files to modify, testing plan, and security considerations.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "specification"
+      ],
+      "complexity": "simple",
+      "languageNotes": "GitHub issue forms schema used to drive an agent-based development workflow via structured issue submissions."
+    },
+    {
+      "id": "document:CHANGELOG.md",
+      "type": "document",
+      "name": "CHANGELOG.md",
+      "filePath": "CHANGELOG.md",
+      "summary": "Keep-a-Changelog style release history tracking the adapter from pre-1.0 through v1.4.9, with sections per version detailing security fixes, added features, and behavioral changes.",
+      "tags": [
+        "documentation",
+        "changelog",
+        "release-notes",
+        "versioning"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Follows Keep a Changelog conventions with Added/Fixed/Changed/Security subsections and severity tagging (Critical/High/Medium/Low)."
+    },
+    {
+      "id": "document:CONTRIBUTING.md",
+      "type": "document",
+      "name": "CONTRIBUTING.md",
+      "filePath": "CONTRIBUTING.md",
+      "summary": "Contributor guide covering how the team works, bug reporting, feature suggestions, pull-request expectations, code style, and security disclosure.",
+      "tags": [
+        "documentation",
+        "development",
+        "contribution-guide"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:PRINCIPLES.md",
+      "type": "document",
+      "name": "PRINCIPLES.md",
+      "filePath": "PRINCIPLES.md",
+      "summary": "Binding architectural contract defining the WordPress compatibility principles the ability suite must follow (registry-first, native APIs, adapter-as-projection, layered permissions) plus a sprint-plan gate and drift examples.",
+      "tags": [
+        "documentation",
+        "architecture",
+        "principles",
+        "governance"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "Primary project overview documenting the adapter's features (discovery/execution, OAuth 2.1, admin UI, layered permissions, safety surface), installation, built-in tools, and the four-layer permissions model.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:SECURITY.md",
+      "type": "document",
+      "name": "SECURITY.md",
+      "filePath": "SECURITY.md",
+      "summary": "Security policy describing vulnerability reporting, the in-scope MCP protocol surface and safety controls, out-of-scope items, and supported versions.",
+      "tags": [
+        "documentation",
+        "security",
+        "vulnerability-disclosure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:composer.json",
+      "type": "config",
+      "name": "composer.json",
+      "filePath": "composer.json",
+      "summary": "Composer manifest declaring the WordPress plugin package, PSR-4 autoload mapping WickedEvolutions\\McpAdapter\\ to src/, PHP >=8.2 requirement, PHPUnit dev dependencies, and a test script.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "php",
+        "dependencies"
+      ],
+      "complexity": "simple",
+      "languageNotes": "PSR-4 autoloading maps the WickedEvolutions\\McpAdapter\\ namespace to the src/ directory."
+    },
+    {
+      "id": "config:phpunit.xml",
+      "type": "config",
+      "name": "phpunit.xml",
+      "filePath": "phpunit.xml",
+      "summary": "PHPUnit configuration bootstrapping tests/bootstrap.php, defining the Unit test suite from tests/Unit, and enabling code coverage over the src directory with strict test/output checks.",
+      "tags": [
+        "configuration",
+        "test",
+        "php",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:readme.txt",
+      "type": "document",
+      "name": "readme.txt",
+      "filePath": "readme.txt",
+      "summary": "WordPress.org-style plugin readme with the standard header block, description, installation, and changelog metadata used by the WordPress plugin directory.",
+      "tags": [
+        "documentation",
+        "wordpress-plugin",
+        "plugin-readme"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the WordPress plugin readme.txt format (Stable tag, Requires at least, Tested up to headers)."
+    },
+    {
+      "id": "file:includes/class-license-manager.php",
+      "type": "file",
+      "name": "class-license-manager.php",
+      "filePath": "includes/class-license-manager.php",
+      "summary": "Manages the plugin's license lifecycle (activate, deactivate, status, grace period) and talks to the remote FluentCart licensing endpoint, with multisite-aware option storage.",
+      "tags": [
+        "service",
+        "license",
+        "wordpress",
+        "multisite"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Static-method utility class using WordPress transients for caching and site-options for network-license storage."
+    },
+    {
+      "id": "class:includes/class-license-manager.php:Abilities_MCP_Adapter_License_Manager",
+      "type": "class",
+      "name": "Abilities_MCP_Adapter_License_Manager",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        20,
+        358
+      ],
+      "summary": "Static license manager handling activation, deactivation, status reporting, remote validation, grace-period checks, and multisite-aware option persistence.",
+      "tags": [
+        "service",
+        "license",
+        "singleton",
+        "wordpress"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:is_active",
+      "type": "function",
+      "name": "is_active",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        85,
+        112
+      ],
+      "summary": "Determines whether the license is currently active, using a cached transient and falling back to a remote check (with grace-period tolerance) on cache miss.",
+      "tags": [
+        "license",
+        "validation",
+        "caching"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:activate",
+      "type": "function",
+      "name": "activate",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        120,
+        165
+      ],
+      "summary": "Activates a license key against the remote endpoint, persists the result, and records network-license state for multisite installs.",
+      "tags": [
+        "license",
+        "activation",
+        "remote-request"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:deactivate",
+      "type": "function",
+      "name": "deactivate",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        172,
+        194
+      ],
+      "summary": "Deactivates the current license remotely and clears all locally stored license options and transients.",
+      "tags": [
+        "license",
+        "deactivation",
+        "remote-request"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:get_status",
+      "type": "function",
+      "name": "get_status",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        201,
+        227
+      ],
+      "summary": "Builds a status payload describing the license including a masked key, active state, product id, and expiry date.",
+      "tags": [
+        "license",
+        "status",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:get_opt",
+      "type": "function",
+      "name": "get_opt",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        252,
+        254
+      ],
+      "summary": "Reads a license option from network-site options or single-site options depending on whether a network license is in effect.",
+      "tags": [
+        "license",
+        "options",
+        "multisite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:remote_check",
+      "type": "function",
+      "name": "remote_check",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        289,
+        309
+      ],
+      "summary": "Performs a remote license-status verification request and returns the parsed validation result.",
+      "tags": [
+        "license",
+        "remote-request",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/class-license-manager.php:remote_request",
+      "type": "function",
+      "name": "remote_request",
+      "filePath": "includes/class-license-manager.php",
+      "lineRange": [
+        318,
+        344
+      ],
+      "summary": "Issues an HTTP POST to the licensing API, handling WP errors, non-200 responses, and JSON decoding into a normalized array.",
+      "tags": [
+        "http",
+        "remote-request",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:includes/updater/class-plugin-updater.php",
+      "type": "file",
+      "name": "class-plugin-updater.php",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "summary": "Self-hosted plugin update integration that hooks WordPress update transients and the plugins API to deliver updates from FluentCart or GitHub release sources.",
+      "tags": [
+        "service",
+        "updater",
+        "wordpress",
+        "self-hosted"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Hooks pre_set_site_transient, plugins_api, and upgrader_pre_download filters to inject custom update metadata and authenticated downloads."
+    },
+    {
+      "id": "class:includes/updater/class-plugin-updater.php:Abilities_MCP_Adapter_Plugin_Updater",
+      "type": "class",
+      "name": "Abilities_MCP_Adapter_Plugin_Updater",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        16,
+        430
+      ],
+      "summary": "Plugin updater that wires WordPress update hooks and resolves version info from FluentCart or GitHub, caching results in site transients.",
+      "tags": [
+        "service",
+        "updater",
+        "wordpress"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:init_hooks",
+      "type": "function",
+      "name": "init_hooks",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        68,
+        118
+      ],
+      "summary": "Registers all WordPress filters and actions for update checks, plugin info, authenticated downloads, and manual cache flushing.",
+      "tags": [
+        "updater",
+        "wordpress-hooks",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:check_plugin_update",
+      "type": "function",
+      "name": "check_plugin_update",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        128,
+        155
+      ],
+      "summary": "Injects update availability into the WordPress update transient by comparing the installed version against the resolved remote version.",
+      "tags": [
+        "updater",
+        "version-compare",
+        "wordpress-hooks"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:plugins_api_filter",
+      "type": "function",
+      "name": "plugins_api_filter",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        167,
+        187
+      ],
+      "summary": "Supplies plugin detail metadata to the WordPress plugins_api for the update-details modal.",
+      "tags": [
+        "updater",
+        "wordpress-hooks",
+        "metadata"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:pre_download",
+      "type": "function",
+      "name": "pre_download",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        201,
+        222
+      ],
+      "summary": "Intercepts the upgrader download step to fetch the release package from the configured authenticated source.",
+      "tags": [
+        "updater",
+        "download",
+        "wordpress-hooks"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:get_fluentcart_version_info",
+      "type": "function",
+      "name": "get_fluentcart_version_info",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        292,
+        339
+      ],
+      "summary": "Queries the FluentCart licensing API for the latest version info, sending site and license context and normalizing the JSON response.",
+      "tags": [
+        "updater",
+        "remote-request",
+        "fluentcart"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:get_github_version_info",
+      "type": "function",
+      "name": "get_github_version_info",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        350,
+        400
+      ],
+      "summary": "Fetches the latest GitHub release, extracts the tag/version and download URL, and normalizes the result into version info.",
+      "tags": [
+        "updater",
+        "remote-request",
+        "github"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:includes/updater/class-plugin-updater.php:normalize_version_info",
+      "type": "function",
+      "name": "normalize_version_info",
+      "filePath": "includes/updater/class-plugin-updater.php",
+      "lineRange": [
+        408,
+        429
+      ],
+      "summary": "Coerces a raw version-info structure into the consistent object shape WordPress update hooks expect.",
+      "tags": [
+        "updater",
+        "normalization",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Abilities/McpAbilityHelperTrait.php",
+      "type": "file",
+      "name": "McpAbilityHelperTrait.php",
+      "filePath": "src/Abilities/McpAbilityHelperTrait.php",
+      "summary": "PHP trait providing shared helpers for MCP abilities: checking MCP exposure, determining public visibility via the discovery-gate priority, and resolving an ability's MCP type.",
+      "tags": [
+        "trait",
+        "utility",
+        "mcp",
+        "abilities"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "PHP trait with protected static methods mixed into ability classes; uses a multi-tier discovery gate (get_show_in_rest, meta.show_in_rest, meta.mcp.public)."
+    },
+    {
+      "id": "function:src/Abilities/McpAbilityHelperTrait.php:check_ability_mcp_exposure",
+      "type": "function",
+      "name": "check_ability_mcp_exposure",
+      "filePath": "src/Abilities/McpAbilityHelperTrait.php",
+      "lineRange": [
+        42,
+        65
+      ],
+      "summary": "Resolves an ability by name and returns true if it is MCP-public, or a WP_Error (with a recovery hint) when not found or not exposed.",
+      "tags": [
+        "mcp",
+        "validation",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/McpAbilityHelperTrait.php:is_ability_mcp_public",
+      "type": "function",
+      "name": "is_ability_mcp_public",
+      "filePath": "src/Abilities/McpAbilityHelperTrait.php",
+      "lineRange": [
+        79,
+        96
+      ],
+      "summary": "Determines whether an ability is exposed via MCP using the prioritized discovery gate of get_show_in_rest, meta.show_in_rest, then meta.mcp.public.",
+      "tags": [
+        "mcp",
+        "validation",
+        "abilities"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Abilities/McpAbilityHelperTrait.php:get_ability_mcp_type",
+      "type": "function",
+      "name": "get_ability_mcp_type",
+      "filePath": "src/Abilities/McpAbilityHelperTrait.php",
+      "lineRange": [
+        107,
+        117
+      ],
+      "summary": "Returns the ability's MCP type (tool, resource, or prompt) from metadata, defaulting to tool for missing or invalid values.",
+      "tags": [
+        "mcp",
+        "abilities",
+        "metadata"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Auth/OAuth/helpers.php",
+      "type": "file",
+      "name": "helpers.php",
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "summary": "Global-namespace OAuth helper functions for client IP resolution, HTTPS detection, auth-header reading, MCP resource-request detection, and standardized token error/success responses.",
+      "tags": [
+        "utility",
+        "oauth",
+        "authentication",
+        "http"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Procedural helpers deliberately defined in the global namespace so they resolve regardless of the calling class's namespace."
+    },
+    {
+      "id": "function:src/Auth/OAuth/helpers.php:oauth_client_ip",
+      "type": "function",
+      "name": "oauth_client_ip",
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "lineRange": [
+        40,
+        51
+      ],
+      "summary": "Resolves the originating client IP for OAuth flows, delegating to the trusted-proxy resolver when configured.",
+      "tags": [
+        "oauth",
+        "networking",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/helpers.php:oauth_read_auth_header",
+      "type": "function",
+      "name": "oauth_read_auth_header",
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "lineRange": [
+        71,
+        93
+      ],
+      "summary": "Reads the Authorization header across server environments using apache_request_headers and getallheaders fallbacks.",
+      "tags": [
+        "oauth",
+        "http",
+        "authentication"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Auth/OAuth/helpers.php:oauth_is_mcp_resource_request",
+      "type": "function",
+      "name": "oauth_is_mcp_resource_request",
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "lineRange": [
+        116,
+        153
+      ],
+      "summary": "Detects whether the current request targets the MCP resource endpoint by inspecting the REST route path and query parameters.",
+      "tags": [
+        "oauth",
+        "mcp",
+        "routing"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Auth/OAuth/helpers.php:token_error",
+      "type": "function",
+      "name": "token_error",
+      "filePath": "src/Auth/OAuth/helpers.php",
+      "lineRange": [
+        155,
+        167
+      ],
+      "summary": "Emits a standardized OAuth token error JSON response with the appropriate status code and headers, then halts.",
+      "tags": [
+        "oauth",
+        "error-handling",
+        "http"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "type": "file",
+      "name": "ErrorLogMcpObservabilityHandler.php",
+      "filePath": "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "summary": "Observability handler that records MCP metric events to the PHP error log, formatting metric names and StatsD-style tags.",
+      "tags": [
+        "observability",
+        "logging",
+        "monitoring"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:ErrorLogMcpObservabilityHandler",
+      "type": "class",
+      "name": "ErrorLogMcpObservabilityHandler",
+      "filePath": "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "lineRange": [
+        24,
+        83
+      ],
+      "summary": "Error-log-backed MCP observability handler that formats and writes metric events with merged default tags.",
+      "tags": [
+        "observability",
+        "logging",
+        "monitoring"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:record_event",
+      "type": "function",
+      "name": "record_event",
+      "filePath": "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "lineRange": [
+        37,
+        59
+      ],
+      "summary": "Records a named metric event with merged tags and optional duration, writing a formatted line to the PHP error log.",
+      "tags": [
+        "observability",
+        "logging",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:format_tags",
+      "type": "function",
+      "name": "format_tags",
+      "filePath": "src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "lineRange": [
+        68,
+        82
+      ],
+      "summary": "Formats an associative tag array into a comma-separated key:value string for log output.",
+      "tags": [
+        "observability",
+        "formatting",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "type": "file",
+      "name": "McpObservabilityHelperTrait.php",
+      "filePath": "src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "summary": "PHP trait of shared observability utilities: default tag enrichment, tag sanitization, metric-name formatting, tag merging, and exception categorization.",
+      "tags": [
+        "trait",
+        "observability",
+        "utility"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "PHP trait with public static helpers mixed into observability handlers."
+    },
+    {
+      "id": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:sanitize_tags",
+      "type": "function",
+      "name": "sanitize_tags",
+      "filePath": "src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "lineRange": [
+        57,
+        91
+      ],
+      "summary": "Sanitizes observability tags by coercing non-scalars to JSON, truncating long values, and stripping unsafe characters.",
+      "tags": [
+        "observability",
+        "sanitization",
+        "utility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:format_metric_name",
+      "type": "function",
+      "name": "format_metric_name",
+      "filePath": "src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "lineRange": [
+        93,
+        113
+      ],
+      "summary": "Normalizes a metric name into a consistent lowercase, dot-delimited form with a project prefix.",
+      "tags": [
+        "observability",
+        "formatting",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:merge_tags",
+      "type": "function",
+      "name": "merge_tags",
+      "filePath": "src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "lineRange": [
+        115,
+        127
+      ],
+      "summary": "Merges caller-supplied tags over the default enrichment tags and sanitizes the combined set.",
+      "tags": [
+        "observability",
+        "utility",
+        "tags"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "type": "file",
+      "name": "PatternMatchers.php",
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "summary": "Pattern-matching predicates used by the redaction subsystem to detect sensitive values such as password hashes, known API-key formats, and Luhn-valid card numbers.",
+      "tags": [
+        "security",
+        "redaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Infrastructure/Redaction/PatternMatchers.php:PatternMatchers",
+      "type": "class",
+      "name": "PatternMatchers",
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "lineRange": [
+        24,
+        147
+      ],
+      "summary": "Static predicate collection identifying password hashes, recognized API-key patterns, and Luhn-valid numeric sequences for redaction.",
+      "tags": [
+        "security",
+        "redaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/PatternMatchers.php:is_password_hash",
+      "type": "function",
+      "name": "is_password_hash",
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "lineRange": [
+        67,
+        77
+      ],
+      "summary": "Detects whether a string looks like a password hash (e.g. bcrypt/phpass prefixes) for redaction.",
+      "tags": [
+        "security",
+        "redaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/PatternMatchers.php:is_known_api_key",
+      "type": "function",
+      "name": "is_known_api_key",
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "lineRange": [
+        89,
+        111
+      ],
+      "summary": "Matches a value against known API-key prefixes and regex shapes to flag it for redaction.",
+      "tags": [
+        "security",
+        "redaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Infrastructure/Redaction/PatternMatchers.php:passes_luhn",
+      "type": "function",
+      "name": "passes_luhn",
+      "filePath": "src/Infrastructure/Redaction/PatternMatchers.php",
+      "lineRange": [
+        125,
+        146
+      ],
+      "summary": "Applies the Luhn checksum to a numeric string to detect likely payment-card numbers for redaction.",
+      "tags": [
+        "security",
+        "redaction",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/RateLimit/CloudflareIps.php",
+      "type": "file",
+      "name": "CloudflareIps.php",
+      "filePath": "src/RateLimit/CloudflareIps.php",
+      "summary": "Provides the bundled list of Cloudflare IPv4 and IPv6 ranges used by the rate-limiter's trusted-proxy resolution.",
+      "tags": [
+        "data-model",
+        "rate-limit",
+        "networking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/RateLimit/CloudflareIps.php:CloudflareIps",
+      "type": "class",
+      "name": "CloudflareIps",
+      "filePath": "src/RateLimit/CloudflareIps.php",
+      "lineRange": [
+        20,
+        59
+      ],
+      "summary": "Static provider of the bundled Cloudflare IPv4 and IPv6 CIDR ranges for trusted-proxy checks.",
+      "tags": [
+        "data-model",
+        "rate-limit",
+        "networking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/RateLimit/CloudflareIps.php:bundled_v4",
+      "type": "function",
+      "name": "bundled_v4",
+      "filePath": "src/RateLimit/CloudflareIps.php",
+      "lineRange": [
+        25,
+        43
+      ],
+      "summary": "Returns the bundled list of Cloudflare IPv4 CIDR ranges.",
+      "tags": [
+        "rate-limit",
+        "networking",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/RateLimit/CloudflareIps.php:bundled_v6",
+      "type": "function",
+      "name": "bundled_v6",
+      "filePath": "src/RateLimit/CloudflareIps.php",
+      "lineRange": [
+        48,
+        58
+      ],
+      "summary": "Returns the bundled list of Cloudflare IPv6 CIDR ranges.",
+      "tags": [
+        "rate-limit",
+        "networking",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "type": "file",
+      "name": "JsonRpcResponseBuilder.php",
+      "filePath": "src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "summary": "Builds JSON-RPC 2.0 success and error responses and handles batch-request detection, normalization, and per-message processing for the MCP transport.",
+      "tags": [
+        "service",
+        "json-rpc",
+        "transport",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:JsonRpcResponseBuilder",
+      "type": "class",
+      "name": "JsonRpcResponseBuilder",
+      "filePath": "src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "lineRange": [
+        22,
+        119
+      ],
+      "summary": "Static builder for JSON-RPC 2.0 responses with batch detection, message normalization, and processing helpers.",
+      "tags": [
+        "service",
+        "json-rpc",
+        "transport"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:create_success_response",
+      "type": "function",
+      "name": "create_success_response",
+      "filePath": "src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "lineRange": [
+        32,
+        43
+      ],
+      "summary": "Constructs a JSON-RPC 2.0 success envelope for a given request id and result payload.",
+      "tags": [
+        "json-rpc",
+        "serialization",
+        "transport"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:process_messages",
+      "type": "function",
+      "name": "process_messages",
+      "filePath": "src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "lineRange": [
+        77,
+        92
+      ],
+      "summary": "Processes one or more JSON-RPC messages via a supplied processor callback, returning a single response or a batch array.",
+      "tags": [
+        "json-rpc",
+        "transport",
+        "batch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/Transport/Infrastructure/SessionManager.php",
+      "type": "file",
+      "name": "SessionManager.php",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "summary": "Manages MCP transport sessions stored in user meta, with DB-level locking, HMAC-signed session tokens, TTL expiry, per-user session caps, and cleanup.",
+      "tags": [
+        "service",
+        "session",
+        "transport",
+        "concurrency"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses GET_LOCK-style DB locking plus transients for mutual exclusion, and hash_hmac/hash_equals for tamper-proof session tokens."
+    },
+    {
+      "id": "class:src/Transport/Infrastructure/SessionManager.php:SessionManager",
+      "type": "class",
+      "name": "SessionManager",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        23,
+        466
+      ],
+      "summary": "Session manager that creates, validates, deletes, and cleans up HMAC-signed MCP sessions in user meta under DB-level locks.",
+      "tags": [
+        "service",
+        "session",
+        "transport",
+        "concurrency"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:acquire_lock",
+      "type": "function",
+      "name": "acquire_lock",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        57,
+        83
+      ],
+      "summary": "Acquires a per-user advisory lock via the database (with transient fallback) and spin-waits with jitter until granted or timed out.",
+      "tags": [
+        "session",
+        "concurrency",
+        "locking"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:create_session",
+      "type": "function",
+      "name": "create_session",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        174,
+        232
+      ],
+      "summary": "Creates a new session under lock, enforcing per-user session caps by evicting the oldest, generating a UUID and HMAC-signed token, and persisting to user meta.",
+      "tags": [
+        "session",
+        "security",
+        "concurrency"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:verify_session_token",
+      "type": "function",
+      "name": "verify_session_token",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        246,
+        257
+      ],
+      "summary": "Verifies a client-supplied session token against the stored HMAC using a constant-time comparison.",
+      "tags": [
+        "session",
+        "security",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:get_session",
+      "type": "function",
+      "name": "get_session",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        267,
+        290
+      ],
+      "summary": "Retrieves a session by id for a user, clearing it if expired before returning.",
+      "tags": [
+        "session",
+        "validation",
+        "ttl"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:validate_session",
+      "type": "function",
+      "name": "validate_session",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        300,
+        339
+      ],
+      "summary": "Validates a session under lock, runs expiry cleanup, refreshes the last-seen timestamp, and returns the session state.",
+      "tags": [
+        "session",
+        "validation",
+        "concurrency"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:delete_session",
+      "type": "function",
+      "name": "delete_session",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        349,
+        377
+      ],
+      "summary": "Deletes a specific session under lock, removing user-meta entries and pruning empty containers.",
+      "tags": [
+        "session",
+        "concurrency",
+        "cleanup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:cleanup_expired_sessions_unlocked",
+      "type": "function",
+      "name": "cleanup_expired_sessions_unlocked",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        416,
+        444
+      ],
+      "summary": "Removes expired sessions for a user from user meta; the lock-free variant intended to be called while a lock is already held.",
+      "tags": [
+        "session",
+        "cleanup",
+        "ttl"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/Transport/Infrastructure/SessionManager.php:get_all_user_sessions",
+      "type": "function",
+      "name": "get_all_user_sessions",
+      "filePath": "src/Transport/Infrastructure/SessionManager.php",
+      "lineRange": [
+        453,
+        465
+      ],
+      "summary": "Reads and returns all stored sessions for a user from user meta as an array.",
+      "tags": [
+        "session",
+        "storage",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/bootstrap.php",
+      "type": "file",
+      "name": "bootstrap.php",
+      "filePath": "tests/bootstrap.php",
+      "summary": "PHPUnit test bootstrap that stubs WordPress core functions (escaping, options, transients, hooks, REST, multisite) so the plugin's classes can be unit-tested without a full WordPress runtime.",
+      "tags": [
+        "test",
+        "bootstrap",
+        "wordpress-stubs"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Defines global function shims (esc_html, get_option, apply_filters, wp_generate_uuid4, etc.) to emulate WordPress in isolation."
+    },
+    {
+      "id": "config:tests/fixtures/live-catalog-snapshot.json",
+      "type": "config",
+      "name": "live-catalog-snapshot.json",
+      "filePath": "tests/fixtures/live-catalog-snapshot.json",
+      "summary": "Test fixture snapshotting the live abilities catalog, with categories, sample abilities per category, and previously-unmapped categories fixed by the snapshot.",
+      "tags": [
+        "test",
+        "fixture",
+        "data"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:.distignore",
+      "type": "file",
+      "name": ".distignore",
+      "filePath": ".distignore",
+      "summary": "Distribution-ignore manifest listing files and folders excluded from the packaged plugin release artifact.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/PULL_REQUEST_TEMPLATE.md",
+      "type": "document",
+      "name": "PULL_REQUEST_TEMPLATE.md",
+      "filePath": ".github/PULL_REQUEST_TEMPLATE.md",
+      "summary": "GitHub pull request template prompting contributors for change description, type, affected abilities, testing done, and a security checklist.",
+      "tags": [
+        "documentation",
+        "development",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.ijfw/.dream-state-v2.json",
+      "type": "config",
+      "name": ".dream-state-v2.json",
+      "filePath": ".ijfw/.dream-state-v2.json",
+      "summary": "IJFW tooling state file tracking dream-cycle consolidation runs, with version, last-run timestamp, run count, and per-stage status.",
+      "tags": [
+        "configuration",
+        "tooling",
+        "state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.ijfw/.dream-state.json",
+      "type": "config",
+      "name": ".dream-state.json",
+      "filePath": ".ijfw/.dream-state.json",
+      "summary": "Legacy single-line IJFW dream-state record holding version and last-run timestamp for the memory consolidation cycle.",
+      "tags": [
+        "configuration",
+        "tooling",
+        "state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.ijfw/.session-counter",
+      "type": "file",
+      "name": ".session-counter",
+      "filePath": ".ijfw/.session-counter",
+      "summary": "Single-value counter file tracking the number of IJFW sessions run against this project.",
+      "tags": [
+        "tooling",
+        "state",
+        "metrics"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.ijfw/memory/project-journal.md",
+      "type": "document",
+      "name": "project-journal.md",
+      "filePath": ".ijfw/memory/project-journal.md",
+      "summary": "IJFW project journal stub capturing accumulated notes and learnings across sessions for this codebase.",
+      "tags": [
+        "documentation",
+        "tooling",
+        "memory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.ijfw/metrics/sessions.jsonl",
+      "type": "file",
+      "name": "sessions.jsonl",
+      "filePath": ".ijfw/metrics/sessions.jsonl",
+      "summary": "Append-only JSON Lines log of IJFW session metrics such as token usage and duration, one record per line.",
+      "tags": [
+        "tooling",
+        "metrics",
+        "data"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.ijfw/sessions/session_2026-06-03_15-41-08.md",
+      "type": "document",
+      "name": "session_2026-06-03_15-41-08.md",
+      "filePath": ".ijfw/sessions/session_2026-06-03_15-41-08.md",
+      "summary": "IJFW session handoff note recording activity and context for the session started 2026-06-03 15:41:08.",
+      "tags": [
+        "documentation",
+        "tooling",
+        "session"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.ijfw/sessions/session_2026-06-03_15-45-58.md",
+      "type": "document",
+      "name": "session_2026-06-03_15-45-58.md",
+      "filePath": ".ijfw/sessions/session_2026-06-03_15-45-58.md",
+      "summary": "IJFW session handoff note recording activity and context for the session started 2026-06-03 15:45:58.",
+      "tags": [
+        "documentation",
+        "tooling",
+        "session"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.understand-anything/.understandignore",
+      "type": "file",
+      "name": ".understandignore",
+      "filePath": ".understand-anything/.understandignore",
+      "summary": "Ignore manifest excluding paths from the Understand-Anything knowledge-graph scanner.",
+      "tags": [
+        "configuration",
+        "tooling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:assets/admin.css",
+      "type": "file",
+      "name": "admin.css",
+      "filePath": "assets/admin.css",
+      "summary": "Stylesheet for the plugin's WordPress admin screens, styling the settings, license, and ability-management UI.",
+      "tags": [
+        "stylesheet",
+        "admin-ui",
+        "frontend"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:assets/consent.css",
+      "type": "file",
+      "name": "consent.css",
+      "filePath": "assets/consent.css",
+      "summary": "Stylesheet for the OAuth consent screen presented to MCP clients during the authorization flow.",
+      "tags": [
+        "stylesheet",
+        "oauth",
+        "frontend"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/architecture.md",
+      "type": "document",
+      "name": "architecture.md",
+      "filePath": "docs/architecture.md",
+      "summary": "Architecture reference describing how the adapter sits in the stack, its directory layout, request flow, protocol negotiation, built-in meta-abilities, security model, and error handling.",
+      "tags": [
+        "documentation",
+        "architecture",
+        "overview"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "type": "file",
+      "name": "HelpersAreGlobalTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "summary": "Unit test asserting that OAuth helper functions are declared in the global namespace and not under the OAuth namespace, guarding against namespace-leakage regressions.",
+      "tags": [
+        "test",
+        "unit-test",
+        "oauth",
+        "namespace",
+        "validation"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses function_exists() to verify namespace placement of procedural helpers in PHP."
+    },
+    {
+      "id": "file:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "type": "file",
+      "name": "OAuthIsMcpResourceRequestTest.php",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "summary": "Comprehensive unit test covering the OAuth request classifier that decides whether an incoming REST request targets an MCP resource, across pretty/plain permalinks, subdir installs, and various WordPress/OAuth endpoints.",
+      "tags": [
+        "test",
+        "unit-test",
+        "oauth",
+        "rest-api",
+        "routing"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Manipulates superglobals ($_SERVER REQUEST_URI) per case and restores state in tearDown."
+    },
+    {
+      "id": "file:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "type": "file",
+      "name": "PatternMatchersTest.php",
+      "filePath": "tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "summary": "Unit test for the redaction PatternMatchers utility, verifying detection of password hashes (phpass/bcrypt/modern), known API key formats (Stripe, Slack, GitHub, AWS, Google), and Luhn-valid card numbers with negative cases.",
+      "tags": [
+        "test",
+        "unit-test",
+        "redaction",
+        "security",
+        "validation"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Exercises static method matchers via PatternMatchers::is_password_hash / is_known_api_key / passes_luhn."
+    },
+    {
+      "id": "file:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "type": "file",
+      "name": "DefaultServerFactoryBootContractTest.php",
+      "summary": "Contract test that reads the DefaultServerFactory source and asserts the advertised boot first-tool matches one declared in the server's tools allowlist, preventing boot-instruction drift.",
+      "filePath": "tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "tags": [
+        "test",
+        "unit-test",
+        "contract-test",
+        "server",
+        "mcp"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Static-source contract test using file_get_contents + regex to assert invariants without instantiating the factory."
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php:HelpersAreGlobalTest",
+      "type": "class",
+      "name": "HelpersAreGlobalTest",
+      "filePath": "tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "lineRange": [
+        22,
+        56
+      ],
+      "summary": "PHPUnit test case verifying OAuth helper functions exist globally and are absent from the OAuth namespace, with a data provider supplying helper names.",
+      "tags": [
+        "test",
+        "test-case",
+        "oauth",
+        "namespace"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php:OAuthIsMcpResourceRequestTest",
+      "type": "class",
+      "name": "OAuthIsMcpResourceRequestTest",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "lineRange": [
+        19,
+        146
+      ],
+      "summary": "PHPUnit test case with 19 cases exercising the MCP-resource-request detection logic for OAuth across permalink styles, subdirectory installs, and excluded WordPress/OAuth routes.",
+      "tags": [
+        "test",
+        "test-case",
+        "oauth",
+        "rest-api",
+        "routing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php:PatternMatchersTest",
+      "type": "class",
+      "name": "PatternMatchersTest",
+      "filePath": "tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "lineRange": [
+        10,
+        107
+      ],
+      "summary": "PHPUnit test case validating the PatternMatchers redaction heuristics for password hashes, vendor API keys, and Luhn-valid card numbers with positive and negative assertions.",
+      "tags": [
+        "test",
+        "test-case",
+        "redaction",
+        "security",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php:DefaultServerFactoryBootContractTest",
+      "type": "class",
+      "name": "DefaultServerFactoryBootContractTest",
+      "filePath": "tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "lineRange": [
+        21,
+        58
+      ],
+      "summary": "PHPUnit contract test case asserting the DefaultServerFactory's advertised boot first-tool is present in its registered tools allowlist.",
+      "tags": [
+        "test",
+        "test-case",
+        "contract-test",
+        "server",
+        "mcp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php:test_subdir_install_uses_rest_url_prefix",
+      "type": "function",
+      "name": "test_subdir_install_uses_rest_url_prefix",
+      "filePath": "tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "lineRange": [
+        125,
+        145
+      ],
+      "summary": "Verifies the MCP-resource detector honors the REST URL prefix for WordPress installs in a subdirectory, matching valid prefixed routes and rejecting non-prefixed ones.",
+      "tags": [
+        "test",
+        "rest-api",
+        "routing",
+        "subdirectory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php:test_advertised_boot_first_tool_is_in_the_tools_allowlist",
+      "type": "function",
+      "name": "test_advertised_boot_first_tool_is_in_the_tools_allowlist",
+      "filePath": "tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "lineRange": [
+        29,
+        57
+      ],
+      "summary": "Parses the factory source via regex to extract the advertised boot first-tool and the tools allowlist, then asserts the first-tool is contained in the allowlist.",
+      "tags": [
+        "test",
+        "contract-test",
+        "regex",
+        "validation"
+      ],
+      "complexity": "moderate"
+    }
+  ],
+  "edges": [
+    {
+      "source": "file:src/Handlers/HandlerHelperTrait.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "target": "class:src/Handlers/Initialize/InitializeHandler.php:InitializeHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "target": "class:src/Handlers/Initialize/InitializeHandler.php:InitializeHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "target": "function:src/Handlers/Initialize/InitializeHandler.php:handle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "class:src/Handlers/Prompts/PromptsHandler.php:PromptsHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "class:src/Handlers/Prompts/PromptsHandler.php:PromptsHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "function:src/Handlers/Prompts/PromptsHandler.php:get_prompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "function:src/Handlers/Prompts/PromptsHandler.php:list_prompts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "file:src/Handlers/HandlerHelperTrait.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "class:src/Handlers/Resources/ResourcesHandler.php:ResourcesHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "class:src/Handlers/Resources/ResourcesHandler.php:ResourcesHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "function:src/Handlers/Resources/ResourcesHandler.php:read_resource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "function:src/Handlers/Resources/ResourcesHandler.php:list_resources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "file:src/Handlers/HandlerHelperTrait.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/System/SystemHandler.php",
+      "target": "class:src/Handlers/System/SystemHandler.php:SystemHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/System/SystemHandler.php",
+      "target": "class:src/Handlers/System/SystemHandler.php:SystemHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Handlers/System/SystemHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "class:src/Handlers/Tools/ToolsHandler.php:ToolsHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "class:src/Handlers/Tools/ToolsHandler.php:ToolsHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "function:src/Handlers/Tools/ToolsHandler.php:handle_tool_call",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "function:src/Handlers/Tools/ToolsHandler.php:call_tool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "function:src/Handlers/Tools/ToolsHandler.php:sanitize_tool_data",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "function:src/Handlers/Tools/ToolsHandler.php:list_tools",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Domain/Tools/McpTool.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Handlers/HandlerHelperTrait.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Handlers/Tools/ToolsHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Handlers/Tools/ToolsHandler.php:handle_tool_call",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorMapper.php:from_wp_error",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "class:src/Infrastructure/ErrorHandling/McpErrorFactory.php:McpErrorFactory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "class:src/Infrastructure/ErrorHandling/McpErrorFactory.php:McpErrorFactory",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:create_error_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:mcp_error_to_http_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:validate_jsonrpc_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:rate_limited",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "target": "class:src/Infrastructure/ErrorHandling/McpErrorMapper.php:McpErrorMapper",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "target": "class:src/Infrastructure/ErrorHandling/McpErrorMapper.php:McpErrorMapper",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorMapper.php:from_wp_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/Infrastructure/ErrorHandling/McpErrorMapper.php:from_wp_error",
+      "target": "function:src/Infrastructure/ErrorHandling/McpErrorFactory.php:create_error_response",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Contracts/McpTransportInterface.php",
+      "target": "class:src/Transport/Contracts/McpTransportInterface.php:McpTransportInterface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Contracts/McpTransportInterface.php",
+      "target": "class:src/Transport/Contracts/McpTransportInterface.php:McpTransportInterface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Contracts/McpTransportInterface.php",
+      "target": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+      "target": "class:src/Transport/Infrastructure/HttpSessionValidator.php:HttpSessionValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+      "target": "class:src/Transport/Infrastructure/HttpSessionValidator.php:HttpSessionValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+      "target": "function:src/Transport/Infrastructure/HttpSessionValidator.php:validate_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "class:src/Transport/Infrastructure/McpTransportContext.php:McpTransportContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "class:src/Transport/Infrastructure/McpTransportContext.php:McpTransportContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Handlers/System/SystemHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Handlers/Tools/ToolsHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "target": "class:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php:OutputSchemaPassthroughTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+      "target": "file:src/Domain/Tools/McpTool.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "target": "class:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php:McpAnnotationMapperTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+      "target": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "target": "class:tests/Unit/Domain/Utils/SchemaTransformerTest.php:SchemaTransformerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+      "target": "file:src/Domain/Utils/SchemaTransformer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "target": "class:tests/Unit/Handlers/HandlerHelperTraitTest.php:HandlerHelperTraitTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Handlers/HandlerHelperTraitTest.php",
+      "target": "file:src/Handlers/HandlerHelperTrait.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "target": "class:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php:PromptsHandlerScopeEnforcementTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "target": "file:src/Domain/Prompts/McpPrompt.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+      "target": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "target": "class:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php:ResourcesHandlerScopeEnforcementTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "target": "file:src/Domain/Resources/McpResource.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+      "target": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "class:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php:PermissionErrorRemediationTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "target": "class:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php:McpErrorFactoryTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "target": "class:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php:McpErrorMapperTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "target": "class:src/Abilities/GetAbilityInfoAbility.php:GetAbilityInfoAbility",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "target": "class:src/Abilities/GetAbilityInfoAbility.php:GetAbilityInfoAbility",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "target": "function:src/Abilities/GetAbilityInfoAbility.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "target": "function:src/Abilities/GetAbilityInfoAbility.php:execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "target": "function:src/Abilities/GetAbilityInfoAbility.php:validate_user_access",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "class:src/Core/McpComponentRegistry.php:McpComponentRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "class:src/Core/McpComponentRegistry.php:McpComponentRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "function:src/Core/McpComponentRegistry.php:register_tools",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "function:src/Core/McpComponentRegistry.php:add_tool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "function:src/Core/McpComponentRegistry.php:register_resources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "function:src/Core/McpComponentRegistry.php:register_prompts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Prompts/McpPrompt.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Resources/McpResource.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Tools/McpTool.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpComponentRegistry.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Core/McpComponentRegistry.php:register_tools",
+      "target": "function:src/Domain/Tools/RegisterAbilityAsMcpTool.php:get_data",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpComponentRegistry.php:register_resources",
+      "target": "function:src/Domain/Resources/RegisterAbilityAsMcpResource.php:get_data",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpComponentRegistry.php:register_prompts",
+      "target": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:get_data",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "class:src/Core/McpServer.php:McpServer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "class:src/Core/McpServer.php:McpServer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "function:src/Core/McpServer.php:__construct",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "function:src/Core/McpServer.php:setup_components",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "function:src/Core/McpServer.php:register_mcp_components",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Domain/Prompts/McpPrompt.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Domain/Resources/McpResource.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Domain/Tools/McpTool.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServer.php",
+      "target": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Core/McpServer.php:register_mcp_components",
+      "target": "function:src/Core/McpComponentRegistry.php:register_tools",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpServer.php:register_mcp_components",
+      "target": "function:src/Core/McpComponentRegistry.php:register_resources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpServer.php:register_mcp_components",
+      "target": "function:src/Core/McpComponentRegistry.php:register_prompts",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpServer.php:setup_components",
+      "target": "function:src/Core/McpTransportFactory.php:initialize_transports",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "class:src/Core/McpTransportFactory.php:McpTransportFactory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "class:src/Core/McpTransportFactory.php:McpTransportFactory",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "function:src/Core/McpTransportFactory.php:initialize_transports",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "function:src/Core/McpTransportFactory.php:create_transport_context",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Handlers/Initialize/InitializeHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Handlers/Prompts/PromptsHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Handlers/Resources/ResourcesHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Handlers/System/SystemHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Handlers/Tools/ToolsHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Transport/Contracts/McpTransportInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpTransportFactory.php",
+      "target": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Core/McpTransportFactory.php:create_transport_context",
+      "target": "class:src/Transport/Infrastructure/McpTransportContext.php:McpTransportContext",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "target": "class:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php:McpPromptBuilderInterface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "target": "class:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php:McpPromptBuilderInterface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "target": "file:src/Domain/Prompts/McpPrompt.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "class:src/Domain/Prompts/McpPrompt.php:McpPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "class:src/Domain/Prompts/McpPrompt.php:McpPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "function:src/Domain/Prompts/McpPrompt.php:to_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "function:src/Domain/Prompts/McpPrompt.php:from_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "function:src/Domain/Prompts/McpPrompt.php:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "function:src/Domain/Prompts/McpPrompt.php:get_ability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPrompt.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptBuilder.php",
+      "target": "class:src/Domain/Prompts/McpPromptBuilder.php:McpPromptBuilder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptBuilder.php",
+      "target": "class:src/Domain/Prompts/McpPromptBuilder.php:McpPromptBuilder",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptBuilder.php",
+      "target": "function:src/Domain/Prompts/McpPromptBuilder.php:build",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptBuilder.php",
+      "target": "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "class:src/Domain/Prompts/McpPromptBuilder.php:McpPromptBuilder",
+      "target": "class:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php:McpPromptBuilderInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "class:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:RegisterAbilityAsMcpPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "class:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:RegisterAbilityAsMcpPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:get_data",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:convert_input_schema_to_arguments",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+      "target": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:get_data",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php:get_data",
+      "target": "function:src/Domain/Prompts/McpPrompt.php:from_array",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "class:src/Domain/Resources/McpResource.php:McpResource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "class:src/Domain/Resources/McpResource.php:McpResource",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "function:src/Domain/Resources/McpResource.php:to_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "function:src/Domain/Resources/McpResource.php:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "function:src/Domain/Resources/McpResource.php:get_ability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResource.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "target": "class:src/Domain/Resources/RegisterAbilityAsMcpResource.php:RegisterAbilityAsMcpResource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "target": "class:src/Domain/Resources/RegisterAbilityAsMcpResource.php:RegisterAbilityAsMcpResource",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "target": "function:src/Domain/Resources/RegisterAbilityAsMcpResource.php:get_data",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+      "target": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Domain/Resources/RegisterAbilityAsMcpResource.php:get_data",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "class:src/Domain/Tools/McpTool.php:McpTool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "class:src/Domain/Tools/McpTool.php:McpTool",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "function:src/Domain/Tools/McpTool.php:to_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "function:src/Domain/Tools/McpTool.php:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "function:src/Domain/Tools/McpTool.php:get_ability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpTool.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "class:src/Domain/Tools/RegisterAbilityAsMcpTool.php:RegisterAbilityAsMcpTool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "class:src/Domain/Tools/RegisterAbilityAsMcpTool.php:RegisterAbilityAsMcpTool",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "function:src/Domain/Tools/RegisterAbilityAsMcpTool.php:get_data",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+      "target": "file:src/Domain/Utils/SchemaTransformer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Domain/Tools/RegisterAbilityAsMcpTool.php:get_data",
+      "target": "function:src/Domain/Utils/SchemaTransformer.php:transform_to_object_schema",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Domain/Tools/RegisterAbilityAsMcpTool.php:get_data",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "class:src/Domain/Utils/McpAnnotationMapper.php:McpAnnotationMapper",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "class:src/Domain/Utils/McpAnnotationMapper.php:McpAnnotationMapper",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:map",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:normalize_annotation_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Domain/Utils/McpAnnotationMapper.php:build_from_ability",
+      "target": "function:src/Domain/Utils/McpAnnotationMapper.php:map",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Utils/SchemaTransformer.php",
+      "target": "class:src/Domain/Utils/SchemaTransformer.php:SchemaTransformer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/SchemaTransformer.php",
+      "target": "class:src/Domain/Utils/SchemaTransformer.php:SchemaTransformer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Utils/SchemaTransformer.php",
+      "target": "function:src/Domain/Utils/SchemaTransformer.php:transform_to_object_schema",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/OriginValidator.php",
+      "target": "class:src/Transport/Infrastructure/OriginValidator.php:OriginValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/OriginValidator.php",
+      "target": "class:src/Transport/Infrastructure/OriginValidator.php:OriginValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "class:src/Transport/Infrastructure/RequestRouter.php:RequestRouter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "class:src/Transport/Infrastructure/RequestRouter.php:RequestRouter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "target": "class:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php:SettingsAbilitiesTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "target": "class:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php:SettingsAbilitiesTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php:OAuthClientIpTrustedProxyTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php:OAuthClientIpTrustedProxyTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Cli/RequestIdStateTest.php",
+      "target": "class:tests/Unit/Cli/RequestIdStateTest.php:RequestIdStateTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Cli/RequestIdStateTest.php",
+      "target": "class:tests/Unit/Cli/RequestIdStateTest.php:RequestIdStateTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "target": "class:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php:BoundaryEventEmitterTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "target": "class:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php:BoundaryEventEmitterTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php:ResponseRedactionGateTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php:ResponseRedactionGateTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/CounterStoreTest.php",
+      "target": "class:tests/Unit/RateLimit/CounterStoreTest.php:CounterStoreTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/CounterStoreTest.php",
+      "target": "class:tests/Unit/RateLimit/CounterStoreTest.php:CounterStoreTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/RateLimiterTest.php",
+      "target": "class:tests/Unit/RateLimit/RateLimiterTest.php:RateLimiterTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/RateLimiterTest.php",
+      "target": "class:tests/Unit/RateLimit/RateLimiterTest.php:RateLimiterTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "target": "class:tests/Unit/RateLimit/TrustedProxyResolverTest.php:TrustedProxyResolverTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "target": "class:tests/Unit/RateLimit/TrustedProxyResolverTest.php:TrustedProxyResolverTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "target": "class:tests/Unit/Settings/ConfirmationTokenStoreTest.php:ConfirmationTokenStoreTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "target": "class:tests/Unit/Settings/ConfirmationTokenStoreTest.php:ConfirmationTokenStoreTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "target": "class:tests/Unit/Settings/SafetySettingsRepositoryTest.php:SafetySettingsRepositoryTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "target": "class:tests/Unit/Settings/SafetySettingsRepositoryTest.php:SafetySettingsRepositoryTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Transport/HttpTransportTest.php",
+      "target": "class:tests/Unit/Transport/HttpTransportTest.php:HttpTransportTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Transport/HttpTransportTest.php",
+      "target": "class:tests/Unit/Transport/HttpTransportTest.php:HttpTransportTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "target": "class:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php:OriginValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "target": "class:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php:OriginValidatorTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "file:src/RateLimit/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "target": "file:src/RateLimit/TrustedProxyResolver.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "target": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Cli/RequestIdStateTest.php",
+      "target": "file:src/Cli/StdioServerBridge.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/CounterStoreTest.php",
+      "target": "file:src/RateLimit/CounterStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/RateLimiterTest.php",
+      "target": "file:src/RateLimit/CounterStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/RateLimiterTest.php",
+      "target": "file:src/RateLimit/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+      "target": "file:src/RateLimit/TrustedProxyResolver.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+      "target": "file:src/Settings/ConfirmationTokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Transport/HttpTransportTest.php",
+      "target": "file:src/Transport/HttpTransport.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+      "target": "file:src/Transport/Infrastructure/OriginValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "target": "class:src/Abilities/Settings/SettingsAbilities.php:SettingsAbilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "target": "class:src/Abilities/Settings/SettingsAbilities.php:SettingsAbilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/SafetyTab.php",
+      "target": "class:src/Admin/Tabs/SafetyTab.php:SafetyTab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/SafetyTab.php",
+      "target": "class:src/Admin/Tabs/SafetyTab.php:SafetyTab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Cli/StdioServerBridge.php",
+      "target": "class:src/Cli/StdioServerBridge.php:StdioServerBridge",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Cli/StdioServerBridge.php",
+      "target": "class:src/Cli/StdioServerBridge.php:StdioServerBridge",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "target": "class:src/Infrastructure/Observability/BoundaryEventEmitter.php:BoundaryEventEmitter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "target": "class:src/Infrastructure/Observability/BoundaryEventEmitter.php:BoundaryEventEmitter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/ConsoleObservabilityHandler.php:ConsoleObservabilityHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/ConsoleObservabilityHandler.php:ConsoleObservabilityHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "target": "class:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php:McpObservabilityHandlerInterface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "target": "class:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php:McpObservabilityHandlerInterface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "target": "class:src/Infrastructure/Redaction/ResponseRedactionGate.php:ResponseRedactionGate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "target": "class:src/Infrastructure/Redaction/ResponseRedactionGate.php:ResponseRedactionGate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/CounterStore.php",
+      "target": "class:src/RateLimit/CounterStore.php:CounterStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/CounterStore.php",
+      "target": "class:src/RateLimit/CounterStore.php:CounterStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/RateLimiter.php",
+      "target": "class:src/RateLimit/RateLimiter.php:RateLimiter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/RateLimiter.php",
+      "target": "class:src/RateLimit/RateLimiter.php:RateLimiter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/TrustedProxyResolver.php",
+      "target": "class:src/RateLimit/TrustedProxyResolver.php:TrustedProxyResolver",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/TrustedProxyResolver.php",
+      "target": "class:src/RateLimit/TrustedProxyResolver.php:TrustedProxyResolver",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Settings/ConfirmationTokenStore.php",
+      "target": "class:src/Settings/ConfirmationTokenStore.php:ConfirmationTokenStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Settings/ConfirmationTokenStore.php",
+      "target": "class:src/Settings/ConfirmationTokenStore.php:ConfirmationTokenStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Settings/SafetySettingsRepository.php",
+      "target": "class:src/Settings/SafetySettingsRepository.php:SafetySettingsRepository",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Settings/SafetySettingsRepository.php",
+      "target": "class:src/Settings/SafetySettingsRepository.php:SafetySettingsRepository",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Contracts/McpRestTransportInterface.php",
+      "target": "class:src/Transport/Contracts/McpRestTransportInterface.php:McpRestTransportInterface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Contracts/McpRestTransportInterface.php",
+      "target": "class:src/Transport/Contracts/McpRestTransportInterface.php:McpRestTransportInterface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "class:src/Transport/HttpTransport.php:HttpTransport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "class:src/Transport/HttpTransport.php:HttpTransport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestContext.php",
+      "target": "class:src/Transport/Infrastructure/HttpRequestContext.php:HttpRequestContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestContext.php",
+      "target": "class:src/Transport/Infrastructure/HttpRequestContext.php:HttpRequestContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "target": "class:src/Transport/Infrastructure/HttpRequestHandler.php:HttpRequestHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "target": "class:src/Transport/Infrastructure/HttpRequestHandler.php:HttpRequestHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "target": "file:src/Settings/ConfirmationTokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/SafetyTab.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/SafetyTab.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/SafetyTab.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Cli/StdioServerBridge.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Cli/StdioServerBridge.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Cli/StdioServerBridge.php",
+      "target": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/RateLimit/TrustedProxyResolver.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Contracts/McpRestTransportInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Infrastructure/HttpRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Infrastructure/McpTransportContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Infrastructure/McpTransportHelperTrait.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/HttpTransport.php",
+      "target": "file:src/Transport/Infrastructure/OriginValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "target": "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "class:src/Infrastructure/Observability/ConsoleObservabilityHandler.php:ConsoleObservabilityHandler",
+      "target": "class:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php:McpObservabilityHandlerInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:src/Transport/HttpTransport.php:HttpTransport",
+      "target": "class:src/Transport/Contracts/McpRestTransportInterface.php:McpRestTransportInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "target": "class:src/Auth/OAuth/AuthorizationCodeStore.php:AuthorizationCodeStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "target": "class:src/Auth/OAuth/AuthorizationCodeStore.php:AuthorizationCodeStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "target": "function:src/Auth/OAuth/AuthorizationCodeStore.php:store",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "target": "function:src/Auth/OAuth/AuthorizationCodeStore.php:consume",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "class:src/Auth/OAuth/ClientRegistry.php:ClientRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "class:src/Auth/OAuth/ClientRegistry.php:ClientRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:find",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:redirect_uri_valid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:revoke",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ClientRegistry.php",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:list_active",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeValidationResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeValidationResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeRequestValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "class:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:AuthorizeRequestValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:pre_redirect_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:redirectable_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "class:src/Auth/OAuth/DiscoveryEndpoints.php:DiscoveryEndpoints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "class:src/Auth/OAuth/DiscoveryEndpoints.php:DiscoveryEndpoints",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "function:src/Auth/OAuth/DiscoveryEndpoints.php:issuer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "function:src/Auth/OAuth/DiscoveryEndpoints.php:serve_protected_resource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "function:src/Auth/OAuth/DiscoveryEndpoints.php:as_metadata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "target": "function:src/Auth/OAuth/DiscoveryEndpoints.php:json_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:RegisterEndpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:RegisterEndpoint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:classify_scopes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:is_valid_redirect_uri",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:RevokeEndpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:RevokeEndpoint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/TokenEndpoint.php:TokenEndpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/TokenEndpoint.php:TokenEndpoint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_auth_code",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_refresh",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/RateLimiter.php",
+      "target": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/RateLimiter.php",
+      "target": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/RateLimiter.php",
+      "target": "function:src/Auth/OAuth/RateLimiter.php:check_dcr",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/RateLimiter.php",
+      "target": "function:src/Auth/OAuth/RateLimiter.php:check_revoke",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/RateLimiter.php",
+      "target": "function:src/Auth/OAuth/RateLimiter.php:counter_increment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "class:src/Auth/OAuth/TokenStore.php:TokenStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "class:src/Auth/OAuth/TokenStore.php:TokenStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:issue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:rotate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:encrypt_replay_blob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:decrypt_replay_blob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:lookup_access_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:find_token_meta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:revoke_by_plaintext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:revoke_family",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/TokenStore.php",
+      "target": "function:src/Auth/OAuth/TokenStore.php:flush_pending_touches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php:AuthorizationCodeStoreSelectedRoleTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php:AuthorizationCodeStoreTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/ClientRegistryTest.php:ClientRegistryTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php:AuthorizeRequestValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php:DiscoveryEndpointsTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "target": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+      "target": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+      "target": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:validate",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:find",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:validate",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:redirect_uri_valid",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php:validate",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/DiscoveryEndpoints.php:serve_protected_resource",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/DiscoveryEndpoints.php:as_metadata",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/RateLimiter.php:check_dcr",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/DiscoveryEndpoints.php:json_response",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "target": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:register",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RegisterEndpoint.php:classify_scopes",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/RateLimiter.php:check_revoke",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "target": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/TokenStore.php:find_token_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/RevokeEndpoint.php:handle_post",
+      "target": "function:src/Auth/OAuth/TokenStore.php:revoke_by_plaintext",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_auth_code",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:find",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_auth_code",
+      "target": "function:src/Auth/OAuth/AuthorizationCodeStore.php:consume",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_auth_code",
+      "target": "function:src/Auth/OAuth/TokenStore.php:issue",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_refresh",
+      "target": "function:src/Auth/OAuth/ClientRegistry.php:find",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/Endpoints/TokenEndpoint.php:handle_refresh",
+      "target": "function:src/Auth/OAuth/TokenStore.php:rotate",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:src/Auth/OAuth/RateLimiter.php:RateLimiter",
+      "target": "class:src/Auth/OAuth/ClientRegistry.php:ClientRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php:RegisterEndpointClassifyScopesTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php:PathStyleMultisiteDiscoveryTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php:RateLimiterAtomicTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/RateLimiterTest.php:RateLimiterTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php:RedirectUriNormalizeTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php:TokenEndpointRedirectUriRawTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php:TokenStoreIssueResponseTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php:TokenStoreReplayBlobTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php:TokenStoreRevocationCascadeTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php:TokenStoreRotationFamilyTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php:TokenStoreSelectedRoleTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php:TokenStoreTouchDeferredTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "target": "class:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php:RevokeEndpointClientAuthTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "target": "class:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php:RevokeEndpointRateLimitTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+      "target": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+      "target": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+      "target": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RateLimiterTest.php",
+      "target": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+      "target": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+      "target": "file:src/Auth/OAuth/TokenStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+      "target": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "target": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+      "target": "file:src/Auth/OAuth/RateLimiter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/McpResourcePath.php",
+      "target": "class:src/Auth/OAuth/McpResourcePath.php:McpResourcePath",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/McpResourcePath.php",
+      "target": "class:src/Auth/OAuth/McpResourcePath.php:McpResourcePath",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "target": "class:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php:BoundaryAuditBufferTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "target": "class:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php:BoundaryAuditBufferTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+      "target": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "target": "class:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php:BridgeRowProjectorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "target": "class:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php:BridgeRowProjectorTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+      "target": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "target": "class:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php:ConnectedBridgesTabTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "target": "class:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php:ConnectedBridgesTabTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+      "target": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php:ConsentDecisionEvaluatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php:ConsentDecisionEvaluatorTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php:ConsentScreenRendererTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php:ConsentScreenRendererTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php:LastConsentLookupTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php:LastConsentLookupTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+      "target": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php:PolicyStoreTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php:PolicyStoreTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php:RenderedScopeNonceTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php:RenderedScopeNonceTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+      "target": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php:RoleSelectorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php:RoleSelectorTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+      "target": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/McpResourcePathTest.php:McpResourcePathTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/McpResourcePathTest.php:McpResourcePathTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+      "target": "file:src/Auth/OAuth/McpResourcePath.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php:PathStyleMultisiteAuthorizeRoutingTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php:PathStyleMultisiteAuthorizeRoutingTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+      "target": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "target": "class:src/Admin/Bridges/BoundaryAuditBuffer.php:BoundaryAuditBuffer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "target": "class:src/Admin/Bridges/BoundaryAuditBuffer.php:BoundaryAuditBuffer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "target": "function:src/Admin/Bridges/BoundaryAuditBuffer.php:capture",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "target": "function:src/Admin/Bridges/BoundaryAuditBuffer.php:read",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "target": "class:src/Admin/Bridges/BridgeRowProjector.php:BridgeRowProjector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "target": "class:src/Admin/Bridges/BridgeRowProjector.php:BridgeRowProjector",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "target": "function:src/Admin/Bridges/BridgeRowProjector.php:project",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "class:src/Admin/Tabs/ConnectedBridgesTab.php:ConnectedBridgesTab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "class:src/Admin/Tabs/ConnectedBridgesTab.php:ConnectedBridgesTab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_table",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_audit_slice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:render_authorization_header_diagnostic",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:handle_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:resolve_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:format_datetime",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "function:src/Admin/Tabs/ConnectedBridgesTab.php:latest_token_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/Bridges/BridgeRowProjector.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Auth/OAuth/ClientRegistry.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentDecision.php:ConsentDecision",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentDecision.php:ConsentDecision",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php:ConsentDecisionEvaluator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php:ConsentDecisionEvaluator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php:evaluate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:ConsentScreenRenderer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "class:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:ConsentScreenRenderer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:build_html",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render_scope_groups",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:render_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "function:src/Auth/OAuth/Consent/ConsentScreenRenderer.php:build_error_html",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "target": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "target": "class:src/Auth/OAuth/Consent/LastConsentLookup.php:LastConsentLookup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "target": "class:src/Auth/OAuth/Consent/LastConsentLookup.php:LastConsentLookup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "target": "function:src/Auth/OAuth/Consent/LastConsentLookup.php:timestamp_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "target": "function:src/Auth/OAuth/Consent/LastConsentLookup.php:days_since",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "target": "class:src/Auth/OAuth/Consent/PolicyStore.php:PolicyStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "target": "class:src/Auth/OAuth/Consent/PolicyStore.php:PolicyStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "target": "function:src/Auth/OAuth/Consent/PolicyStore.php:consent_max_silent_days",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "target": "class:src/Auth/OAuth/Consent/PriorGrantLookup.php:PriorGrantLookup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "target": "class:src/Auth/OAuth/Consent/PriorGrantLookup.php:PriorGrantLookup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "target": "function:src/Auth/OAuth/Consent/PriorGrantLookup.php:scopes_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "target": "class:src/Auth/OAuth/Consent/RenderedScopeNonce.php:RenderedScopeNonce",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "target": "class:src/Auth/OAuth/Consent/RenderedScopeNonce.php:RenderedScopeNonce",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "target": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:issue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "target": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:redeem",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "target": "function:src/Auth/OAuth/Consent/RenderedScopeNonce.php:submitted_subset_is_valid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "target": "class:src/Auth/OAuth/Consent/RoleSelector.php:RoleSelector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "target": "class:src/Auth/OAuth/Consent/RoleSelector.php:RoleSelector",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "target": "function:src/Auth/OAuth/Consent/RoleSelector.php:roles_for_user_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:AuthorizeEndpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "class:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:AuthorizeEndpoint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:dispatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:handle_get",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:mint_code_and_redirect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:render_consent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:handle_post",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:submitted_scopes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_to_login",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_with_code",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:redirect_with_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "function:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php:resource_indicator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/McpResourcePath.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/PolicyStore.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/RoleSelector.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "target": "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "target": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "target": "class:src/Admin/Bridges/AuthHeaderProbe.php:AuthHeaderProbe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "target": "class:src/Admin/Bridges/AuthHeaderProbe.php:AuthHeaderProbe",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "target": "function:src/Admin/Bridges/AuthHeaderProbe.php:record",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "target": "function:src/Admin/Bridges/AuthHeaderProbe.php:resolve_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "class:src/Auth/OAuth/AuthorizationServer.php:AuthorizationServer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "class:src/Auth/OAuth/AuthorizationServer.php:AuthorizationServer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:boot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:maybe_run_migration",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:run_migration",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:intercept_pre_wp_routes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:extract_path_prefix",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:extract_authorize_path_prefix",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:is_well_known_or_oauth_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:register_rest_routes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:rest_host_allowlist_gate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:authenticate_bearer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "target": "function:src/Auth/OAuth/AuthorizationServer.php:schedule_www_authenticate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/Auth/OAuth/AuthorizationServer.php:boot",
+      "target": "function:src/Admin/Bridges/AuthHeaderProbe.php:record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/AuthorizationServer.php:authenticate_bearer",
+      "target": "function:src/Admin/Bridges/AuthHeaderProbe.php:record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/AuthorizationServer.php:authenticate_bearer",
+      "target": "function:src/Auth/OAuth/OAuthRequestContext.php:set",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/AuthorizationServer.php:rest_host_allowlist_gate",
+      "target": "class:src/Auth/OAuth/OAuthHostAllowlist.php:OAuthHostAllowlist",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Auth/OAuth/AuthorizationServer.php:intercept_pre_wp_routes",
+      "target": "class:src/Auth/OAuth/OAuthHostAllowlist.php:OAuthHostAllowlist",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "target": "class:src/Auth/OAuth/OAuthHostAllowlist.php:OAuthHostAllowlist",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "target": "class:src/Auth/OAuth/OAuthHostAllowlist.php:OAuthHostAllowlist",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "target": "function:src/Auth/OAuth/OAuthHostAllowlist.php:build",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "target": "class:src/Auth/OAuth/OAuthRequestContext.php:OAuthRequestContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "target": "class:src/Auth/OAuth/OAuthRequestContext.php:OAuthRequestContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "target": "function:src/Auth/OAuth/OAuthRequestContext.php:set",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "target": "class:src/Auth/OAuth/SelectedRoleEnforcer.php:SelectedRoleEnforcer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "target": "class:src/Auth/OAuth/SelectedRoleEnforcer.php:SelectedRoleEnforcer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "target": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:apply",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "target": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:role_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "target": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:default_role_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/Auth/OAuth/SelectedRoleEnforcer.php:apply",
+      "target": "class:src/Auth/OAuth/OAuthRequestContext.php:OAuthRequestContext",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "target": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+      "target": "class:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php:AuthHeaderProbeTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "target": "file:src/Admin/Bridges/AuthHeaderProbe.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php:AuthHeaderProbeNamespaceGateTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php:AuthenticateBearerNarrowsToMcpResourceTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php:AuthenticateBearerSelectedRoleTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php:BearerHeaderTrimTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php:IsWellKnownOrOAuthPathTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "target": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php:OAuthHostAllowlistTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php:OAuthRequestContextResetTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php:OAuthRequestContextTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php:ResponseDifferentialHardeningTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "target": "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php:RestRouteHostAllowlistTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "target": "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php:SelectedRoleEnforcerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php:WwwAuthenticateBareChallengeCTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "class:src/Abilities/BatchExecuteAbility.php:BatchExecuteAbility",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "class:src/Abilities/BatchExecuteAbility.php:BatchExecuteAbility",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "function:src/Abilities/BatchExecuteAbility.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "function:src/Abilities/BatchExecuteAbility.php:execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "file:src/Core/McpAdapter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/BatchExecuteAbility.php",
+      "target": "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Abilities/BatchExecuteAbility.php:execute",
+      "target": "class:src/Core/McpAdapter.php:McpAdapter",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "class:src/Abilities/ExecuteAbilityAbility.php:ExecuteAbilityAbility",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "class:src/Abilities/ExecuteAbilityAbility.php:ExecuteAbilityAbility",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "function:src/Abilities/ExecuteAbilityAbility.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "function:src/Abilities/ExecuteAbilityAbility.php:check_permission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "function:src/Abilities/ExecuteAbilityAbility.php:validate_user_access",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "function:src/Abilities/ExecuteAbilityAbility.php:execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/PermissionManager.php",
+      "target": "class:src/Admin/PermissionManager.php:PermissionManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/PermissionManager.php",
+      "target": "class:src/Admin/PermissionManager.php:PermissionManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/PermissionManager.php",
+      "target": "function:src/Admin/PermissionManager.php:get_permission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/PermissionManager.php",
+      "target": "function:src/Admin/PermissionManager.php:set_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/PermissionManager.php",
+      "target": "function:src/Admin/PermissionManager.php:get_settings",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "target": "class:src/Auth/OAuth/Consent/ScopeGrouper.php:ScopeGrouper",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "target": "class:src/Auth/OAuth/Consent/ScopeGrouper.php:ScopeGrouper",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "target": "function:src/Auth/OAuth/Consent/ScopeGrouper.php:group",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Auth/OAuth/Consent/ScopeGrouper.php:group",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "class:src/Auth/OAuth/OAuthScopeEnforcer.php:OAuthScopeEnforcer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "class:src/Auth/OAuth/OAuthScopeEnforcer.php:OAuthScopeEnforcer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check_scope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:umbrella_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check_scope",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:src/Auth/OAuth/OAuthScopeEnforcer.php:OAuthScopeEnforcer",
+      "target": "function:src/Admin/PermissionManager.php:get_permission",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "class:src/Auth/OAuth/ScopeRegistry.php:ScopeRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "function:src/Auth/OAuth/ScopeRegistry.php:expand",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "function:src/Auth/OAuth/ScopeRegistry.php:all_scopes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "function:src/Auth/OAuth/ScopeRegistry.php:categories_from_registry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "target": "function:src/Auth/OAuth/ScopeRegistry.php:has_category_coverage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "target": "class:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php:ExecuteAbilityScopeEnforcementTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "target": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "target": "class:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php:MetaToolPermissionAnnotationTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "target": "file:src/Abilities/BatchExecuteAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "target": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/PermissionManagerTest.php",
+      "target": "class:tests/Unit/Admin/PermissionManagerTest.php:PermissionManagerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/PermissionManagerTest.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php:ScopeGrouperTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+      "target": "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php:OAuthScopeEnforcerCheckScopeTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php:OAuthScopeEnforcerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "target": "file:src/Auth/OAuth/OAuthRequestContext.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "target": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php:ScopeCoverageDriftTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/ScopeRegistryTest.php:ScopeRegistryTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+      "target": "file:src/Auth/OAuth/ScopeRegistry.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "target": "class:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php:McpAnnotationMapperBuildTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+      "target": "file:src/Domain/Utils/McpAnnotationMapper.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "file:src/Core/McpAdapter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Abilities/BatchExecuteAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Abilities/ExecuteAbilityAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Abilities/GetAbilityInfoAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Abilities/GetStartedAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Cli/McpCommand.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "file:src/Servers/DefaultServerFactory.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "file:src/Core/McpAdapter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "file:src/Core/McpServerConfig.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "file:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "file:src/Transport/HttpTransport.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "target": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "file:src/Cli/StdioServerBridge.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "file:src/Core/McpServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "file:src/Transport/Infrastructure/RequestRouter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Core/McpServerConfigTest.php",
+      "target": "file:src/Core/McpServerConfig.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "target": "class:src/Abilities/DiscoverAbilitiesAbility.php:DiscoverAbilitiesAbility",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "target": "class:src/Abilities/DiscoverAbilitiesAbility.php:DiscoverAbilitiesAbility",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "target": "function:src/Abilities/DiscoverAbilitiesAbility.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "target": "function:src/Abilities/DiscoverAbilitiesAbility.php:validate_user_access",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/DiscoverAbilitiesAbility.php",
+      "target": "function:src/Abilities/DiscoverAbilitiesAbility.php:execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetStartedAbility.php",
+      "target": "class:src/Abilities/GetStartedAbility.php:GetStartedAbility",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetStartedAbility.php",
+      "target": "class:src/Abilities/GetStartedAbility.php:GetStartedAbility",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Abilities/GetStartedAbility.php",
+      "target": "function:src/Abilities/GetStartedAbility.php:register",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetStartedAbility.php",
+      "target": "function:src/Abilities/GetStartedAbility.php:check_permission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/GetStartedAbility.php",
+      "target": "function:src/Abilities/GetStartedAbility.php:execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "class:src/Cli/McpCommand.php:McpCommand",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "class:src/Cli/McpCommand.php:McpCommand",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "function:src/Cli/McpCommand.php:serve",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "function:src/Cli/McpCommand.php:list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Cli/McpCommand.php",
+      "target": "function:src/Cli/McpCommand.php:get_user",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "class:src/Core/McpAdapter.php:McpAdapter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "class:src/Core/McpAdapter.php:McpAdapter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:instance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:init",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:create_server_from_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:create_server",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:maybe_create_default_server",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpAdapter.php",
+      "target": "function:src/Core/McpAdapter.php:register_wp_cli_commands",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "class:src/Core/McpServerConfig.php:McpServerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "class:src/Core/McpServerConfig.php:McpServerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Core/McpServerConfig.php",
+      "target": "function:src/Core/McpServerConfig.php:from_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "target": "class:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php:McpErrorHandlerInterface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+      "target": "class:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php:McpErrorHandlerInterface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "target": "class:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php:ErrorLogMcpErrorHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+      "target": "class:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php:ErrorLogMcpErrorHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php:ErrorLogMcpErrorHandler",
+      "target": "class:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php:McpErrorHandlerInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "target": "class:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php:NullMcpErrorHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+      "target": "class:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php:NullMcpErrorHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php:NullMcpErrorHandler",
+      "target": "class:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php:McpErrorHandlerInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/NullMcpObservabilityHandler.php:NullMcpObservabilityHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/NullMcpObservabilityHandler.php:NullMcpObservabilityHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:src/Infrastructure/Observability/NullMcpObservabilityHandler.php:NullMcpObservabilityHandler",
+      "target": "class:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php:McpObservabilityHandlerInterface",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "class:src/Servers/DefaultServerFactory.php:DefaultServerFactory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "class:src/Servers/DefaultServerFactory.php:DefaultServerFactory",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "function:src/Servers/DefaultServerFactory.php:create",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "function:src/Servers/DefaultServerFactory.php:is_ability_mcp_public",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Servers/DefaultServerFactory.php",
+      "target": "function:src/Servers/DefaultServerFactory.php:discover_abilities_by_type",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "target": "class:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php:DiscoverAbilitiesDefaultsTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+      "target": "class:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php:DiscoverAbilitiesDefaultsTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "class:tests/Unit/Cli/StdioServerBridgeIdNullTest.php:StdioServerBridgeIdNullTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+      "target": "class:tests/Unit/Cli/StdioServerBridgeIdNullTest.php:StdioServerBridgeIdNullTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Core/McpServerConfigTest.php",
+      "target": "class:tests/Unit/Core/McpServerConfigTest.php:McpServerConfigTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Core/McpServerConfigTest.php",
+      "target": "class:tests/Unit/Core/McpServerConfigTest.php:McpServerConfigTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "target": "class:src/Abilities/GetStartedAbility.php:GetStartedAbility",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "target": "class:src/Abilities/DiscoverAbilitiesAbility.php:DiscoverAbilitiesAbility",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "target": "class:src/Abilities/GetAbilityInfoAbility.php:GetAbilityInfoAbility",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "target": "class:src/Abilities/ExecuteAbilityAbility.php:ExecuteAbilityAbility",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_default_abilities",
+      "target": "class:src/Abilities/BatchExecuteAbility.php:BatchExecuteAbility",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Core/McpAdapter.php:register_wp_cli_commands",
+      "target": "class:src/Cli/McpCommand.php:McpCommand",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Servers/DefaultServerFactory.php:create",
+      "target": "function:src/Core/McpAdapter.php:instance",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Servers/DefaultServerFactory.php:create",
+      "target": "function:src/Core/McpServerConfig.php:from_array",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Servers/DefaultServerFactory.php:create",
+      "target": "function:src/Core/McpAdapter.php:create_server_from_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Cli/McpCommand.php:serve",
+      "target": "function:src/Core/McpAdapter.php:instance",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Cli/McpCommand.php:list",
+      "target": "function:src/Core/McpAdapter.php:instance",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Admin/AbilitySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Admin/SafetySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Auth/OAuth/AuthorizationServer.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/Core/McpAdapter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:abilities-mcp-adapter.php",
+      "target": "file:src/RateLimit/TrustedProxyResolver.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/AbilitySettingsPage.php",
+      "target": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "file:src/Admin/Tabs/SafetyTab.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "file:src/Admin/PermissionManager.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "file:src/Abilities/Settings/SettingsAbilities.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "file:src/Admin/AbilitySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "file:src/Admin/SafetySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "file:src/Core/McpAdapter.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/AdapterAdminPageTest.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "target": "file:src/Admin/AbilitySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "target": "file:src/Admin/AdapterAdminPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "target": "file:src/Admin/SafetySettingsPage.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "target": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Admin/AbilitySettingsPage.php",
+      "target": "class:src/Admin/AbilitySettingsPage.php:AbilitySettingsPage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AbilitySettingsPage.php",
+      "target": "class:src/Admin/AbilitySettingsPage.php:AbilitySettingsPage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/AbilitySettingsPage.php",
+      "target": "function:src/Admin/AbilitySettingsPage.php:maybe_redirect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "class:src/Admin/AdapterAdminPage.php:AdapterAdminPage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "class:src/Admin/AdapterAdminPage.php:AdapterAdminPage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "function:src/Admin/AdapterAdminPage.php:add_menu_page",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "function:src/Admin/AdapterAdminPage.php:dispatch_form_submissions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "function:src/Admin/AdapterAdminPage.php:enqueue_assets",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "function:src/Admin/AdapterAdminPage.php:render_page",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/AdapterAdminPage.php",
+      "target": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/SafetySettingsPage.php",
+      "target": "class:src/Admin/SafetySettingsPage.php:SafetySettingsPage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/SafetySettingsPage.php",
+      "target": "class:src/Admin/SafetySettingsPage.php:SafetySettingsPage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/SafetySettingsPage.php",
+      "target": "function:src/Admin/SafetySettingsPage.php:maybe_redirect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "class:src/Admin/Tabs/AbilitiesTab.php:AbilitiesTab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "class:src/Admin/Tabs/AbilitiesTab.php:AbilitiesTab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:handle_save_abilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:handle_license_actions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:render",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:render_abilities_subtab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:render_license_subtab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:group_abilities_by_permission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Admin/Tabs/AbilitiesTab.php",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:is_mcp_exposed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "class:src/Auth/OAuth/OAuthCleanup.php:OAuthCleanup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "class:src/Auth/OAuth/OAuthCleanup.php:OAuthCleanup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "function:src/Auth/OAuth/OAuthCleanup.php:schedule",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "function:src/Auth/OAuth/OAuthCleanup.php:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "function:src/Auth/OAuth/OAuthCleanup.php:batch_delete",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthCleanup.php",
+      "target": "function:src/Auth/OAuth/OAuthCleanup.php:maybe_alert_row_counts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "class:src/Plugin.php:Plugin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "class:src/Plugin.php:Plugin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "function:src/Plugin.php:instance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "function:src/Plugin.php:setup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Plugin.php",
+      "target": "function:src/Plugin.php:has_dependencies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/AdapterAdminPageTest.php",
+      "target": "class:tests/Unit/Admin/AdapterAdminPageTest.php:AdapterAdminPageTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+      "target": "class:tests/Unit/Admin/LegacyRedirectorsTest.php:LegacyRedirectorsTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthCleanupTest.php:OAuthCleanupTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/Admin/AbilitySettingsPage.php:maybe_redirect",
+      "target": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/SafetySettingsPage.php:maybe_redirect",
+      "target": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/AdapterAdminPage.php:dispatch_form_submissions",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:handle_save_abilities",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/AdapterAdminPage.php:dispatch_form_submissions",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:handle_license_actions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/AdapterAdminPage.php:render_page",
+      "target": "function:src/Admin/Tabs/AbilitiesTab.php:render",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/Tabs/AbilitiesTab.php:handle_save_abilities",
+      "target": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Admin/Tabs/AbilitiesTab.php:render",
+      "target": "function:src/Admin/AdapterAdminPage.php:tab_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/Plugin.php:setup",
+      "target": "class:src/Core/McpAdapter.php:McpAdapter",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "file:src/Domain/Resources/McpResourceValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "target": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "target": "file:src/Domain/Resources/McpResourceValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "target": "file:src/Domain/Tools/McpToolValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "class:src/Domain/Utils/McpValidator.php:McpValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "class:src/Domain/Utils/McpValidator.php:McpValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:validate_iso8601_timestamp",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:validate_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:validate_base64",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:validate_resource_uri",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:validate_roles_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:get_tool_annotation_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Utils/McpValidator.php",
+      "target": "function:src/Domain/Utils/McpValidator.php:get_annotation_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "class:src/Domain/Tools/McpToolValidator.php:McpToolValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "class:src/Domain/Tools/McpToolValidator.php:McpToolValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "function:src/Domain/Tools/McpToolValidator.php:get_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "function:src/Domain/Tools/McpToolValidator.php:get_schema_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "function:src/Domain/Tools/McpToolValidator.php:validate_tool_uniqueness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "class:src/Domain/Resources/McpResourceValidator.php:McpResourceValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "class:src/Domain/Resources/McpResourceValidator.php:McpResourceValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "function:src/Domain/Resources/McpResourceValidator.php:get_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "function:src/Domain/Resources/McpResourceValidator.php:validate_resource_uniqueness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "class:src/Domain/Prompts/McpPromptValidator.php:McpPromptValidator",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "class:src/Domain/Prompts/McpPromptValidator.php:McpPromptValidator",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "function:src/Domain/Prompts/McpPromptValidator.php:get_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "function:src/Domain/Prompts/McpPromptValidator.php:get_arguments_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "function:src/Domain/Prompts/McpPromptValidator.php:validate_prompt_messages",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "function:src/Domain/Prompts/McpPromptValidator.php:get_content_validation_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Utils/McpValidatorTest.php",
+      "target": "class:tests/Unit/Domain/Utils/McpValidatorTest.php:McpValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+      "target": "class:tests/Unit/Domain/Tools/McpToolValidatorTest.php:McpToolValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+      "target": "class:tests/Unit/Domain/Resources/McpResourceValidatorTest.php:McpResourceValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+      "target": "class:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php:McpPromptValidatorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Domain/Tools/McpToolValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Resources/McpResourceValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "file:src/Domain/Utils/McpValidator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Domain/Prompts/McpPromptValidator.php",
+      "target": "file:src/Domain/Resources/McpResourceValidator.php",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "class:src/Infrastructure/Redaction/RedactionConfig.php:RedactionConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "class:src/Infrastructure/Redaction/RedactionConfig.php:RedactionConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "function:src/Infrastructure/Redaction/RedactionConfig.php:is_master_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "function:src/Infrastructure/Redaction/RedactionConfig.php:bucket3_keywords",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "function:src/Infrastructure/Redaction/RedactionConfig.php:is_ability_exempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "function:src/Infrastructure/Redaction/RedactionConfig.php:normalize_keywords",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "target": "file:src/Settings/SafetySettingsRepository.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "target": "class:src/Infrastructure/Redaction/RedactionLimitExceeded.php:RedactionLimitExceeded",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "target": "class:src/Infrastructure/Redaction/RedactionLimitExceeded.php:RedactionLimitExceeded",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "class:src/Infrastructure/Redaction/ResponseRedactor.php:ResponseRedactor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "class:src/Infrastructure/Redaction/ResponseRedactor.php:ResponseRedactor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:__construct",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:redact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:walk_array",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:process_named_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:count_subtree_safe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:process_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:maybe_redact_scalar_string",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "function:src/Infrastructure/Redaction/ResponseRedactor.php:default_marker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php:Bucket3EmailFamilyTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php:RedactionConfigTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php:ResponseRedactorTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionConfig.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php:SchemaPathExemptionTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php:ToolsListSchemaExemptionTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "target": "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+      "target": "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "file:src/RateLimit/BurstHarness.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/BurstHarnessTest.php",
+      "target": "file:src/RateLimit/BurstHarness.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:parse_args",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:usage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:send",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:compose_headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:parse_args",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:usage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:send",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:bin/rate-limit-burst.php",
+      "target": "function:bin/rate-limit-burst.php:compose_headers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:bin/rate-limit-burst.php:send",
+      "target": "function:src/RateLimit/BurstHarness.php:parse_response",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "class:src/RateLimit/BurstHarness.php:BurstHarness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "class:src/RateLimit/BurstHarness.php:BurstHarness",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "function:src/RateLimit/BurstHarness.php:parse_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "function:src/RateLimit/BurstHarness.php:classify_threshold_trip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "function:src/RateLimit/BurstHarness.php:build_tools_call_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/BurstHarness.php",
+      "target": "function:src/RateLimit/BurstHarness.php:build_initialize_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/BurstHarnessTest.php",
+      "target": "class:tests/Unit/RateLimit/BurstHarnessTest.php:BurstHarnessTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/RateLimit/BurstHarnessTest.php",
+      "target": "class:tests/Unit/RateLimit/BurstHarnessTest.php:BurstHarnessTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "pipeline:.github/workflows/test.yml",
+      "target": "step:.github/workflows/test.yml:Setup PHP",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "pipeline:.github/workflows/test.yml",
+      "target": "step:.github/workflows/test.yml:Install dependencies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "pipeline:.github/workflows/test.yml",
+      "target": "step:.github/workflows/test.yml:Run tests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:abilities-mcp-adapter.php",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:readme.txt",
+      "target": "file:abilities-mcp-adapter.php",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:composer.json",
+      "target": "file:abilities-mcp-adapter.php",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:composer.json",
+      "target": "file:src/Plugin.php",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:phpunit.xml",
+      "target": "file:tests/bootstrap.php",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:CHANGELOG.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:PRINCIPLES.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "class:includes/class-license-manager.php:Abilities_MCP_Adapter_License_Manager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "class:includes/class-license-manager.php:Abilities_MCP_Adapter_License_Manager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:is_active",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:activate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:deactivate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:get_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:get_opt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:remote_check",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/class-license-manager.php",
+      "target": "function:includes/class-license-manager.php:remote_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "class:includes/updater/class-plugin-updater.php:Abilities_MCP_Adapter_Plugin_Updater",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "class:includes/updater/class-plugin-updater.php:Abilities_MCP_Adapter_Plugin_Updater",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:init_hooks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:check_plugin_update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:plugins_api_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:pre_download",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:get_fluentcart_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:get_github_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:includes/updater/class-plugin-updater.php",
+      "target": "function:includes/updater/class-plugin-updater.php:normalize_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/McpAbilityHelperTrait.php",
+      "target": "function:src/Abilities/McpAbilityHelperTrait.php:check_ability_mcp_exposure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/McpAbilityHelperTrait.php",
+      "target": "function:src/Abilities/McpAbilityHelperTrait.php:is_ability_mcp_public",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Abilities/McpAbilityHelperTrait.php",
+      "target": "function:src/Abilities/McpAbilityHelperTrait.php:get_ability_mcp_type",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/helpers.php",
+      "target": "function:src/Auth/OAuth/helpers.php:oauth_client_ip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/helpers.php",
+      "target": "function:src/Auth/OAuth/helpers.php:oauth_read_auth_header",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/helpers.php",
+      "target": "function:src/Auth/OAuth/helpers.php:oauth_is_mcp_resource_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/helpers.php",
+      "target": "function:src/Auth/OAuth/helpers.php:token_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:ErrorLogMcpObservabilityHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "target": "class:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:ErrorLogMcpObservabilityHandler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "target": "function:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:record_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "target": "function:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php:format_tags",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "target": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:sanitize_tags",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "target": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:format_metric_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "target": "function:src/Infrastructure/Observability/McpObservabilityHelperTrait.php:merge_tags",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+      "target": "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "target": "class:src/Infrastructure/Redaction/PatternMatchers.php:PatternMatchers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "target": "class:src/Infrastructure/Redaction/PatternMatchers.php:PatternMatchers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "target": "function:src/Infrastructure/Redaction/PatternMatchers.php:is_password_hash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "target": "function:src/Infrastructure/Redaction/PatternMatchers.php:is_known_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "target": "function:src/Infrastructure/Redaction/PatternMatchers.php:passes_luhn",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/CloudflareIps.php",
+      "target": "class:src/RateLimit/CloudflareIps.php:CloudflareIps",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/CloudflareIps.php",
+      "target": "class:src/RateLimit/CloudflareIps.php:CloudflareIps",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/RateLimit/CloudflareIps.php",
+      "target": "function:src/RateLimit/CloudflareIps.php:bundled_v4",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/RateLimit/CloudflareIps.php",
+      "target": "function:src/RateLimit/CloudflareIps.php:bundled_v6",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "target": "class:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:JsonRpcResponseBuilder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "target": "class:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:JsonRpcResponseBuilder",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "target": "function:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:create_success_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+      "target": "function:src/Transport/Infrastructure/JsonRpcResponseBuilder.php:process_messages",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "class:src/Transport/Infrastructure/SessionManager.php:SessionManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "class:src/Transport/Infrastructure/SessionManager.php:SessionManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:acquire_lock",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:create_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:verify_session_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:get_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:validate_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:delete_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:cleanup_expired_sessions_unlocked",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Transport/Infrastructure/SessionManager.php",
+      "target": "function:src/Transport/Infrastructure/SessionManager.php:get_all_user_sessions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php:HelpersAreGlobalTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php:HelpersAreGlobalTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php:OAuthIsMcpResourceRequestTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "target": "class:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php:OAuthIsMcpResourceRequestTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+      "target": "function:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php:test_subdir_install_uses_rest_url_prefix",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php:PatternMatchersTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "target": "class:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php:PatternMatchersTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+      "target": "file:src/Infrastructure/Redaction/PatternMatchers.php",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "target": "class:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php:DefaultServerFactoryBootContractTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "target": "class:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php:DefaultServerFactoryBootContractTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php",
+      "target": "function:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php:test_advertised_boot_first_tool_is_in_the_tools_allowlist",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+      "target": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/Abilities/ExecuteAbilityAbility.php:execute",
+      "target": "function:src/Auth/OAuth/OAuthScopeEnforcer.php:check",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    }
+  ],
+  "layers": [
+    {
+      "id": "layer:transport",
+      "name": "Transport Layer",
+      "description": "HTTP and stdio transports that receive MCP requests, validate sessions/origins, route JSON-RPC, and build responses.",
+      "nodeIds": [
+        "file:src/Transport/Contracts/McpTransportInterface.php",
+        "file:src/Transport/Infrastructure/HttpSessionValidator.php",
+        "file:src/Transport/Infrastructure/McpTransportContext.php",
+        "file:src/Transport/Infrastructure/McpTransportHelperTrait.php",
+        "file:src/Transport/Infrastructure/OriginValidator.php",
+        "file:src/Transport/Infrastructure/RequestRouter.php",
+        "file:src/Transport/Contracts/McpRestTransportInterface.php",
+        "file:src/Transport/HttpTransport.php",
+        "file:src/Transport/Infrastructure/HttpRequestContext.php",
+        "file:src/Transport/Infrastructure/HttpRequestHandler.php",
+        "file:src/Transport/Infrastructure/JsonRpcResponseBuilder.php",
+        "file:src/Transport/Infrastructure/SessionManager.php"
+      ]
+    },
+    {
+      "id": "layer:server-core",
+      "name": "MCP Server & Protocol Core",
+      "description": "The McpServer, component registry, transport/server factories, and per-method JSON-RPC handlers (initialize, tools, resources, prompts, system) that implement the MCP protocol.",
+      "nodeIds": [
+        "file:src/Handlers/HandlerHelperTrait.php",
+        "file:src/Handlers/Initialize/InitializeHandler.php",
+        "file:src/Handlers/Prompts/PromptsHandler.php",
+        "file:src/Handlers/Resources/ResourcesHandler.php",
+        "file:src/Handlers/System/SystemHandler.php",
+        "file:src/Handlers/Tools/ToolsHandler.php",
+        "file:src/Core/McpComponentRegistry.php",
+        "file:src/Core/McpServer.php",
+        "file:src/Core/McpTransportFactory.php",
+        "file:src/Core/McpAdapter.php",
+        "file:src/Core/McpServerConfig.php",
+        "file:src/Servers/DefaultServerFactory.php"
+      ]
+    },
+    {
+      "id": "layer:domain",
+      "name": "Domain & Abilities",
+      "description": "Tool/Resource/Prompt value objects and the adapters plus meta-tool abilities that expose WordPress abilities as MCP tools, resources, and prompts.",
+      "nodeIds": [
+        "file:src/Abilities/GetAbilityInfoAbility.php",
+        "file:src/Abilities/Settings/SettingsAbilities.php",
+        "file:src/Abilities/BatchExecuteAbility.php",
+        "file:src/Abilities/ExecuteAbilityAbility.php",
+        "file:src/Abilities/DiscoverAbilitiesAbility.php",
+        "file:src/Abilities/GetStartedAbility.php",
+        "file:src/Abilities/McpAbilityHelperTrait.php",
+        "file:src/Domain/Prompts/Contracts/McpPromptBuilderInterface.php",
+        "file:src/Domain/Prompts/McpPrompt.php",
+        "file:src/Domain/Prompts/McpPromptBuilder.php",
+        "file:src/Domain/Prompts/RegisterAbilityAsMcpPrompt.php",
+        "file:src/Domain/Resources/McpResource.php",
+        "file:src/Domain/Resources/RegisterAbilityAsMcpResource.php",
+        "file:src/Domain/Tools/McpTool.php",
+        "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+        "file:src/Domain/Utils/McpAnnotationMapper.php",
+        "file:src/Domain/Utils/SchemaTransformer.php",
+        "file:src/Domain/Utils/McpValidator.php",
+        "file:src/Domain/Tools/McpToolValidator.php",
+        "file:src/Domain/Resources/McpResourceValidator.php",
+        "file:src/Domain/Prompts/McpPromptValidator.php"
+      ]
+    },
+    {
+      "id": "layer:auth",
+      "name": "Auth & OAuth",
+      "description": "OAuth 2.1 authorization server: token/code/client stores, scopes and enforcement, consent screens, discovery endpoints, and request-context hardening.",
+      "nodeIds": [
+        "file:src/Auth/OAuth/AuthorizationCodeStore.php",
+        "file:src/Auth/OAuth/ClientRegistry.php",
+        "file:src/Auth/OAuth/Consent/AuthorizeRequestValidator.php",
+        "file:src/Auth/OAuth/DiscoveryEndpoints.php",
+        "file:src/Auth/OAuth/Endpoints/RegisterEndpoint.php",
+        "file:src/Auth/OAuth/Endpoints/RevokeEndpoint.php",
+        "file:src/Auth/OAuth/Endpoints/TokenEndpoint.php",
+        "file:src/Auth/OAuth/RateLimiter.php",
+        "file:src/Auth/OAuth/TokenStore.php",
+        "file:src/Auth/OAuth/McpResourcePath.php",
+        "file:src/Auth/OAuth/Consent/ConsentDecision.php",
+        "file:src/Auth/OAuth/Consent/ConsentDecisionEvaluator.php",
+        "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php",
+        "file:src/Auth/OAuth/Consent/LastConsentLookup.php",
+        "file:src/Auth/OAuth/Consent/PolicyStore.php",
+        "file:src/Auth/OAuth/Consent/PriorGrantLookup.php",
+        "file:src/Auth/OAuth/Consent/RenderedScopeNonce.php",
+        "file:src/Auth/OAuth/Consent/RoleSelector.php",
+        "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+        "file:src/Auth/OAuth/AuthorizationServer.php",
+        "file:src/Auth/OAuth/OAuthHostAllowlist.php",
+        "file:src/Auth/OAuth/OAuthRequestContext.php",
+        "file:src/Auth/OAuth/SelectedRoleEnforcer.php",
+        "file:src/Auth/OAuth/Consent/ScopeGrouper.php",
+        "file:src/Auth/OAuth/OAuthScopeEnforcer.php",
+        "file:src/Auth/OAuth/ScopeRegistry.php",
+        "file:src/Auth/OAuth/OAuthCleanup.php",
+        "file:src/Auth/OAuth/helpers.php"
+      ]
+    },
+    {
+      "id": "layer:infrastructure",
+      "name": "Infrastructure & Cross-Cutting",
+      "description": "Error mapping, observability, response redaction, rate limiting, and safety settings persistence shared across the MCP request lifecycle.",
+      "nodeIds": [
+        "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+        "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+        "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+        "file:src/Infrastructure/Observability/ConsoleObservabilityHandler.php",
+        "file:src/Infrastructure/Observability/Contracts/McpObservabilityHandlerInterface.php",
+        "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+        "file:src/Infrastructure/ErrorHandling/Contracts/McpErrorHandlerInterface.php",
+        "file:src/Infrastructure/ErrorHandling/ErrorLogMcpErrorHandler.php",
+        "file:src/Infrastructure/ErrorHandling/NullMcpErrorHandler.php",
+        "file:src/Infrastructure/Observability/NullMcpObservabilityHandler.php",
+        "file:src/Infrastructure/Redaction/RedactionConfig.php",
+        "file:src/Infrastructure/Redaction/RedactionLimitExceeded.php",
+        "file:src/Infrastructure/Redaction/ResponseRedactor.php",
+        "file:src/Infrastructure/Observability/ErrorLogMcpObservabilityHandler.php",
+        "file:src/Infrastructure/Observability/McpObservabilityHelperTrait.php",
+        "file:src/Infrastructure/Redaction/PatternMatchers.php",
+        "file:src/RateLimit/CounterStore.php",
+        "file:src/RateLimit/RateLimiter.php",
+        "file:src/RateLimit/TrustedProxyResolver.php",
+        "file:src/RateLimit/BurstHarness.php",
+        "file:src/RateLimit/CloudflareIps.php",
+        "file:src/Settings/ConfirmationTokenStore.php",
+        "file:src/Settings/SafetySettingsRepository.php"
+      ]
+    },
+    {
+      "id": "layer:admin-ui",
+      "name": "Admin UI",
+      "description": "WordPress admin pages, settings tabs, connected-bridge views, permission management, and their stylesheets.",
+      "nodeIds": [
+        "file:src/Admin/Tabs/SafetyTab.php",
+        "file:src/Admin/Bridges/BoundaryAuditBuffer.php",
+        "file:src/Admin/Bridges/BridgeRowProjector.php",
+        "file:src/Admin/Tabs/ConnectedBridgesTab.php",
+        "file:src/Admin/Bridges/AuthHeaderProbe.php",
+        "file:src/Admin/PermissionManager.php",
+        "file:src/Admin/AbilitySettingsPage.php",
+        "file:src/Admin/AdapterAdminPage.php",
+        "file:src/Admin/SafetySettingsPage.php",
+        "file:src/Admin/Tabs/AbilitiesTab.php",
+        "file:assets/admin.css",
+        "file:assets/consent.css"
+      ]
+    },
+    {
+      "id": "layer:entry",
+      "name": "Entry & Bootstrap",
+      "description": "Plugin bootstrap, the WP-CLI / stdio bridge entry points, license/updater includes, and the rate-limit burst harness script.",
+      "nodeIds": [
+        "file:abilities-mcp-adapter.php",
+        "file:src/Cli/StdioServerBridge.php",
+        "file:src/Cli/McpCommand.php",
+        "file:src/Plugin.php",
+        "file:bin/rate-limit-burst.php",
+        "file:includes/class-license-manager.php",
+        "file:includes/updater/class-plugin-updater.php"
+      ]
+    },
+    {
+      "id": "layer:test",
+      "name": "Tests",
+      "description": "PHPUnit unit suite and bootstrap/fixtures covering handlers, OAuth, domain adapters, redaction, rate limiting, and admin bridges.",
+      "nodeIds": [
+        "file:tests/Unit/Domain/Tools/OutputSchemaPassthroughTest.php",
+        "file:tests/Unit/Domain/Utils/McpAnnotationMapperTest.php",
+        "file:tests/Unit/Domain/Utils/SchemaTransformerTest.php",
+        "file:tests/Unit/Handlers/HandlerHelperTraitTest.php",
+        "file:tests/Unit/Handlers/Prompts/PromptsHandlerScopeEnforcementTest.php",
+        "file:tests/Unit/Handlers/Resources/ResourcesHandlerScopeEnforcementTest.php",
+        "file:tests/Unit/Handlers/Tools/PermissionErrorRemediationTest.php",
+        "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorFactoryTest.php",
+        "file:tests/Unit/Infrastructure/ErrorHandling/McpErrorMapperTest.php",
+        "file:tests/Unit/Abilities/Settings/SettingsAbilitiesTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthClientIpTrustedProxyTest.php",
+        "file:tests/Unit/Cli/RequestIdStateTest.php",
+        "file:tests/Unit/Infrastructure/Observability/BoundaryEventEmitterTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/ResponseRedactionGateTest.php",
+        "file:tests/Unit/RateLimit/CounterStoreTest.php",
+        "file:tests/Unit/RateLimit/RateLimiterTest.php",
+        "file:tests/Unit/RateLimit/TrustedProxyResolverTest.php",
+        "file:tests/Unit/Settings/ConfirmationTokenStoreTest.php",
+        "file:tests/Unit/Settings/SafetySettingsRepositoryTest.php",
+        "file:tests/Unit/Transport/HttpTransportTest.php",
+        "file:tests/Unit/Transport/Infrastructure/OriginValidatorTest.php",
+        "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreSelectedRoleTest.php",
+        "file:tests/Unit/Auth/OAuth/AuthorizationCodeStoreTest.php",
+        "file:tests/Unit/Auth/OAuth/ClientRegistryTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/AuthorizeRequestValidatorTest.php",
+        "file:tests/Unit/Auth/OAuth/DiscoveryEndpointsTest.php",
+        "file:tests/Unit/Auth/OAuth/Endpoints/RegisterEndpointClassifyScopesTest.php",
+        "file:tests/Unit/Auth/OAuth/PathStyleMultisiteDiscoveryTest.php",
+        "file:tests/Unit/Auth/OAuth/RateLimiterAtomicTest.php",
+        "file:tests/Unit/Auth/OAuth/RateLimiterTest.php",
+        "file:tests/Unit/Auth/OAuth/RedirectUriNormalizeTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenEndpointRedirectUriRawTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreIssueResponseTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreReplayBlobTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreRevocationCascadeTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreRotationFamilyTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreSelectedRoleTest.php",
+        "file:tests/Unit/Auth/OAuth/TokenStoreTouchDeferredTest.php",
+        "file:tests/Unit/Endpoints/RevokeEndpointClientAuthTest.php",
+        "file:tests/Unit/Endpoints/RevokeEndpointRateLimitTest.php",
+        "file:tests/Unit/Admin/Bridges/BoundaryAuditBufferTest.php",
+        "file:tests/Unit/Admin/Bridges/BridgeRowProjectorTest.php",
+        "file:tests/Unit/Admin/Tabs/ConnectedBridgesTabTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/ConsentDecisionEvaluatorTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/ConsentScreenRendererTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/LastConsentLookupTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/PolicyStoreTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/RenderedScopeNonceTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/RoleSelectorTest.php",
+        "file:tests/Unit/Auth/OAuth/McpResourcePathTest.php",
+        "file:tests/Unit/Auth/OAuth/PathStyleMultisiteAuthorizeRoutingTest.php",
+        "file:tests/Unit/Admin/Bridges/AuthHeaderProbeTest.php",
+        "file:tests/Unit/Auth/OAuth/AuthHeaderProbeNamespaceGateTest.php",
+        "file:tests/Unit/Auth/OAuth/AuthenticateBearerNarrowsToMcpResourceTest.php",
+        "file:tests/Unit/Auth/OAuth/AuthenticateBearerSelectedRoleTest.php",
+        "file:tests/Unit/Auth/OAuth/BearerHeaderTrimTest.php",
+        "file:tests/Unit/Auth/OAuth/IsWellKnownOrOAuthPathTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthHostAllowlistTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthRequestContextResetTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthRequestContextTest.php",
+        "file:tests/Unit/Auth/OAuth/ResponseDifferentialHardeningTest.php",
+        "file:tests/Unit/Auth/OAuth/RestRouteHostAllowlistTest.php",
+        "file:tests/Unit/Auth/OAuth/SelectedRoleEnforcerTest.php",
+        "file:tests/Unit/Auth/OAuth/WwwAuthenticateBareChallengeCTest.php",
+        "file:tests/Unit/Abilities/ExecuteAbilityScopeEnforcementTest.php",
+        "file:tests/Unit/Abilities/MetaToolPermissionAnnotationTest.php",
+        "file:tests/Unit/Admin/PermissionManagerTest.php",
+        "file:tests/Unit/Auth/OAuth/Consent/ScopeGrouperTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerCheckScopeTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthScopeEnforcerTest.php",
+        "file:tests/Unit/Auth/OAuth/ScopeCoverageDriftTest.php",
+        "file:tests/Unit/Auth/OAuth/ScopeRegistryTest.php",
+        "file:tests/Unit/Domain/Utils/McpAnnotationMapperBuildTest.php",
+        "file:tests/Unit/Abilities/DiscoverAbilitiesDefaultsTest.php",
+        "file:tests/Unit/Cli/StdioServerBridgeIdNullTest.php",
+        "file:tests/Unit/Core/McpServerConfigTest.php",
+        "file:tests/Unit/Admin/AdapterAdminPageTest.php",
+        "file:tests/Unit/Admin/LegacyRedirectorsTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthCleanupTest.php",
+        "file:tests/Unit/Domain/Utils/McpValidatorTest.php",
+        "file:tests/Unit/Domain/Tools/McpToolValidatorTest.php",
+        "file:tests/Unit/Domain/Resources/McpResourceValidatorTest.php",
+        "file:tests/Unit/Domain/Prompts/McpPromptValidatorTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/Bucket3EmailFamilyTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/RedactionConfigTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/ResponseRedactorTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/SchemaPathExemptionTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/ToolsListSchemaExemptionTest.php",
+        "file:tests/Unit/RateLimit/BurstHarnessTest.php",
+        "file:tests/bootstrap.php",
+        "config:tests/fixtures/live-catalog-snapshot.json",
+        "file:tests/Unit/Auth/OAuth/HelpersAreGlobalTest.php",
+        "file:tests/Unit/Auth/OAuth/OAuthIsMcpResourceRequestTest.php",
+        "file:tests/Unit/Infrastructure/Redaction/PatternMatchersTest.php",
+        "file:tests/Unit/Servers/DefaultServerFactoryBootContractTest.php"
+      ]
+    },
+    {
+      "id": "layer:project-support",
+      "name": "Project Support",
+      "description": "Documentation, project/build configuration (composer, phpunit), CI workflow, issue templates, and tooling metadata that support the codebase.",
+      "nodeIds": [
+        "document:CHANGELOG.md",
+        "document:CONTRIBUTING.md",
+        "document:PRINCIPLES.md",
+        "document:README.md",
+        "document:SECURITY.md",
+        "config:composer.json",
+        "config:phpunit.xml",
+        "document:readme.txt",
+        "file:.distignore",
+        "pipeline:.github/workflows/test.yml",
+        "step:.github/workflows/test.yml:Setup PHP",
+        "step:.github/workflows/test.yml:Install dependencies",
+        "step:.github/workflows/test.yml:Run tests",
+        "config:.github/ISSUE_TEMPLATE/ability-gap.yml",
+        "config:.github/ISSUE_TEMPLATE/bug-report.yml",
+        "config:.github/ISSUE_TEMPLATE/dev-brief.yml",
+        "document:.github/PULL_REQUEST_TEMPLATE.md",
+        "config:.ijfw/.dream-state-v2.json",
+        "config:.ijfw/.dream-state.json",
+        "file:.ijfw/.session-counter",
+        "document:.ijfw/memory/project-journal.md",
+        "file:.ijfw/metrics/sessions.jsonl",
+        "document:.ijfw/sessions/session_2026-06-03_15-41-08.md",
+        "document:.ijfw/sessions/session_2026-06-03_15-45-58.md",
+        "file:.understand-anything/.understandignore",
+        "document:docs/architecture.md"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "Project Overview",
+      "description": "Start at the README to learn what this project is: an adapter that exposes WordPress's Abilities as Model Context Protocol (MCP) tools, resources, and prompts so AI clients can discover and call them safely. It introduces the headline features you'll meet throughout the tour: discovery/execution meta-tools, an OAuth 2.1 auth boundary, the admin UI, the four-layer permissions model, and the redaction safety surface. Read this first to get the vocabulary before any code.",
+      "nodeIds": [
+        "document:README.md"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "Architecture & Principles",
+      "description": "Before reading code, absorb the two documents that define the system's shape. docs/architecture.md describes where the adapter sits in the stack, the directory layout, the request flow, and the security model — essentially a textual version of the tour you're taking. PRINCIPLES.md is the binding architectural contract (registry-first, native WordPress APIs, adapter-as-projection, layered permissions) that every layer ahead is required to honor.",
+      "nodeIds": [
+        "document:docs/architecture.md",
+        "document:PRINCIPLES.md"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Plugin Bootstrap",
+      "description": "This is depth-0 of the dependency graph and where execution actually begins. abilities-mcp-adapter.php is the WordPress plugin entry file: it defines plugin headers/constants, wires the PSR-4 autoloader, and hooks the core services into WordPress. It hands off to src/Plugin.php, a guarded singleton orchestrator that checks runtime dependencies and boots the MCP adapter plus the admin pages. composer.json shows the package contract behind it all — the PSR-4 mapping of WickedEvolutions\\McpAdapter\\ to src/ and the PHP >=8.2 requirement.",
+      "nodeIds": [
+        "file:abilities-mcp-adapter.php",
+        "file:src/Plugin.php",
+        "config:composer.json"
+      ],
+      "languageLesson": "Plugin.php uses the PHP singleton pattern and blocks __clone() and __wakeup() (unserialization) to guarantee exactly one orchestrator instance — a common hardening technique for WordPress plugin lifecycle objects."
+    },
+    {
+      "order": 4,
+      "title": "MCP Core: Adapter & Server",
+      "description": "Building on the bootstrap from Step 3, the server-core layer takes over. McpAdapter is the central singleton that wires WordPress hooks, creates MCP servers from configuration, registers the default abilities, and exposes the WP-CLI command. McpServer is the aggregate it produces: it holds the server's identity/config and wires up the component registry, transport factory, and the per-method handlers. These two are the highest-fan-out, highest-fan-in nodes in the core — almost everything downstream flows through them.",
+      "nodeIds": [
+        "file:src/Core/McpAdapter.php",
+        "file:src/Core/McpServer.php"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "Component Registry & Server Factory",
+      "description": "How do WordPress abilities actually become MCP components? McpComponentRegistry is the converter: it turns each ability into an MCP tool, resource, or prompt, validates it, and records observability events on success and failure. DefaultServerFactory is the assembler invoked during boot — it discovers public abilities by type and builds the default server through McpAdapter and McpServerConfig. Together they are the 'projection' machinery the PRINCIPLES contract from Step 2 describes.",
+      "nodeIds": [
+        "file:src/Core/McpComponentRegistry.php",
+        "file:src/Servers/DefaultServerFactory.php"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "Domain Value Objects",
+      "description": "At the heart of the domain layer sit three immutable value objects that model the MCP protocol's primitives. McpTool carries input/output schemas, annotations, and metadata; McpResource models a text or blob resource with URI and mime type; McpPrompt represents a prompt with arguments and an optional builder for direct execution. Each supports serialization, hydration, and validation against the server — they are the shared vocabulary every handler and transport speaks.",
+      "nodeIds": [
+        "file:src/Domain/Tools/McpTool.php",
+        "file:src/Domain/Resources/McpResource.php",
+        "file:src/Domain/Prompts/McpPrompt.php"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Ability Adapters & Meta-Tools",
+      "description": "This step shows the projection from Step 5 in concrete form. RegisterAbilityAsMcpTool is the adapter that builds an McpTool (Step 6) from a raw WordPress ability, transforming its schemas and mapping annotations. The two meta-tools are the product's signature feature: DiscoverAbilitiesAbility lists, filters, and summarizes the abilities exposed over MCP, while ExecuteAbilityAbility runs a single named ability — enforcing permission checks, MCP exposure rules, and OAuth scope before it ever delegates.",
+      "nodeIds": [
+        "file:src/Domain/Tools/RegisterAbilityAsMcpTool.php",
+        "file:src/Abilities/DiscoverAbilitiesAbility.php",
+        "file:src/Abilities/ExecuteAbilityAbility.php"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "Request Handlers",
+      "description": "Once a request reaches the server, per-method handlers process it. InitializeHandler negotiates the MCP protocol version and returns the server's capabilities and identity. ToolsHandler implements tools/list and tools/call — sanitizing tool data, enforcing permission and scope, executing the backing ability, and shaping the result into MCP content. The shared HandlerHelperTrait gives every handler consistent helpers for params and for building success/error envelopes. The graph's tightest cluster forms right here, around these handlers and the server.",
+      "nodeIds": [
+        "file:src/Handlers/Initialize/InitializeHandler.php",
+        "file:src/Handlers/Tools/ToolsHandler.php",
+        "file:src/Handlers/HandlerHelperTrait.php"
+      ],
+      "languageLesson": "HandlerHelperTrait is a PHP trait — horizontal code reuse that lets unrelated handler classes share the same param-extraction and response-building methods without inheritance, avoiding a deep class hierarchy."
+    },
+    {
+      "order": 9,
+      "title": "Transports: HTTP & stdio",
+      "description": "Handlers don't talk to the network directly — transports do. HttpTransport registers the MCP REST routes and enforces authentication, origin checks, and CORS before delegating to the infrastructure handler. StdioServerBridge offers the same server over stdin/stdout JSON-RPC framing for CLI/stdio clients, applying response redaction on the way out. Both are wired through McpTransportContext, the immutable bundle of server, handlers, observability/error handlers, router, and permission callback — the object that appears in nearly every core cluster.",
+      "nodeIds": [
+        "file:src/Transport/HttpTransport.php",
+        "file:src/Cli/StdioServerBridge.php",
+        "file:src/Transport/Infrastructure/McpTransportContext.php"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "OAuth 2.1 Authorization & Scopes",
+      "description": "The HTTP transport's authentication from Step 9 is backed by a full OAuth 2.1 boundary. AuthorizationServer boots the OAuth hooks, runs DB migrations, intercepts discovery/authorize routes, registers REST endpoints, and authenticates Bearer tokens narrowed to the MCP resource. ScopeRegistry is the canonical catalog of scopes with umbrella-to-scope expansions and sensitivity flags, while OAuthScopeEnforcer is the gate that derives the required scope for an ability and checks it against what was granted — the enforcement point ExecuteAbilityAbility (Step 7) relies on.",
+      "nodeIds": [
+        "file:src/Auth/OAuth/AuthorizationServer.php",
+        "file:src/Auth/OAuth/ScopeRegistry.php",
+        "file:src/Auth/OAuth/OAuthScopeEnforcer.php"
+      ]
+    },
+    {
+      "order": 11,
+      "title": "OAuth Consent Flow",
+      "description": "This step follows the human-in-the-loop side of the auth boundary. AuthorizeEndpoint orchestrates the OAuth authorization request: on GET it validates the request, evaluates whether prior consent allows auto-approval, and otherwise renders a consent screen; on POST it verifies the nonce, mints an authorization code, and redirects. ConsentScreenRenderer produces that screen as escaped HTML with grouped, toggleable scope checkboxes, mapping the scopes from Step 10 into a UI the resource owner can review.",
+      "nodeIds": [
+        "file:src/Auth/OAuth/Endpoints/AuthorizeEndpoint.php",
+        "file:src/Auth/OAuth/Consent/ConsentScreenRenderer.php"
+      ]
+    },
+    {
+      "order": 12,
+      "title": "Infrastructure: Errors, Redaction, Safety",
+      "description": "Cross-cutting infrastructure keeps every layer above consistent and safe. McpErrorFactory produces standardized JSON-RPC/MCP error responses and maps error codes to HTTP statuses (it has one of the highest fan-ins in the codebase), while McpErrorMapper translates WordPress WP_Error codes into that format. ResponseRedactionGate strips sensitive content from tool responses, driven by configurable keyword buckets and exemptions, and BoundaryEventEmitter emits observability events with secrets hashed out. SECURITY.md documents the threat surface these pieces defend.",
+      "nodeIds": [
+        "file:src/Infrastructure/ErrorHandling/McpErrorFactory.php",
+        "file:src/Infrastructure/ErrorHandling/McpErrorMapper.php",
+        "file:src/Infrastructure/Redaction/ResponseRedactionGate.php",
+        "file:src/Infrastructure/Observability/BoundaryEventEmitter.php",
+        "document:SECURITY.md"
+      ]
+    },
+    {
+      "order": 13,
+      "title": "Admin UI & Permissions",
+      "description": "Site administrators control the adapter through the WordPress admin UI. AdapterAdminPage is the controller that registers the top-level menu, resolves and renders the Abilities / Connected Bridges / Safety tabs, and dispatches their form submissions. PermissionManager backs the permissions model the README promised: it derives an ability's effective read/write/delete permission from meta or MCP annotations and persists per-ability enabled/disabled settings — the same gate enforced at execution time in Steps 7 and 10, now made configurable. SafetySettingsRepository is the persistence behind the Safety tab this page renders, storing the keyword buckets and exemptions that feed Step 12's redaction gate.",
+      "nodeIds": [
+        "file:src/Admin/AdapterAdminPage.php",
+        "file:src/Admin/PermissionManager.php",
+        "file:src/Settings/SafetySettingsRepository.php"
+      ]
+    },
+    {
+      "order": 14,
+      "title": "Tests & CI Capstone",
+      "description": "The tour ends where quality is enforced. tests/bootstrap.php stubs WordPress core functions (escaping, options, transients, hooks, REST) so the plugin's classes can be unit-tested without a full WordPress runtime — the trick that makes the large PHPUnit suite fast. phpunit.xml wires that bootstrap, defines the Unit suite, and turns on coverage over src/. The test.yml GitHub Actions workflow runs the whole suite via Composer across a PHP 8.2/8.3 matrix on every push and PR to main, closing the loop on every layer you've just toured.",
+      "nodeIds": [
+        "file:tests/bootstrap.php",
+        "config:phpunit.xml",
+        "pipeline:.github/workflows/test.yml"
+      ],
+      "languageLesson": "GitHub Actions matrix builds (here PHP 8.2 and 8.3) run the same job in parallel across each version, catching version-specific regressions before merge. The 'on' triggers (push/pull_request to main) decide when the workflow fires."
+    }
+  ]
+}

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,0 +1,6 @@
+{
+  "lastAnalyzedAt": "2026-06-07T12:36:41Z",
+  "gitCommitHash": "05fcd5a13d4da9cf0ba1eae81860f81c24fb38e8",
+  "version": "1.0.0",
+  "analyzedFiles": 233
+}


### PR DESCRIPTION
## What this adds

An interactive **Understand-Anything** knowledge graph of this plugin plus an automated **GitHub Pages** dashboard to explore it.

- `.understand-anything/knowledge-graph.json` (+ `meta.json`, `fingerprints.json`) — generated graph: nodes (files/classes/functions/config/docs), edges (imports, contains, calls, depends_on, …), architectural layers, and a guided tour.
- `.github/workflows/understand-dashboard.yml` — on push to `main`, builds the static dashboard (Understand-Anything pinned @5c1e35f) and deploys it to GitHub Pages.
- `.gitignore` — ignores analysis scratch dirs.

## After merge
The workflow runs, auto-enables Pages (GitHub Actions source), and publishes to **https://wicked-evolutions.github.io/abilities-mcp-adapter/**. Ongoing: refresh the graph with an incremental `/understand`, commit, and Pages redeploys automatically.

> First-run note: if org policy blocks automatic Pages enablement, set Settings → Pages → Source: GitHub Actions once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)