### PR TITLE
ci: fix pnpm install (--no-frozen-lockfile) for Pages deploy

### DIFF
--- a/.github/workflows/understand-dashboard.yml
+++ b/.github/workflows/understand-dashboard.yml
@@ -39,7 +39,7 @@ jobs:
           cache-dependency-path: .ua/understand-anything-plugin/pnpm-lock.yaml
       - name: Install deps
         working-directory: .ua/understand-anything-plugin
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Build core
         working-directory: .ua/understand-anything-plugin
         run: pnpm --filter @understand-anything/core build


### PR DESCRIPTION
## CI fix: pnpm install in the Pages workflow

The prior deploy got further but failed at **Install deps**: GitHub Actions defaults `pnpm install` to `--frozen-lockfile`, and the pinned Understand-Anything commit's lockfile is out of sync with its `package.json` (`graphology`, `graphology-communities-louvain` added) → `ERR_PNPM_OUTDATED_LOCKFILE`. Switched to `pnpm install --no-frozen-lockfile`.

### Validation
Dispatched this workflow on the branch: **Install → Build core → Build static dashboard → Inject graph all pass** ✓. The branch run can't run the final deploy (the `github-pages` environment restricts deployments to `main`), and Pages has now been enabled (Actions source). Merging to `main` should complete the deploy to **https://wicked-evolutions.github.io/abilities-mcp-adapter/**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)